### PR TITLE
[Feat] #74 비디오 리뷰 조회 API (메인페이지)

### DIFF
--- a/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.lokoko.domain.review.dto.request.ReviewMediaRequest;
 import com.lokoko.domain.review.dto.request.ReviewReceiptRequest;
 import com.lokoko.domain.review.dto.request.ReviewRequest;
 import com.lokoko.domain.review.dto.response.MainImageReviewResponse;
+import com.lokoko.domain.review.dto.response.MainVideoReviewResponse;
 import com.lokoko.domain.review.dto.response.ReviewMediaResponse;
 import com.lokoko.domain.review.dto.response.ReviewReceiptResponse;
 import com.lokoko.domain.review.dto.response.ReviewResponse;
@@ -74,5 +75,9 @@ public class ReviewController {
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.MAIN_REVIEW_IMAGE_SUCCESS.getMessage(), response);
     }
 
-
+    @GetMapping("/video")
+    public ApiResponse<MainVideoReviewResponse> getMainVideoReviews() {
+        MainVideoReviewResponse response = reviewService.getMainVideoReview();
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.MAIN_REVIEW_VIDEO_SUCCESS.getMessage(), response);
+    }
 }

--- a/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
@@ -69,12 +69,14 @@ public class ReviewController {
         );
     }
 
+    @Operation(summary = "메인페이지에서 이미지 리뷰 조회")
     @GetMapping("/image")
     public ApiResponse<MainImageReviewResponse> getMainImageReviews() {
         MainImageReviewResponse response = reviewService.getMainImageReview();
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.MAIN_REVIEW_IMAGE_SUCCESS.getMessage(), response);
     }
 
