### PR TITLE
[Feat] #91 어드민용 리뷰 작성 api 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
+++ b/src/main/java/com/lokoko/domain/image/entity/ReviewImage.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -38,6 +39,10 @@ public class ReviewImage extends BaseEntity {
     @JoinColumn(name = "review_id")
     private Review review; // 이미지가 어떤 리뷰에 대한 것인지 (외래키)
 
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isMain = false;
+
     public static ReviewImage createReviewImage(MediaFile mediaFile, int displayOrder, Review review) {
         return ReviewImage.builder()
                 .mediaFile(mediaFile)
@@ -45,8 +50,4 @@ public class ReviewImage extends BaseEntity {
                 .review(review)
                 .build();
     }
-
-    private boolean isMain;
-
-
 }

--- a/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.lokoko.domain.review.controller;
 
 import com.lokoko.domain.review.controller.enums.ResponseMessage;
+import com.lokoko.domain.review.dto.request.ReviewAdminRequest;
 import com.lokoko.domain.review.dto.request.ReviewMediaRequest;
 import com.lokoko.domain.review.dto.request.ReviewReceiptRequest;
 import com.lokoko.domain.review.dto.request.ReviewRequest;
@@ -11,8 +12,8 @@ import com.lokoko.domain.review.dto.response.ReviewMediaResponse;
 import com.lokoko.domain.review.dto.response.ReviewReceiptResponse;
 import com.lokoko.domain.review.dto.response.ReviewResponse;
 import com.lokoko.domain.review.dto.response.VideoReviewDetailResponse;
-import com.lokoko.domain.review.service.ReviewDetailsService;
 import com.lokoko.domain.review.dto.response.VideoReviewProductDetailResponse;
+import com.lokoko.domain.review.service.ReviewDetailsService;
 import com.lokoko.domain.review.service.ReviewService;
 import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.common.response.ApiResponse;
@@ -120,5 +121,17 @@ public class ReviewController {
         VideoReviewDetailResponse response = reviewDetailsService.getVideoReviewDetails(reviewId, userId);
 
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.VIDEO_REVIEW_DETAIL_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "어드민용 리뷰 작성 (기획 전용)")
+    @PostMapping("/{productId}/{userId}")
+    public ApiResponse<Void> createAdminReview(
+            @PathVariable Long productId,
+            @PathVariable Long userId,
+            @RequestBody @Valid ReviewAdminRequest request
+    ) {
+        reviewService.createAdminReview(productId, userId, request);
+
+        return ApiResponse.success(HttpStatus.CREATED, ResponseMessage.REVIEW_UPLOAD_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/lokoko/domain/review/dto/request/ReviewAdminRequest.java
+++ b/src/main/java/com/lokoko/domain/review/dto/request/ReviewAdminRequest.java
@@ -1,0 +1,18 @@
+package com.lokoko.domain.review.dto.request;
+
+import com.lokoko.global.common.entity.MediaType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record ReviewAdminRequest(
+        @NotNull Long productOptionId,
+        @NotNull Integer rating,
+        @NotNull @Size(min = 15, max = 1500) String positiveComment,
+        @NotNull @Size(min = 15, max = 1500) String negativeComment,
+        @NotNull MediaType mediaType,
+        String videoUrl,           // mediaType == VIDEO 일 때 사용
+        List<@Size(min = 1) String> imageUrl, // mediaType == IMAGE 일 때 사용
+        String receiptUrl
+) {
+}

--- a/src/main/java/com/lokoko/domain/review/dto/request/ReviewAdminRequest.java
+++ b/src/main/java/com/lokoko/domain/review/dto/request/ReviewAdminRequest.java
@@ -12,7 +12,7 @@ public record ReviewAdminRequest(
         @NotNull @Size(min = 15, max = 1500) String negativeComment,
         @NotNull MediaType mediaType,
         String videoUrl,           // mediaType == VIDEO 일 때 사용
-        List<@Size(min = 1) String> imageUrl, // mediaType == IMAGE 일 때 사용
+        @Size(min = 1) List<String> imageUrl, // mediaType == IMAGE 일 때 사용
         String receiptUrl
 ) {
 }

--- a/src/main/java/com/lokoko/domain/review/entity/Review.java
+++ b/src/main/java/com/lokoko/domain/review/entity/Review.java
@@ -36,9 +36,6 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User author; // 리뷰 작성자 foreign key 매핑
 
-    @Column(nullable = false, length = 100)
-    private String productInfo;
-
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
@@ -67,5 +64,9 @@ public class Review extends BaseEntity {
     // 부정 리뷰 내용 수정
     public void changeNegativeContent(String content) {
         this.negativeContent = content;
+    }
+
+    public void markReceiptUploaded() {
+        this.receiptUploaded = true;
     }
 }

--- a/src/main/java/com/lokoko/domain/review/service/ReviewService.java
+++ b/src/main/java/com/lokoko/domain/review/service/ReviewService.java
@@ -332,8 +332,8 @@ public class ReviewService {
 
                 reviewImageRepository.save(ri);
                 order++;
-                review.markReceiptUploaded();
             }
+            review.markReceiptUploaded();
         }
     }
 }

