### PR TITLE
[MOD] #79 리뷰 검색 결과가 좋아요 순으로 정렬되도록 수정 

### DIFF
--- a/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
+++ b/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
@@ -1,5 +1,7 @@
 package com.lokoko.domain.image.entity;
 
+import static jakarta.persistence.FetchType.LAZY;
+
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.global.common.entity.BaseEntity;
 import com.lokoko.global.common.entity.MediaFile;
@@ -15,8 +17,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import static jakarta.persistence.FetchType.LAZY;
 
 @Getter
 @Entity
@@ -45,4 +45,8 @@ public class ReviewImage extends BaseEntity {
                 .review(review)
                 .build();
     }
+
+    private boolean isMain;
+
+
 }

--- a/src/main/java/com/lokoko/domain/product/controller/ProductController.java
+++ b/src/main/java/com/lokoko/domain/product/controller/ProductController.java
@@ -83,7 +83,7 @@ public class ProductController {
         if (searchType == SearchType.REVIEW) {
             if (mediaType == MediaType.VIDEO) {
                 VideoReviewListResponse videoReviewResponse = reviewReadService.searchVideoReviewsByCategory(
-                        middleCategory, subCategory, userId, page, size);
+                        middleCategory, subCategory, page, size);
 
                 return ApiResponse.success(HttpStatus.OK, CATEGORY_REVIEW_SEARCH_SUCCESS.getMessage(),
                         videoReviewResponse);

--- a/src/main/java/com/lokoko/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/product/repository/ProductRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.lokoko.domain.review.entity.enums.Rating;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -47,8 +46,14 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             allMatches = List.of();
         } else {
             NumberExpression<Long> reviewCount = r.id.count();
-
-            NumberExpression<Double> ratingAvgExpr = Expressions.numberTemplate(Double.class, "avg({0})", r.rating);
+            NumberExpression<Integer> ratingValue = new CaseBuilder()
+                    .when(r.rating.eq(Rating.ONE)).then(1)
+                    .when(r.rating.eq(Rating.TWO)).then(2)
+                    .when(r.rating.eq(Rating.THREE)).then(3)
+                    .when(r.rating.eq(Rating.FOUR)).then(4)
+                    .when(r.rating.eq(Rating.FIVE)).then(5)
+                    .otherwise(0);
+            NumberExpression<Double> ratingAvgExpr = ratingValue.avg();
 
             BooleanBuilder finalCondition = buildSearchCondition(tokens);
 

--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewResponse.java
@@ -2,7 +2,6 @@ package com.lokoko.domain.review.dto.response;
 
 public record ImageReviewResponse(
         Long reviewId,
-        int ranking,
         String brandName,
         String productName,
         int likeCount,

--- a/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewResponse.java
@@ -2,7 +2,6 @@ package com.lokoko.domain.review.dto.response;
 
 public record VideoReviewResponse(
         Long reviewId,
-        int ranking,
         String brandName,
         String productName,
         int likeCount,

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.lokoko.domain.review.repository;
 
 import com.lokoko.domain.image.entity.QReviewImage;
+import com.lokoko.domain.like.entity.QReviewLike;
 import com.lokoko.domain.product.entity.QProduct;
 import com.lokoko.domain.product.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.entity.enums.SubCategory;
@@ -13,7 +14,6 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,6 +32,8 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     private final QProduct product = QProduct.product;
     private final QReviewVideo reviewVideo = QReviewVideo.reviewVideo;
     private final QReviewImage reviewImage = QReviewImage.reviewImage;
+    private final QReviewLike reviewLike = QReviewLike.reviewLike;
+
 
     @Override
     public Slice<VideoReviewResponse> findVideoReviewsByCategory(MiddleCategory middleCategory,
@@ -40,34 +42,23 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         List<VideoReviewResponse> content = queryFactory
                 .select(Projections.constructor(VideoReviewResponse.class,
                         review.id,
-                        Expressions.constant(0),
                         product.brandName,
                         product.productName,
-                        review.likeCount,
+                        reviewLike.count().intValue(),
                         reviewVideo.mediaFile.fileUrl
                 ))
                 .from(reviewVideo)
                 .innerJoin(reviewVideo.review, review)
                 .innerJoin(review.product, product)
+                .leftJoin(reviewLike).on(reviewLike.review.eq(review))
                 .where(
                         categoryCondition(middleCategory, subCategory)
                 )
-                .orderBy(review.createdAt.desc())
+                .groupBy(review.id, product.brandName, product.productName, reviewVideo.mediaFile.fileUrl)
+                .orderBy(reviewLike.count().desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
-
-        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
-            VideoReviewResponse original = content.get(i);
-            content.set(i, new VideoReviewResponse(
-                    original.reviewId(),
-                    (int) pageable.getOffset() + i + 1,
-                    original.brandName(),
-                    original.productName(),
-                    original.likeCount(),
-                    original.url()
-            ));
-        }
 
         boolean hasNext = content.size() > pageable.getPageSize();
         if (hasNext) {
@@ -91,34 +82,24 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         List<ImageReviewResponse> content = queryFactory
                 .select(Projections.constructor(ImageReviewResponse.class,
                         review.id,
-                        Expressions.constant(0),
                         product.brandName,
                         product.productName,
-                        review.likeCount,
+                        reviewLike.count().intValue(),
                         reviewImage.mediaFile.fileUrl
                 ))
                 .from(reviewImage)
                 .innerJoin(reviewImage.review, review)
                 .innerJoin(review.product, product)
+                .leftJoin(reviewLike).on(reviewLike.review.eq(review))
                 .where(
-                        categoryCondition(middleCategory, subCategory)
+                        categoryCondition(middleCategory, subCategory),
+                        reviewImage.isMain.eq(true)
                 )
-                .orderBy(review.createdAt.desc())
+                .groupBy(review.id, product.brandName, product.productName, reviewImage.mediaFile.fileUrl)
+                .orderBy(reviewLike.count().desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
-
-        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
-            ImageReviewResponse original = content.get(i);
-            content.set(i, new ImageReviewResponse(
-                    original.reviewId(),
-                    (int) pageable.getOffset() + i + 1,
-                    original.brandName(),
-                    original.productName(),
-                    original.likeCount(),
-                    original.url()
-            ));
-        }
 
         boolean hasNext = content.size() > pageable.getPageSize();
         if (hasNext) {
@@ -148,15 +129,131 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     @Override
     public Slice<VideoReviewResponse> findVideoReviewsByKeyword(List<String> tokens, Pageable pageable) {
         List<VideoReviewResponse> content = getVideoReviewsByKeyword(tokens, pageable);
-        updateVideoSequence(content, pageable);
         return createSlice(content, pageable);
     }
 
     @Override
     public Slice<ImageReviewResponse> findImageReviewsByKeyword(List<String> tokens, Pageable pageable) {
         List<ImageReviewResponse> content = getImageReviewsByKeyword(tokens, pageable);
-        updateImageSequence(content, pageable);
         return createSlice(content, pageable);
+    }
+
+    private List<VideoReviewResponse> getVideoReviewsByKeyword(List<String> tokens, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(VideoReviewResponse.class,
+                        review.id,
+                        product.brandName,
+                        product.productName,
+                        reviewLike.count().intValue(),
+                        reviewVideo.mediaFile.fileUrl
+                ))
+                .from(reviewVideo)
+                .innerJoin(reviewVideo.review, review)
+                .innerJoin(review.product, product)
+                .leftJoin(reviewLike).on(reviewLike.review.eq(review))
+                .where(keywordCondition(tokens))
+                .groupBy(review.id, product.brandName, product.productName, reviewVideo.mediaFile.fileUrl)
+                .orderBy(reviewLike.count().desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    private List<ImageReviewResponse> getImageReviewsByKeyword(List<String> tokens, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(ImageReviewResponse.class,
+                        review.id,
+                        product.brandName,
+                        product.productName,
+                        reviewLike.count().intValue(),
+                        reviewImage.mediaFile.fileUrl
+                ))
+                .from(reviewImage)
+                .innerJoin(reviewImage.review, review)
+                .innerJoin(review.product, product)
+                .leftJoin(reviewLike).on(reviewLike.review.eq(review))
+                .where(keywordCondition(tokens),
+                        reviewImage.isMain.eq(true))
+                .groupBy(review.id, product.brandName, product.productName, reviewImage.mediaFile.fileUrl)
+                .orderBy(review.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    private BooleanBuilder keywordCondition(List<String> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            return null;
+        }
+
+        // 1단계: 완전 일치 검색
+        String fullKeyword = String.join("", tokens);
+        BooleanBuilder exactMatch = new BooleanBuilder()
+                .and(product.searchToken.containsIgnoreCase(fullKeyword));
+
+        // 완전 일치 결과가 있는지 확인
+        long exactMatchCount = queryFactory
+                .select(review.count())
+                .from(review)
+                .innerJoin(review.product, product)
+                .where(exactMatch)
+                .fetchOne();
+
+        if (exactMatchCount > 0) {
+            return exactMatch;
+        }
+
+        // 2단계: 모든 토큰 포함 (AND 검색)
+        BooleanBuilder allTokensMatch = new BooleanBuilder();
+        tokens.forEach(token ->
+                allTokensMatch.and(product.searchToken.containsIgnoreCase(token))
+        );
+
+        long allTokensCount = queryFactory
+                .select(review.count())
+                .from(review)
+                .innerJoin(review.product, product)
+                .where(allTokensMatch)
+                .fetchOne();
+
+        if (allTokensCount > 0) {
+            return allTokensMatch;
+        }
+
+        // 3단계: 주요 토큰 포함 (첫 번째와 마지막 토큰)
+        if (tokens.size() >= 3) {
+            BooleanBuilder majorTokensMatch = new BooleanBuilder()
+                    .and(product.searchToken.containsIgnoreCase(tokens.get(0)))
+                    .and(product.searchToken.containsIgnoreCase(tokens.get(tokens.size() - 1)));
+
+            long majorTokensCount = queryFactory
+                    .select(review.count())
+                    .from(review)
+                    .innerJoin(review.product, product)
+                    .where(majorTokensMatch)
+                    .fetchOne();
+
+            if (majorTokensCount > 0) {
+                return majorTokensMatch;
+            }
+        }
+
+        // 4단계: 일부 토큰 포함 (OR 검색)
+        BooleanBuilder anyTokenMatch = new BooleanBuilder();
+        tokens.forEach(token ->
+                anyTokenMatch.or(product.searchToken.containsIgnoreCase(token))
+        );
+
+        return anyTokenMatch;
+    }
+
+
+    private <T> Slice<T> createSlice(List<T> content, Pageable pageable) {
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content.remove(content.size() - 1);
+        }
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 
     @Override
@@ -180,124 +277,6 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                         t.get(review.id.count())
                 ))
                 .collect(Collectors.toList());
-    }
-
-    private List<VideoReviewResponse> getVideoReviewsByKeyword(List<String> tokens, Pageable pageable) {
-        return queryFactory
-                .select(Projections.constructor(VideoReviewResponse.class,
-                        review.id,
-                        Expressions.constant(0),
-                        product.brandName,
-                        product.productName,
-                        review.likeCount,
-                        reviewVideo.mediaFile.fileUrl
-                ))
-                .from(reviewVideo)
-                .innerJoin(reviewVideo.review, review)
-                .innerJoin(review.product, product)
-                .where(keywordCondition(tokens))
-                .orderBy(review.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
-    }
-
-    private List<ImageReviewResponse> getImageReviewsByKeyword(List<String> tokens, Pageable pageable) {
-        return queryFactory
-                .select(Projections.constructor(ImageReviewResponse.class,
-                        review.id,
-                        Expressions.constant(0),
-                        product.brandName,
-                        product.productName,
-                        review.likeCount,
-                        reviewImage.mediaFile.fileUrl
-                ))
-                .from(reviewImage)
-                .innerJoin(reviewImage.review, review)
-                .innerJoin(review.product, product)
-                .where(keywordCondition(tokens))
-                .orderBy(review.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
-    }
-
-    private BooleanBuilder keywordCondition(List<String> tokens) {
-        if (tokens == null || tokens.isEmpty()) {
-            return null;
-        }
-
-        // 1단계: 완전 일치 검색
-        String fullKeyword = String.join("", tokens);
-        BooleanExpression exactMatch = product.searchToken.containsIgnoreCase(fullKeyword);
-
-        // 2단계: 모든 토큰 포함 (AND 검색)
-        BooleanBuilder allTokensMatch = new BooleanBuilder();
-        tokens.forEach(token ->
-                allTokensMatch.and(product.searchToken.containsIgnoreCase(token))
-        );
-
-        // 3단계: 주요 토큰 포함 (첫 번째와 마지막 토큰)
-        BooleanExpression majorTokensMatch = null;
-        if (tokens.size() >= 3) {
-            majorTokensMatch = product.searchToken.containsIgnoreCase(tokens.get(0))
-                    .and(product.searchToken.containsIgnoreCase(tokens.get(tokens.size() - 1)));
-        }
-
-        // 4단계: 일부 토큰 포함 (OR 검색)
-        BooleanBuilder anyTokenMatch = new BooleanBuilder();
-        tokens.forEach(token ->
-                anyTokenMatch.or(product.searchToken.containsIgnoreCase(token))
-        );
-
-        // 모든 검색 조건을 OR로 연결
-        BooleanBuilder finalCondition = new BooleanBuilder();
-        finalCondition.or(exactMatch);
-        finalCondition.or(allTokensMatch);
-        if (majorTokensMatch != null) {
-            finalCondition.or(majorTokensMatch);
-        }
-        finalCondition.or(anyTokenMatch);
-
-        return finalCondition;
-    }
-
-    private void updateVideoSequence(List<VideoReviewResponse> content, Pageable pageable) {
-        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
-            VideoReviewResponse original = content.get(i);
-            VideoReviewResponse updated = new VideoReviewResponse(
-                    original.reviewId(),
-                    (int) pageable.getOffset() + i + 1,
-                    original.brandName(),
-                    original.productName(),
-                    original.likeCount(),
-                    original.url()
-            );
-            content.set(i, updated);
-        }
-    }
-
-    private void updateImageSequence(List<ImageReviewResponse> content, Pageable pageable) {
-        for (int i = 0; i < Math.min(content.size(), pageable.getPageSize()); i++) {
-            ImageReviewResponse original = content.get(i);
-            ImageReviewResponse updated = new ImageReviewResponse(
-                    original.reviewId(),
-                    (int) pageable.getOffset() + i + 1,
-                    original.brandName(),
-                    original.productName(),
-                    original.likeCount(),
-                    original.url()
-            );
-            content.set(i, updated);
-        }
-    }
-
-    private <T> Slice<T> createSlice(List<T> content, Pageable pageable) {
-        boolean hasNext = content.size() > pageable.getPageSize();
-        if (hasNext) {
-            content.remove(content.size() - 1);
-        }
-        return new SliceImpl<>(content, pageable, hasNext);
     }
 
 }

--- a/src/main/java/com/lokoko/domain/review/service/ReviewReadService.java
+++ b/src/main/java/com/lokoko/domain/review/service/ReviewReadService.java
@@ -28,7 +28,7 @@ public class ReviewReadService {
     // 카테고리별 영상 리뷰 조회
     public VideoReviewListResponse searchVideoReviewsByCategory(MiddleCategory middleCategory,
                                                                 SubCategory subCategory,
-                                                                Long userId, int page, int size) {
+                                                                int page, int size) {
 
         Pageable pageable = PageRequest.of(page, size);
 


### PR DESCRIPTION
## Related issue 🛠

- closed #75 

## 작업 내용 💻

- [카테고리 별 리뷰 검색에서 검색 결과가 좋아요 순으로 정렬 되도록 수정했습니다.] 
- [상품명 또는 브랜드 명 리뷰 검색에서 검색 결과가 좋아요 순으로 정렬 되도록 수정했습니다. ] 


기존에 QueryDSL 에  작성하였던 메소드에, ReviewLike 에 대한 LeftJoin 만 추가했습니다.
LeftJoin 으로 조인을 한 이유는, 좋아요 수가 0인 리뷰도 조회결과에 포함 시키기 위함입니다.
leftjoin 을 하지 않으면 좋아요가 0인 리뷰는 조회 결과에 포함되지 않게 됩니다.


리뷰는 여러 이미지를 가질 수 있기 때문에, 어떤 이미지가 대표이미지인지 알아야합니다.
ReviewImage 엔티티의 필드에 isMain 을 추가했습니다.


## 스크린샷 📷

상품명 / 브랜드 명 리뷰 검색 결과 (영상 리뷰)

<img width="885" height="497" alt="image" src="https://github.com/user-attachments/assets/e9caa6cd-07f9-475b-a50e-0b561deb97a5" />


카테고리 별 리뷰 검색 결과 (영상 리뷰)
<img width="918" height="503" alt="image" src="https://github.com/user-attachments/assets/c69f4cab-78be-43f6-a816-e6c4171a203a" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

