### PR TITLE
[FEAT] #56 카테고리 별 리뷰 검색 기능 추가

### DIFF
--- a/src/main/java/com/lokoko/domain/product/controller/ProductController.java
+++ b/src/main/java/com/lokoko/domain/product/controller/ProductController.java
@@ -26,6 +26,8 @@ import com.lokoko.domain.product.service.ProductService;
 import com.lokoko.domain.review.dto.ImageReviewListResponse;
 import com.lokoko.domain.review.dto.VideoReviewListResponse;
 import com.lokoko.domain.review.service.ReviewReadService;
+import com.lokoko.global.common.entity.MediaType;
+import com.lokoko.global.common.entity.SearchType;
 import com.lokoko.global.common.response.ApiResponse;
 import com.lokoko.global.kuromoji.service.ProductMigrationService;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -69,20 +71,20 @@ public class ProductController {
     public ApiResponse<?> searchProductsByCategory(
             @RequestParam MiddleCategory middleCategory,
             @RequestParam(required = false) SubCategory subCategory,
-            @RequestParam(defaultValue = "false") boolean isReview,
-            @RequestParam(required = false) String mediaType,
+            @RequestParam(defaultValue = "false") SearchType searchType,
+            @RequestParam(required = false) MediaType mediaType,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
 
-        if (isReview) {
-            if (mediaType.equals("video")) {
+        if (searchType == SearchType.REVIEW) {
+            if (mediaType == MediaType.VIDEO) {
                 VideoReviewListResponse videoReviewResponse = reviewReadService.searchVideoReviewsByCategory(
                         middleCategory, subCategory, page, size);
 
                 return ApiResponse.success(HttpStatus.OK, CATEGORY_REVIEW_SEARCH_SUCCESS.getMessage(),
                         videoReviewResponse);
 
-            } else if (mediaType.equals("image")) {
+            } else if (mediaType == MediaType.IMAGE) {
                 ImageReviewListResponse imageReviewListResponse = reviewReadService.searchImageReviewsByCategory(
                         middleCategory, subCategory, page, size);
 

--- a/src/main/java/com/lokoko/domain/product/controller/ProductController.java
+++ b/src/main/java/com/lokoko/domain/product/controller/ProductController.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.product.controller;
 
 import static com.lokoko.domain.product.controller.enums.ResponseMessage.CATEGORY_NEW_LIST_SUCCESS;
 import static com.lokoko.domain.product.controller.enums.ResponseMessage.CATEGORY_POPULAR_LIST_SUCCESS;
+import static com.lokoko.domain.product.controller.enums.ResponseMessage.CATEGORY_REVIEW_SEARCH_SUCCESS;
 import static com.lokoko.domain.product.controller.enums.ResponseMessage.CATEGORY_SEARCH_SUCCESS;
 import static com.lokoko.domain.product.controller.enums.ResponseMessage.PRODUCT_DETAIL_SUCCESS;
 import static com.lokoko.domain.product.controller.enums.ResponseMessage.PRODUCT_YOUTUBE_DETAIL_SUCCESS;
@@ -22,6 +23,9 @@ import com.lokoko.domain.product.service.NewProductCrawlingService;
 import com.lokoko.domain.product.service.ProductCrawlingService;
 import com.lokoko.domain.product.service.ProductReadService;
 import com.lokoko.domain.product.service.ProductService;
+import com.lokoko.domain.review.dto.ImageReviewListResponse;
+import com.lokoko.domain.review.dto.VideoReviewListResponse;
+import com.lokoko.domain.review.service.ReviewReadService;
 import com.lokoko.global.common.response.ApiResponse;
 import com.lokoko.global.kuromoji.service.ProductMigrationService;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -48,6 +52,7 @@ public class ProductController {
     private final ProductCrawlingService productCrawlingService;
     private final NewProductCrawlingService newProductCrawlingService;
     private final ProductMigrationService productMigrationService;
+    private final ReviewReadService reviewReadService;
 
     @Hidden
     @Operation(summary = "카테고리별 상품 크롤링")
@@ -61,14 +66,33 @@ public class ProductController {
 
     @Operation(summary = "카테고리 별 상품 검색")
     @GetMapping("/categories/search")
-    public ApiResponse<CategoryProductPageResponse> searchProductsByCategory(
+    public ApiResponse<?> searchProductsByCategory(
             @RequestParam MiddleCategory middleCategory,
             @RequestParam(required = false) SubCategory subCategory,
+            @RequestParam(defaultValue = "false") boolean isReview,
+            @RequestParam(required = false) String mediaType,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
+
+        if (isReview) {
+            if (mediaType.equals("video")) {
+                VideoReviewListResponse videoReviewResponse = reviewReadService.searchVideoReviewsByCategory(
+                        middleCategory, subCategory, page, size);
+
+                return ApiResponse.success(HttpStatus.OK, CATEGORY_REVIEW_SEARCH_SUCCESS.getMessage(),
+                        videoReviewResponse);
+
+            } else if (mediaType.equals("image")) {
+                ImageReviewListResponse imageReviewListResponse = reviewReadService.searchImageReviewsByCategory(
+                        middleCategory, subCategory, page, size);
+
+                return ApiResponse.success(HttpStatus.OK, CATEGORY_REVIEW_SEARCH_SUCCESS.getMessage(),
+                        imageReviewListResponse);
+            }
+
+        }
         CategoryProductPageResponse categoryProductResponse = productReadService.searchProductsByCategory(
-                middleCategory,
-                subCategory, page, size);
+                middleCategory, subCategory, page, size);
 
         return ApiResponse.success(HttpStatus.OK, CATEGORY_SEARCH_SUCCESS.getMessage(), categoryProductResponse);
     }

--- a/src/main/java/com/lokoko/domain/product/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/product/controller/enums/ResponseMessage.java
@@ -16,7 +16,8 @@ public enum ResponseMessage {
     PRODUCT_YOUTUBE_DETAIL_SUCCESS("상세조회 (유튜브) 조회에 성공했습니다."),
     NAME_BRAND_SEARCH_SUCCESS("상품명 / 브랜드명 제품 검색에 성공했습니다."),
     PRODUCT_MIGRATION_SUCCESS("제품 검색 필드 업데이트 완료"),
-    CATEGORY_POPULAR_LIST_SUCCESS("카테고리 인기 제품 리스트 반환에 성공했습니다.");
+    CATEGORY_POPULAR_LIST_SUCCESS("카테고리 인기 제품 리스트 반환에 성공했습니다."),
+    CATEGORY_REVIEW_SEARCH_SUCCESS("카테고리 별 리뷰 검색에 성공했습니다");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/review/dto/ImageReviewListResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/ImageReviewListResponse.java
@@ -2,8 +2,12 @@ package com.lokoko.domain.review.dto;
 
 import com.lokoko.global.common.response.PageableResponse;
 import java.util.List;
+import lombok.Builder;
 
+@Builder
 public record ImageReviewListResponse(
+        String searchQuery,
+        String parentCategoryName,
         List<ImageReviewResponse> reviews,
         PageableResponse pageInfo
 ) {

--- a/src/main/java/com/lokoko/domain/review/dto/ImageReviewListResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/ImageReviewListResponse.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.review.dto;
+
+import com.lokoko.global.common.response.PageableResponse;
+import java.util.List;
+
+public record ImageReviewListResponse(
+        List<ImageReviewResponse> reviews,
+        PageableResponse pageInfo
+) {
+}

--- a/src/main/java/com/lokoko/domain/review/dto/ImageReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/ImageReviewResponse.java
@@ -1,7 +1,7 @@
 package com.lokoko.domain.review.dto;
 
 public record ImageReviewResponse(
-        String reviewId,
+        Long reviewId,
         int ranking,
         String brandName,
         String productName,

--- a/src/main/java/com/lokoko/domain/review/dto/ImageReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/ImageReviewResponse.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.review.dto;
+
+public record ImageReviewResponse(
+        String reviewId,
+        int ranking,
+        String brandName,
+        String productName,
+        int likeCount,
+        String url
+) {
+}

--- a/src/main/java/com/lokoko/domain/review/dto/VideoReviewListResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/VideoReviewListResponse.java
@@ -2,8 +2,12 @@ package com.lokoko.domain.review.dto;
 
 import com.lokoko.global.common.response.PageableResponse;
 import java.util.List;
+import lombok.Builder;
 
+@Builder
 public record VideoReviewListResponse(
+        String searchQuery,
+        String parentCategoryName,
         List<VideoReviewResponse> reviews,
         PageableResponse pageInfo
 ) {

--- a/src/main/java/com/lokoko/domain/review/dto/VideoReviewListResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/VideoReviewListResponse.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.review.dto;
+
+import com.lokoko.global.common.response.PageableResponse;
+import java.util.List;
+
+public record VideoReviewListResponse(
+        List<VideoReviewResponse> reviews,
+        PageableResponse pageInfo
+) {
+}

--- a/src/main/java/com/lokoko/domain/review/dto/VideoReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/VideoReviewResponse.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.review.dto;
+
+public record VideoReviewResponse(
+        String reviewId,
+        int ranking,
+        String brandName,
+        String productName,
+        int likeCount,
+        String url
+) {
+}

--- a/src/main/java/com/lokoko/domain/review/dto/VideoReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/VideoReviewResponse.java
@@ -1,7 +1,7 @@
 package com.lokoko.domain.review.dto;
 
 public record VideoReviewResponse(
-        String reviewId,
+        Long reviewId,
         int ranking,
         String brandName,
         String productName,

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
 
     @Query("SELECT r.product.id, r.rating , COUNT(r) "
             + "FROM Review r "

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,28 @@
+package com.lokoko.domain.review.repository;
+
+import com.lokoko.domain.product.entity.enums.MiddleCategory;
+import com.lokoko.domain.product.entity.enums.SubCategory;
+import com.lokoko.domain.review.dto.ImageReviewResponse;
+import com.lokoko.domain.review.dto.VideoReviewResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface ReviewRepositoryCustom {
+
+    Slice<VideoReviewResponse> findVideoReviewsByCategory(MiddleCategory middleCategory, SubCategory subCategory,
+                                                          Pageable pageable
+    );
+
+    Slice<VideoReviewResponse> findVideoReviewsByCategory(MiddleCategory middleCategory,
+                                                          Pageable pageable
+    );
+
+    Slice<ImageReviewResponse> findImageReviewsByCategory(MiddleCategory middleCategory, SubCategory subCategory,
+                                                          Pageable pageable
+    );
+
+    Slice<ImageReviewResponse> findImageReviewsByCategory(MiddleCategory middleCategory,
+                                                          Pageable pageable
+    );
+
+}

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,217 @@
+package com.lokoko.domain.review.repository;
+
+import com.lokoko.domain.image.entity.QReviewImage;
+import com.lokoko.domain.product.entity.QProduct;
+import com.lokoko.domain.product.entity.enums.MiddleCategory;
+import com.lokoko.domain.product.entity.enums.SubCategory;
+import com.lokoko.domain.review.dto.ImageReviewResponse;
+import com.lokoko.domain.review.dto.VideoReviewResponse;
+import com.lokoko.domain.review.entity.QReview;
+import com.lokoko.domain.video.entity.QReviewVideo;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QReview review = QReview.review;
+    private final QProduct product = QProduct.product;
+    private final QReviewVideo reviewVideo = QReviewVideo.reviewVideo;
+    private final QReviewImage reviewImage = QReviewImage.reviewImage;
+
+    @Override
+    public Slice<VideoReviewResponse> findVideoReviewsByCategory(MiddleCategory middleCategory,
+                                                                 SubCategory subCategory,
+                                                                 Pageable pageable) {
+        List<VideoReviewResponse> content = queryFactory
+                .select(Projections.constructor(VideoReviewResponse.class,
+                        review.id.stringValue(),
+                        Expressions.constant(0),
+                        product.brandName,
+                        product.productName,
+                        review.likeCount,
+                        reviewVideo.mediaFile.fileUrl
+                ))
+                .from(reviewVideo)
+                .innerJoin(reviewVideo.review, review)
+                .innerJoin(review.product, product)
+                .where(
+                        categoryCondition(middleCategory, subCategory)
+                )
+                .orderBy(review.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
+            VideoReviewResponse original = content.get(i);
+            content.set(i, new VideoReviewResponse(
+                    original.reviewId(),
+                    (int) pageable.getOffset() + i + 1,
+                    original.brandName(),
+                    original.productName(),
+                    original.likeCount(),
+                    original.url()
+            ));
+        }
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content.remove(content.size() - 1);
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
+    public Slice<ImageReviewResponse> findImageReviewsByCategory(MiddleCategory middleCategory,
+                                                                 SubCategory subCategory,
+                                                                 Pageable pageable) {
+        List<ImageReviewResponse> content = queryFactory
+                .select(Projections.constructor(ImageReviewResponse.class,
+                        review.id.stringValue(),
+                        Expressions.constant(0),
+                        product.brandName,
+                        product.productName,
+                        review.likeCount,
+                        reviewImage.mediaFile.fileUrl
+                ))
+                .from(reviewImage)
+                .innerJoin(reviewImage.review, review)
+                .innerJoin(review.product, product)
+                .where(
+                        categoryCondition(middleCategory, subCategory)
+                )
+                .orderBy(review.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
+            ImageReviewResponse original = content.get(i);
+            content.set(i, new ImageReviewResponse(
+                    original.reviewId(),
+                    (int) pageable.getOffset() + i + 1,
+                    original.brandName(),
+                    original.productName(),
+                    original.likeCount(),
+                    original.url()
+            ));
+        }
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content.remove(content.size() - 1);
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
+    public Slice<VideoReviewResponse> findVideoReviewsByCategory(MiddleCategory middleCategory,
+                                                                 Pageable pageable) {
+        List<VideoReviewResponse> content = queryFactory
+                .select(Projections.constructor(VideoReviewResponse.class,
+                        review.id.stringValue(),
+                        Expressions.constant(0),
+                        product.brandName,
+                        product.productName,
+                        review.likeCount,
+                        reviewVideo.mediaFile.fileUrl
+                ))
+                .from(reviewVideo)
+                .innerJoin(reviewVideo.review, review)
+                .innerJoin(review.product, product)
+                .where(
+                        product.middleCategory.eq(middleCategory)
+                )
+                .orderBy(review.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
+            VideoReviewResponse original = content.get(i);
+            content.set(i, new VideoReviewResponse(
+                    original.reviewId(),
+                    (int) pageable.getOffset() + i + 1,
+                    original.brandName(),
+                    original.productName(),
+                    original.likeCount(),
+                    original.url()
+            ));
+        }
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content.remove(content.size() - 1);
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
+    public Slice<ImageReviewResponse> findImageReviewsByCategory(MiddleCategory middleCategory,
+                                                                 Pageable pageable) {
+        List<ImageReviewResponse> content = queryFactory
+                .select(Projections.constructor(ImageReviewResponse.class,
+                        review.id.stringValue(),
+                        Expressions.constant(0),
+                        product.brandName,
+                        product.productName,
+                        review.likeCount,
+                        reviewImage.mediaFile.fileUrl
+                ))
+                .from(reviewImage)
+                .innerJoin(reviewImage.review, review)
+                .innerJoin(review.product, product)
+                .where(
+                        product.middleCategory.eq(middleCategory)
+                )
+                .orderBy(review.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
+            ImageReviewResponse original = content.get(i);
+            content.set(i, new ImageReviewResponse(
+                    original.reviewId(),
+                    (int) pageable.getOffset() + i + 1,
+                    original.brandName(),
+                    original.productName(),
+                    original.likeCount(),
+                    original.url()
+            ));
+        }
+
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content.remove(content.size() - 1);
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    private BooleanExpression categoryCondition(MiddleCategory middleCategory, SubCategory subCategory) {
+        BooleanExpression condition = product.middleCategory.eq(middleCategory);
+
+        if (subCategory != null) {
+            condition = condition.and(product.subCategory.eq(subCategory));
+        }
+
+        return condition;
+    }
+
+}
+

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryImpl.java
@@ -35,7 +35,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                                                                  Pageable pageable) {
         List<VideoReviewResponse> content = queryFactory
                 .select(Projections.constructor(VideoReviewResponse.class,
-                        review.id.stringValue(),
+                        review.id,
                         Expressions.constant(0),
                         product.brandName,
                         product.productName,
@@ -56,50 +56,6 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
             VideoReviewResponse original = content.get(i);
             content.set(i, new VideoReviewResponse(
-                    original.reviewId(),
-                    (int) pageable.getOffset() + i + 1,
-                    original.brandName(),
-                    original.productName(),
-                    original.likeCount(),
-                    original.url()
-            ));
-        }
-
-        boolean hasNext = content.size() > pageable.getPageSize();
-        if (hasNext) {
-            content.remove(content.size() - 1);
-        }
-
-        return new SliceImpl<>(content, pageable, hasNext);
-    }
-
-    @Override
-    public Slice<ImageReviewResponse> findImageReviewsByCategory(MiddleCategory middleCategory,
-                                                                 SubCategory subCategory,
-                                                                 Pageable pageable) {
-        List<ImageReviewResponse> content = queryFactory
-                .select(Projections.constructor(ImageReviewResponse.class,
-                        review.id.stringValue(),
-                        Expressions.constant(0),
-                        product.brandName,
-                        product.productName,
-                        review.likeCount,
-                        reviewImage.mediaFile.fileUrl
-                ))
-                .from(reviewImage)
-                .innerJoin(reviewImage.review, review)
-                .innerJoin(review.product, product)
-                .where(
-                        categoryCondition(middleCategory, subCategory)
-                )
-                .orderBy(review.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
-
-        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
-            ImageReviewResponse original = content.get(i);
-            content.set(i, new ImageReviewResponse(
                     original.reviewId(),
                     (int) pageable.getOffset() + i + 1,
                     original.brandName(),
@@ -120,52 +76,17 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     @Override
     public Slice<VideoReviewResponse> findVideoReviewsByCategory(MiddleCategory middleCategory,
                                                                  Pageable pageable) {
-        List<VideoReviewResponse> content = queryFactory
-                .select(Projections.constructor(VideoReviewResponse.class,
-                        review.id.stringValue(),
-                        Expressions.constant(0),
-                        product.brandName,
-                        product.productName,
-                        review.likeCount,
-                        reviewVideo.mediaFile.fileUrl
-                ))
-                .from(reviewVideo)
-                .innerJoin(reviewVideo.review, review)
-                .innerJoin(review.product, product)
-                .where(
-                        product.middleCategory.eq(middleCategory)
-                )
-                .orderBy(review.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
-
-        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
-            VideoReviewResponse original = content.get(i);
-            content.set(i, new VideoReviewResponse(
-                    original.reviewId(),
-                    (int) pageable.getOffset() + i + 1,
-                    original.brandName(),
-                    original.productName(),
-                    original.likeCount(),
-                    original.url()
-            ));
-        }
-
-        boolean hasNext = content.size() > pageable.getPageSize();
-        if (hasNext) {
-            content.remove(content.size() - 1);
-        }
-
-        return new SliceImpl<>(content, pageable, hasNext);
+        return findVideoReviewsByCategory(middleCategory, null, pageable);
     }
+
 
     @Override
     public Slice<ImageReviewResponse> findImageReviewsByCategory(MiddleCategory middleCategory,
+                                                                 SubCategory subCategory,
                                                                  Pageable pageable) {
         List<ImageReviewResponse> content = queryFactory
                 .select(Projections.constructor(ImageReviewResponse.class,
-                        review.id.stringValue(),
+                        review.id,
                         Expressions.constant(0),
                         product.brandName,
                         product.productName,
@@ -176,7 +97,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                 .innerJoin(reviewImage.review, review)
                 .innerJoin(review.product, product)
                 .where(
-                        product.middleCategory.eq(middleCategory)
+                        categoryCondition(middleCategory, subCategory)
                 )
                 .orderBy(review.createdAt.desc())
                 .offset(pageable.getOffset())
@@ -202,6 +123,14 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
         return new SliceImpl<>(content, pageable, hasNext);
     }
+
+
+    @Override
+    public Slice<ImageReviewResponse> findImageReviewsByCategory(MiddleCategory middleCategory,
+                                                                 Pageable pageable) {
+        return findImageReviewsByCategory(middleCategory, null, pageable);
+    }
+
 
     private BooleanExpression categoryCondition(MiddleCategory middleCategory, SubCategory subCategory) {
         BooleanExpression condition = product.middleCategory.eq(middleCategory);

--- a/src/main/java/com/lokoko/domain/review/service/ReviewReadService.java
+++ b/src/main/java/com/lokoko/domain/review/service/ReviewReadService.java
@@ -31,8 +31,16 @@ public class ReviewReadService {
                 ? reviewRepository.findVideoReviewsByCategory(middleCategory, pageable)
                 : reviewRepository.findVideoReviewsByCategory(middleCategory, subCategory, pageable);
 
-        return new VideoReviewListResponse(videoReviews.getContent(), PageableResponse.of(videoReviews));
-
+        return VideoReviewListResponse.builder()
+                .searchQuery(subCategory == null
+                        ? middleCategory.getDisplayName()
+                        : subCategory.getDisplayName())
+                .parentCategoryName(subCategory == null
+                        ? middleCategory.getParent().getDisplayName()
+                        : subCategory.getMiddleCategory().getParent().getDisplayName())
+                .reviews(videoReviews.getContent())
+                .pageInfo(PageableResponse.of(videoReviews))
+                .build();
 
     }
 
@@ -47,7 +55,18 @@ public class ReviewReadService {
                 ? reviewRepository.findImageReviewsByCategory(middleCategory, pageable)
                 : reviewRepository.findImageReviewsByCategory(middleCategory, subCategory, pageable);
 
-        return new ImageReviewListResponse(imageReviews.getContent(), PageableResponse.of(imageReviews));
+//        return new ImageReviewListResponse(imageReviews.getContent(), PageableResponse.of(imageReviews));
+
+        return ImageReviewListResponse.builder()
+                .searchQuery(subCategory == null
+                        ? middleCategory.getDisplayName()
+                        : subCategory.getDisplayName())
+                .parentCategoryName(subCategory == null
+                        ? middleCategory.getParent().getDisplayName()
+                        : subCategory.getMiddleCategory().getParent().getDisplayName())
+                .reviews(imageReviews.getContent())
+                .pageInfo(PageableResponse.of(imageReviews))
+                .build();
 
     }
 

--- a/src/main/java/com/lokoko/domain/review/service/ReviewReadService.java
+++ b/src/main/java/com/lokoko/domain/review/service/ReviewReadService.java
@@ -1,0 +1,55 @@
+package com.lokoko.domain.review.service;
+
+import com.lokoko.domain.product.entity.enums.MiddleCategory;
+import com.lokoko.domain.product.entity.enums.SubCategory;
+import com.lokoko.domain.review.dto.ImageReviewListResponse;
+import com.lokoko.domain.review.dto.ImageReviewResponse;
+import com.lokoko.domain.review.dto.VideoReviewListResponse;
+import com.lokoko.domain.review.dto.VideoReviewResponse;
+import com.lokoko.domain.review.repository.ReviewRepository;
+import com.lokoko.global.common.response.PageableResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewReadService {
+
+    private final ReviewRepository reviewRepository;
+
+    // 카테고리별 영상 리뷰 조회
+    public VideoReviewListResponse searchVideoReviewsByCategory(MiddleCategory middleCategory,
+                                                                SubCategory subCategory,
+                                                                int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<VideoReviewResponse> videoReviews = (subCategory == null)
+                ? reviewRepository.findVideoReviewsByCategory(middleCategory, pageable)
+                : reviewRepository.findVideoReviewsByCategory(middleCategory, subCategory, pageable);
+
+        return new VideoReviewListResponse(videoReviews.getContent(), PageableResponse.of(videoReviews));
+
+
+    }
+
+    // 카테고리 별 사진 리뷰조회
+    public ImageReviewListResponse searchImageReviewsByCategory(MiddleCategory middleCategory,
+                                                                SubCategory subCategory,
+                                                                int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<ImageReviewResponse> imageReviews = (subCategory == null)
+                ? reviewRepository.findImageReviewsByCategory(middleCategory, pageable)
+                : reviewRepository.findImageReviewsByCategory(middleCategory, subCategory, pageable);
+
+        return new ImageReviewListResponse(imageReviews.getContent(), PageableResponse.of(imageReviews));
+
+    }
+
+
+}

--- a/src/main/java/com/lokoko/global/common/entity/MediaType.java
+++ b/src/main/java/com/lokoko/global/common/entity/MediaType.java
@@ -1,0 +1,5 @@
+package com.lokoko.global.common.entity;
+
+public enum MediaType {
+    IMAGE, VIDEO
+}

--- a/src/main/java/com/lokoko/global/common/entity/SearchType.java
+++ b/src/main/java/com/lokoko/global/common/entity/SearchType.java
@@ -1,0 +1,5 @@
+package com.lokoko.global.common.entity;
+
+public enum SearchType {
+    PRODUCT, REVIEW
+}


### PR DESCRIPTION


엔드포인트 예시

localhost:8080/api/products/categories/search?middleCategory=FACE_MAKEUP&searchType=REVIEW&mediaType=VIDEO&page=0&size=2

## Related issue 🛠

- closed #55 

## 작업 내용 💻

- [기존에는 카테고리 별 상품 검색만 있었는데, 카테고리 별 리뷰 검색 기능도 추가했습니다. ] 

- [리뷰 검색 결과를 반환하는 DTO 추가하였습니다.]

- [QueryDSL 이용하여 리뷰 검색 쿼리를 구현하였습니다.]

현재, 정렬은 "리뷰 작성 최순 순" 으로 해놓은 상태입니다.
추후에, 좋아요 엔티티가 구현 됨에 따라 "좋아요가 많은 순" 으로 정렬 로직을 수정할 계획입니다.

-[API 의 반환 타입을 수정했습니다]

기존에는, 카테고리 별 상품 검색의 결과를 반환하는 DTO 만 존재했습니다.
하지만, 리뷰 검색 기능을 추가함에 따라,  고정된 반환 값을 수정할 필요가 있었습니다.

기존에 CategoryProductResponse 만 반환하는 것에서, 와일드 카드를 이용하여 모든 타입의 반환을 처리할 수 있도록 수정했습니다.

이제, CategoryProductResponse(카테고리 별 상품 검색의 결과) 뿐만 아니라, 
VideoReviewListResponse(카테고리 별 리뷰 검색의 결과 - 영상 리뷰 리스트) ,
ImageReviewListResponse(카테고리 별 리뷰 검색의 결과 - 사진 리뷰 리스트) 의 반환이 가능해집니다,

```
 public ApiResponse<?> searchProductsByCategory

```

- [요청 파라미터의 타입을 수정했습니다]

boolean isReview -> SearchType searchType (Enum)
String mediaType -> MediaType mediaType (Enum)


## 스크린샷 📷

![image](https://github.com/user-attachments/assets/e945ffca-53cd-45ab-bef0-a9a6aaba567b)


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 카테고리별 상품 검색 시, 리뷰(이미지/영상) 검색 옵션이 추가되었습니다.
  * 이미지 및 영상 리뷰에 대해 브랜드, 상품명, 좋아요 수, 미디어 URL 등 상세 정보를 포함한 페이징 결과를 제공합니다.
  * 리뷰 검색 성공 메시지가 추가되었습니다.

* **버그 수정**
  * 없음

* **기타**
  * 없음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->