--- a/src/main/java/com/lokoko/global/common/entity/MediaFile.java
+++ b/src/main/java/com/lokoko/global/common/entity/MediaFile.java
@@ -3,6 +3,7 @@ package com.lokoko.global.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @EqualsAndHashCode
 public class MediaFile {
 
@@ -20,13 +22,7 @@ public class MediaFile {
     @Column(length = 1000)
     private String fileUrl;
 
-    public MediaFile(String fileName, String fileUrl) {
-        this.fileName = fileName;
-        this.fileUrl = fileUrl;
-    }
-
     public static MediaFile of(String fileName, String fileUrl) {
         return new MediaFile(fileName, fileUrl);
     }
-
 }

--- a/src/main/java/com/lokoko/global/common/entity/MediaFile.java
+++ b/src/main/java/com/lokoko/global/common/entity/MediaFile.java
@@ -3,12 +3,14 @@ package com.lokoko.global.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode
 public class MediaFile {

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -9,7 +9,8 @@ public class PermitUrlConfig {
         return new String[]{
                 "/swagger-ui/**",
                 "/v3/api-docs/**",
-                "/api/auth/**"
+                "/api/auth/**",
+                "/api/reviews/{productId}/{userId}"
         };
     }
 


### PR DESCRIPTION
## Related issue 🛠

- closed #90 

## 작업 내용 💻

- [x] 기획분들이 리뷰 데이터 구축시 필요한, 어드민용 리뷰 작성 API를 구현 

## 스크린샷 📷

<img width="2152" height="1156" alt="image" src="https://github.com/user-attachments/assets/f5445e6c-790a-40fd-9f54-762c76dabf5a" />

<img width="977" height="188" alt="image" src="https://github.com/user-attachments/assets/4929f06c-5ac2-4872-ac17-15014148132d" />

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 추후 삭제 예정인 API입니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 특정 상품 및 사용자에 대해 리뷰를 생성할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 관리자 리뷰 생성을 위한 요청 데이터 구조가 추가되었습니다.

* **버그 수정**
  * 리뷰 이미지에서 대표 이미지 여부를 표시하는 기능이 추가되었습니다.

* **기타 변경사항**
  * 일부 엔티티 및 서비스 로직이 개선되어, 미디어 타입 및 영수증 이미지 처리 방식이 강화되었습니다.
  * 특정 리뷰 관련 필드가 제거되고, 리뷰 영수증 업로드 상태를 표시하는 기능이 추가되었습니다.
  * 일부 엔티티에 빌더 패턴 및 생성자 자동 생성 기능이 적용되었습니다.
  * 신규 리뷰 생성 API가 공개 접근 URL 목록에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->