### PR TITLE
[Feat] #78 리뷰 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/like/controller/ProductLikeController.java
+++ b/src/main/java/com/lokoko/domain/like/controller/ProductLikeController.java
@@ -1,7 +1,8 @@
 package com.lokoko.domain.like.controller;
 
-import static com.lokoko.domain.like.controller.enums.ResponseMessage.LIKE_TOGGLE_SUCCESS;
+import static com.lokoko.domain.like.controller.enums.ResponseMessage.PRODUCT_LIKE_TOGGLE_SUCCESS;
 
+import com.lokoko.domain.like.dto.ToggleLikeResponse;
 import com.lokoko.domain.like.service.ProductLikeService;
 import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.common.response.ApiResponse;
@@ -24,10 +25,11 @@ public class ProductLikeController {
 
     @Operation(summary = "상품 좋아요 토글 (추가/취소)")
     @PostMapping
-    public ApiResponse<Void> toggleLike(@PathVariable final Long productId,
-                                        @Parameter(hidden = true) @CurrentUser Long userId) {
+    public ApiResponse<ToggleLikeResponse> toggleLike(@PathVariable final Long productId,
+                                                      @Parameter(hidden = true) @CurrentUser Long userId) {
         productLikeService.toggleProductLike(productId, userId);
-
-        return ApiResponse.success(HttpStatus.OK, LIKE_TOGGLE_SUCCESS.getMessage());
+        boolean isLiked = productLikeService.isLiked(productId, userId);
+        return ApiResponse.success(HttpStatus.OK, PRODUCT_LIKE_TOGGLE_SUCCESS.getMessage(),
+                new ToggleLikeResponse(isLiked));
     }
 }

--- a/src/main/java/com/lokoko/domain/like/controller/ProductLikeController.java
+++ b/src/main/java/com/lokoko/domain/like/controller/ProductLikeController.java
@@ -2,7 +2,7 @@ package com.lokoko.domain.like.controller;
 
 import static com.lokoko.domain.like.controller.enums.ResponseMessage.PRODUCT_LIKE_TOGGLE_SUCCESS;
 
-import com.lokoko.domain.like.dto.ToggleLikeResponse;
+import com.lokoko.domain.like.dto.response.ToggleLikeResponse;
 import com.lokoko.domain.like.service.ProductLikeService;
 import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.common.response.ApiResponse;

--- a/src/main/java/com/lokoko/domain/like/controller/ReviewLikeController.java
+++ b/src/main/java/com/lokoko/domain/like/controller/ReviewLikeController.java
@@ -1,7 +1,18 @@
 package com.lokoko.domain.like.controller;
 
+import static com.lokoko.domain.like.controller.enums.ResponseMessage.REVIEW_LIKE_TOGGLE_SUCCESS;
+
+import com.lokoko.domain.like.dto.response.ReviewLikeResponse;
+import com.lokoko.domain.like.service.ReviewLikeService;
+import com.lokoko.global.auth.annotation.CurrentUser;
+import com.lokoko.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +21,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/likes/reviews/{reviewId}")
 @RequiredArgsConstructor
 public class ReviewLikeController {
+    private final ReviewLikeService reviewLikeService;
+
+    @Operation(summary = "리뷰 좋아요 토글 (추가/취소)")
+    @PostMapping
+    public ApiResponse<ReviewLikeResponse> toggleLike(@PathVariable final Long reviewId,
+                                                      @Parameter(hidden = true) @CurrentUser Long userId) {
+        long likeCount = reviewLikeService.toggleReviewLike(reviewId, userId);
+
+        return ApiResponse.success(HttpStatus.OK, REVIEW_LIKE_TOGGLE_SUCCESS.getMessage(),
+                new ReviewLikeResponse(likeCount));
+    }
 }

--- a/src/main/java/com/lokoko/domain/like/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/like/controller/enums/ResponseMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ResponseMessage {
-    PRODUCT_LIKE_TOGGLE_SUCCESS("상품 좋아요 토글에 성공했습니다.");
+    PRODUCT_LIKE_TOGGLE_SUCCESS("상품 좋아요 토글에 성공했습니다."),
+    REVIEW_LIKE_TOGGLE_SUCCESS("리뷰 좋아요 토글에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/like/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/like/controller/enums/ResponseMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ResponseMessage {
-    LIKE_TOGGLE_SUCCESS("좋아요 토글에 성공했습니다.");
+    PRODUCT_LIKE_TOGGLE_SUCCESS("상품 좋아요 토글에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/like/dto/ToggleLikeResponse.java
+++ b/src/main/java/com/lokoko/domain/like/dto/ToggleLikeResponse.java
@@ -1,0 +1,6 @@
+package com.lokoko.domain.like.dto;
+
+public record ToggleLikeResponse(
+        boolean isLiked
+) {
+}

--- a/src/main/java/com/lokoko/domain/like/dto/response/ReviewLikeResponse.java
+++ b/src/main/java/com/lokoko/domain/like/dto/response/ReviewLikeResponse.java
@@ -1,0 +1,6 @@
+package com.lokoko.domain.like.dto.response;
+
+public record ReviewLikeResponse(
+        long likeCount
+) {
+}

--- a/src/main/java/com/lokoko/domain/like/dto/response/ToggleLikeResponse.java
+++ b/src/main/java/com/lokoko/domain/like/dto/response/ToggleLikeResponse.java
@@ -1,4 +1,4 @@
-package com.lokoko.domain.like.dto;
+package com.lokoko.domain.like.dto.response;
 
 public record ToggleLikeResponse(
         boolean isLiked

--- a/src/main/java/com/lokoko/domain/like/entity/ReviewLike.java
+++ b/src/main/java/com/lokoko/domain/like/entity/ReviewLike.java
@@ -44,12 +44,12 @@ public class ReviewLike extends BaseEntity {
     @JoinColumn(name = "user_id") //  foreign key
     private User user;  // 어떤 회원이 좋아요를 눌렀는지
 
-    // 정적 팩토리 메소드
-    public static ReviewLike createReviewLike(Review review, User user) {
-        return ReviewLike.builder()
-                .review(review)
-                .user(user)
-                .build();
+    protected ReviewLike(Review review, User user) {
+        this.review = review;
+        this.user = user;
     }
 
+    public static ReviewLike of(Review review, User user) {
+        return new ReviewLike(review, user);
+    }
 }

--- a/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
@@ -1,9 +1,13 @@
 package com.lokoko.domain.like.repository;
 
 import com.lokoko.domain.like.entity.ReviewLike;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
+    Optional<ReviewLike> findByReviewIdAndUserId(Long reviewId, Long userId);
+
+    long countByReviewId(Long reviewId);
 }

--- a/src/main/java/com/lokoko/domain/like/service/ReviewLikeService.java
+++ b/src/main/java/com/lokoko/domain/like/service/ReviewLikeService.java
@@ -1,0 +1,41 @@
+package com.lokoko.domain.like.service;
+
+import com.lokoko.domain.like.entity.ReviewLike;
+import com.lokoko.domain.like.repository.ReviewLikeRepository;
+import com.lokoko.domain.review.entity.Review;
+import com.lokoko.domain.review.exception.ReviewNotFoundException;
+import com.lokoko.domain.review.repository.ReviewRepository;
+import com.lokoko.domain.user.entity.User;
+import com.lokoko.domain.user.exception.UserNotFoundException;
+import com.lokoko.domain.user.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewLikeService {
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+    private final ReviewLikeRepository reviewLikeRepository;
+
+    @Transactional
+    public long toggleReviewLike(Long reviewId, Long userId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(ReviewNotFoundException::new);
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Optional<ReviewLike> existing = reviewLikeRepository
+                .findByReviewIdAndUserId(reviewId, userId);
+        if (existing.isPresent()) {
+            reviewLikeRepository.delete(existing.get());
+        } else {
+            reviewLikeRepository.save(ReviewLike.of(review, user));
+        }
+
+        return reviewLikeRepository.countByReviewId(reviewId);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #77 

## 작업 내용 💻

- [x] 리뷰 좋아요 기능 구현

## 스크린샷 📷

<img width="345" height="147" alt="image" src="https://github.com/user-attachments/assets/bbd49146-2f2e-4a9b-a202-67dc796e9a54" />

좋아요를 누른 유저가 한번 더 좋아요를 누르면 좋아요가 취소

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

반환값으로는 총 리뷰 좋아요의 개수를 반환하도록 했습니다

시간이 된다면, 리뷰 좋아요도 조회시 함께 반환할 수 있도록 구현할 예정입니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 리뷰에 좋아요를 토글할 수 있는 기능이 추가되었습니다. 리뷰 좋아요 상태 변경 시, 최신 좋아요 수가 반환됩니다.
  * 상품 좋아요 토글 시, 현재 좋아요 상태가 응답에 포함되어 표시됩니다.

* **버그 수정**
  * 좋아요 토글 성공 메시지가 상품과 리뷰 각각에 맞게 구분되어 제공됩니다.

* **기타**
  * 좋아요 관련 응답 데이터 구조가 개선되어, 좋아요 상태 및 수가 명확하게 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->