+    @Operation(summary = "메인페이지에서 영상 리뷰 조회")
     @GetMapping("/video")
     public ApiResponse<MainVideoReviewResponse> getMainVideoReviews() {
         MainVideoReviewResponse response = reviewService.getMainVideoReview();

--- a/src/main/java/com/lokoko/domain/review/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/review/controller/enums/ResponseMessage.java
@@ -9,7 +9,8 @@ public enum ResponseMessage {
     REVIEW_RECEIPT_PRESIGNED_URL_SUCCESS("영수증 사진의 Presigned Url이 성공적으로 발급되었습니다."),
     REVIEW_MEDIA_PRESIGNED_URL_SUCCESS("리뷰 사진의 Presigned Url이 성공적으로 발급되었습니다."),
     REVIEW_UPLOAD_SUCCESS("리뷰가 성공적으로 작성되었습니다."),
-    MAIN_REVIEW_IMAGE_SUCCESS("메인페이지 상세 리뷰 조회에 성공했습니다.");
+    MAIN_REVIEW_IMAGE_SUCCESS("메인페이지 상세 리뷰 이미지 조회에 성공했습니다."),
+    MAIN_REVIEW_VIDEO_SUCCESS("메인페이지 상세 리뷰 비디오 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/review/dto/response/MainVideoReview.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/MainVideoReview.java
@@ -1,0 +1,28 @@
+package com.lokoko.domain.review.dto.response;
+
+import com.lokoko.domain.review.entity.Review;
+import com.lokoko.domain.video.entity.ReviewVideo;
+
+public record MainVideoReview(
+        Long reviewId,
+        String brandName,
+        String productName,
+        int likeCount,
+        int rank,
+        String reviewVideo
+) {
+
+    public static MainVideoReview from(ReviewVideo reviewVideo, int rank) {
+        Review review = reviewVideo.getReview();
+
+        return new MainVideoReview(
+                review.getId(),
+                review.getProduct().getBrandName(),
+                review.getProduct().getProductName(),
+                review.getLikeCount(),
+                rank,
+                reviewVideo.getMediaFile().getFileUrl()
+        );
+    }
+}
+

--- a/src/main/java/com/lokoko/domain/review/dto/response/MainVideoReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/MainVideoReviewResponse.java
@@ -1,0 +1,9 @@
+package com.lokoko.domain.review.dto.response;
+
+import java.util.List;
+
+
+public record MainVideoReviewResponse(
+        List<MainVideoReview> videoReviews
+) {
+}

--- a/src/main/java/com/lokoko/domain/review/service/ReviewService.java
+++ b/src/main/java/com/lokoko/domain/review/service/ReviewService.java
@@ -37,7 +37,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -205,32 +204,43 @@ public class ReviewService {
     }
 
     public MainImageReviewResponse getMainImageReview() {
-        List<ReviewImage> sorted = reviewImageRepository.findMainImageReviewSorted();
+        List<ReviewImage> sortedImage = reviewImageRepository.findMainImageReviewSorted();
 
-        List<MainImageReview> dtoList = IntStream.range(0, sorted.size())
-                .mapToObj(i -> MainImageReview.from(sorted.get(i), i + 1))
+        List<MainImageReview> dtoList = IntStream.range(0, sortedImage.size())
+                .mapToObj(i -> MainImageReview.from(sortedImage.get(i), i + 1))
                 .toList();
 
         return new MainImageReviewResponse(dtoList);
     }
 
-    public MainVideoReviewResponse getMainVideoReview() {
-        List<ReviewVideo> videos = reviewVideoRepository.findAllMainReviewVideoWithReview();
+    public MainVideoReviewResponse getMainVideoReview()  {
+        List<ReviewVideo> sortedVideo = reviewVideoRepository.findMainVideoReviewSorted();
 
-        // 정렬: likeCount DESC, 좋아요 개수 같을 시 rating.value DESC
-        List<ReviewVideo> sorted = videos.stream()
-                .sorted(Comparator
-                        .comparing((ReviewVideo ri) -> ri.getReview().getLikeCount()).reversed()
-                        .thenComparing(ri -> ri.getReview().getRating().getValue(), Comparator.reverseOrder()))
-                .limit(4)
-                .toList();
-
-        List<MainVideoReview> dtoList = IntStream.range(0, sorted.size())
-                .mapToObj(i -> MainVideoReview.from(sorted.get(i), i + 1))
+        List<MainVideoReview> dtoList = IntStream.range(0, sortedVideo.size())
+                .mapToObj(i -> MainVideoReview.from(sortedVideo.get(i), i + 1))
                 .toList();
 
         return new MainVideoReviewResponse(dtoList);
     }
+
+
+//    public MainVideoReviewResponse getMainVideoReview() {
+//        List<ReviewVideo> videos = reviewVideoRepository.findAllMainReviewVideoWithReview();
+//
+//        // 정렬: likeCount DESC, 좋아요 개수 같을 시 rating.value DESC
+//        List<ReviewVideo> sorted = videos.stream()
+//                .sorted(Comparator
+//                        .comparing((ReviewVideo ri) -> ri.getReview().getLikeCount()).reversed()
+//                        .thenComparing(ri -> ri.getReview().getRating().getValue(), Comparator.reverseOrder()))
+//                .limit(4)
+//                .toList();
+//
+//        List<MainVideoReview> dtoList = IntStream.range(0, sorted.size())
+//                .mapToObj(i -> MainVideoReview.from(sorted.get(i), i + 1))
+//                .toList();
+//
+//        return new MainVideoReviewResponse(dtoList);
+//    }
 
 
 }

--- a/src/main/java/com/lokoko/domain/review/service/ReviewService.java
+++ b/src/main/java/com/lokoko/domain/review/service/ReviewService.java
@@ -13,6 +13,8 @@ import com.lokoko.domain.review.dto.request.ReviewReceiptRequest;
 import com.lokoko.domain.review.dto.request.ReviewRequest;
 import com.lokoko.domain.review.dto.response.MainImageReview;
 import com.lokoko.domain.review.dto.response.MainImageReviewResponse;
+import com.lokoko.domain.review.dto.response.MainVideoReview;
+import com.lokoko.domain.review.dto.response.MainVideoReviewResponse;
 import com.lokoko.domain.review.dto.response.ReviewMediaResponse;
 import com.lokoko.domain.review.dto.response.ReviewReceiptResponse;
 import com.lokoko.domain.review.dto.response.ReviewResponse;
@@ -210,7 +212,7 @@ public class ReviewService {
                 .sorted(Comparator
                         .comparing((ReviewImage ri) -> ri.getReview().getLikeCount()).reversed()
                         .thenComparing(ri -> ri.getReview().getRating().getValue(), Comparator.reverseOrder()))
-                .limit(10)
+                .limit(4)
                 .toList();
 
         List<MainImageReview> dtoList = IntStream.range(0, sorted.size())
@@ -219,5 +221,24 @@ public class ReviewService {
 
         return new MainImageReviewResponse(dtoList);
     }
+
+    public MainVideoReviewResponse getMainVideoReview() {
+        List<ReviewVideo> videos = reviewVideoRepository.findAllMainReviewVideoWithReview();
+
+        // 정렬: likeCount DESC, 좋아요 개수 같을 시 rating.value DESC
+        List<ReviewVideo> sorted = videos.stream()
+                .sorted(Comparator
+                        .comparing((ReviewVideo ri) -> ri.getReview().getLikeCount()).reversed()
+                        .thenComparing(ri -> ri.getReview().getRating().getValue(), Comparator.reverseOrder()))
+                .limit(4)
+                .toList();
+
+        List<MainVideoReview> dtoList = IntStream.range(0, sorted.size())
+                .mapToObj(i -> MainVideoReview.from(sorted.get(i), i + 1))
+                .toList();
+
+        return new MainVideoReviewResponse(dtoList);
+    }
+
 
 }

--- a/src/main/java/com/lokoko/domain/user/admin/controller/AdminController.java
+++ b/src/main/java/com/lokoko/domain/user/admin/controller/AdminController.java
@@ -4,6 +4,7 @@ import com.lokoko.domain.user.admin.controller.enums.ResponseMessage;
 import com.lokoko.domain.user.admin.service.AdminReviewService;
 import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,7 @@ public class AdminController {
 
     private final AdminReviewService adminReviewService;
 
+    @Operation(summary = "어드민 리뷰 삭제")
     @DeleteMapping("/reviews/{reviewId}")
     public ApiResponse<Void> deleteReviewByAdmin(@CurrentUser Long userId, @PathVariable Long reviewId) {
         adminReviewService.deleteReview(userId, reviewId);

--- a/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
+++ b/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
@@ -1,11 +1,27 @@
 package com.lokoko.domain.video.repository;
 
+import com.lokoko.domain.image.entity.ReviewImage;
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.video.entity.ReviewVideo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ReviewVideoRepository extends JpaRepository<ReviewVideo, Long> {
+
+    // 리뷰 비디오ㅓ 참조하는 리뷰
+    // 리뷰가 참조하는 상품
+    // 대표 영상(displayOrder = 0)만 조회
+    @Query("""
+                SELECT ri FROM ReviewVideo ri
+                JOIN FETCH ri.review r         
+                JOIN FETCH r.product p       
+                WHERE ri.displayOrder = 0      
+            """)
+    List<ReviewVideo> findAllMainReviewVideoWithReview();
+
     void deleteAllByReview(Review review);
 }

--- a/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
+++ b/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
@@ -1,27 +1,11 @@
 package com.lokoko.domain.video.repository;
 
-import com.lokoko.domain.image.entity.ReviewImage;
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.video.entity.ReviewVideo;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
-public interface ReviewVideoRepository extends JpaRepository<ReviewVideo, Long> ,ReviewVideoRepositoryCustom{
-
-    // 리뷰 비디오ㅓ 참조하는 리뷰
-    // 리뷰가 참조하는 상품
-    // 대표 영상(displayOrder = 0)만 조회
-    @Query("""
-                SELECT ri FROM ReviewVideo ri
-                JOIN FETCH ri.review r         
-                JOIN FETCH r.product p       
-                WHERE ri.displayOrder = 0      
-            """)
-    List<ReviewVideo> findAllMainReviewVideoWithReview();
-
+public interface ReviewVideoRepository extends JpaRepository<ReviewVideo, Long>, ReviewVideoRepositoryCustom {
     void deleteAllByReview(Review review);
 }

--- a/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
+++ b/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ReviewVideoRepository extends JpaRepository<ReviewVideo, Long> {
+public interface ReviewVideoRepository extends JpaRepository<ReviewVideo, Long> ,ReviewVideoRepositoryCustom{
 
     // 리뷰 비디오ㅓ 참조하는 리뷰
     // 리뷰가 참조하는 상품

--- a/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.lokoko.domain.video.repository;
+
+import com.lokoko.domain.video.entity.ReviewVideo;
+
+import java.util.List;
+
+public interface ReviewVideoRepositoryCustom {
+    List<ReviewVideo> findMainVideoReviewSorted();
+}

--- a/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepositoryImpl.java
@@ -24,8 +24,10 @@ public class ReviewVideoRepositoryImpl implements ReviewVideoRepositoryCustom {
                 .selectFrom(reviewVideo)
                 .join(reviewVideo.review, review).fetchJoin()
                 .join(review.product, product).fetchJoin()
+                .leftJoin(reviewVideo).on(reviewVideo.review.eq(review))
                 // 대표 이미지 조건: displayOrder == 0
                 .where(reviewVideo.displayOrder.eq(0))
+                .groupBy(reviewVideo.id, review.id, product.id, review.rating)
                 // 정렬 조건: 좋아요 내림차순 → 평점 내림차순
                 .orderBy(
                         review.likeCount.desc(),

--- a/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/video/repository/ReviewVideoRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.lokoko.domain.video.repository;
+
+import com.lokoko.domain.product.entity.QProduct;
+import com.lokoko.domain.review.entity.QReview;
+import com.lokoko.domain.video.entity.QReviewVideo;
+import com.lokoko.domain.video.entity.ReviewVideo;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewVideoRepositoryImpl implements ReviewVideoRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    private static final QReviewVideo reviewVideo = QReviewVideo.reviewVideo;
+    private static final QReview review = QReview.review;
+    private static final QProduct product = QProduct.product;
+
+    @Override
+    public List<ReviewVideo> findMainVideoReviewSorted() {
+        return queryFactory
+                .selectFrom(reviewVideo)
+                .join(reviewVideo.review, review).fetchJoin()
+                .join(review.product, product).fetchJoin()
+                // 대표 이미지 조건: displayOrder == 0
+                .where(reviewVideo.displayOrder.eq(0))
+                // 정렬 조건: 좋아요 내림차순 → 평점 내림차순
+                .orderBy(
+                        review.likeCount.desc(),
+                        review.rating.desc()
+                )
+                .limit(4)
+                .fetch();
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #72 

## 작업 내용 💻
- [x]  유저 영상 리뷰 조회하는 API입니다.

## 스크린샷 📷
<img width="2004" height="1366" alt="image" src="https://github.com/user-attachments/assets/820e4fd3-ae31-458d-bda0-f72298087ac8" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢
1. 좋아요 순으로 정렬합니다
2. 좋아요 수가 같을 시 별점순으로 정렬합니다.
3. 비디오는 리뷰당 한개이지만.. (혹시나 몰라) displayOrder = 0으로 내려주기로 했습니다. 

일단 메인페이지 4개만 내려주는 걸로 얘기 완료했습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 메인 페이지에서 이미지 및 동영상 리뷰를 조회할 수 있는 새로운 엔드포인트가 추가되었습니다.
  * 메인 동영상 리뷰 목록을 반환하는 기능이 제공됩니다.

* **문서화**
  * 어드민 리뷰 삭제 API에 대한 설명이 Swagger 문서에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->