### PR TITLE
[FEAT] #92 사진 리뷰 상세조회 API 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/image/repository/ReviewImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ReviewImageRepository.java
@@ -2,10 +2,13 @@ package com.lokoko.domain.image.repository;
 
 import com.lokoko.domain.image.entity.ReviewImage;
 import com.lokoko.domain.review.entity.Review;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long>, ReviewImageRepositoryCustom {
     void deleteAllByReview(Review review);
+
+    List<ReviewImage> findByReviewId(Long reviewId);
 }

--- a/src/main/java/com/lokoko/domain/product/dto/ProductMainImageResponse.java
+++ b/src/main/java/com/lokoko/domain/product/dto/ProductMainImageResponse.java
@@ -1,0 +1,48 @@
+package com.lokoko.domain.product.dto;
+
+import com.lokoko.domain.product.dto.response.ProductSummary;
+import com.lokoko.domain.product.entity.Product;
+import java.util.Arrays;
+import java.util.Optional;
+
+public record ProductMainImageResponse(
+        Long productId,                // 제품 ID
+        Optional<String> url,         // 대표 이미지 (1개만, Optional)
+        String productName,           // 제품명
+        String brandName,             // 브랜드명
+        String unit,                  // 용량/단위
+        Long reviewCount,             // 리뷰 수
+        Double rating,                // 평균 별점
+        Boolean isLiked               // 사용자 좋아요 여부
+) {
+    public static ProductMainImageResponse of(
+            Product product,
+            ProductSummary summary,
+            boolean isLiked
+    ) {
+        Optional<String> url = Optional.ofNullable(summary.imageUrl())
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(u -> u.contains(",")
+                        ? Arrays.stream(u.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .findFirst()
+                        .orElse(null)
+                        : u
+                )
+                .map(Optional::ofNullable)
+                .orElse(Optional.empty());
+
+        return new ProductMainImageResponse(
+                product.getId(),
+                url,
+                product.getProductName(),
+                product.getBrandName(),
+                product.getUnit(),
+                summary.reviewCount(),
+                summary.avgRating(),
+                isLiked
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/product/dto/response/CategoryProductPageResponse.java
+++ b/src/main/java/com/lokoko/domain/product/dto/response/CategoryProductPageResponse.java
@@ -1,5 +1,6 @@
 package com.lokoko.domain.product.dto.response;
 
+import com.lokoko.domain.product.dto.ProductMainImageResponse;
 import com.lokoko.global.common.response.PageableResponse;
 import java.util.List;
 import lombok.Builder;
@@ -8,7 +9,7 @@ import lombok.Builder;
 public record CategoryProductPageResponse(
         String searchQuery,
         String parentCategoryName,
-        List<ProductResponse> products,
+        List<ProductMainImageResponse> products,
         PageableResponse pageInfo
 ) {
 }

--- a/src/main/java/com/lokoko/domain/product/dto/response/NameBrandProductResponse.java
+++ b/src/main/java/com/lokoko/domain/product/dto/response/NameBrandProductResponse.java
@@ -1,11 +1,12 @@
 package com.lokoko.domain.product.dto.response;
 
+import com.lokoko.domain.product.dto.ProductMainImageResponse;
 import com.lokoko.global.common.response.PageableResponse;
 import java.util.List;
 
 public record NameBrandProductResponse(
         String searchQuery,
-        List<ProductResponse> products,
+        List<ProductMainImageResponse> products,
         PageableResponse pageInfo
 ) {
 }

--- a/src/main/java/com/lokoko/domain/product/service/ProductReadService.java
+++ b/src/main/java/com/lokoko/domain/product/service/ProductReadService.java
@@ -4,6 +4,7 @@ package com.lokoko.domain.product.service;
 import com.lokoko.domain.image.entity.ProductImage;
 import com.lokoko.domain.image.repository.ProductImageRepository;
 import com.lokoko.domain.like.service.ProductLikeService;
+import com.lokoko.domain.product.dto.ProductMainImageResponse;
 import com.lokoko.domain.product.dto.response.CategoryNewProductResponse;
 import com.lokoko.domain.product.dto.response.CategoryPopularProductResponse;
 import com.lokoko.domain.product.dto.response.CategoryProductPageResponse;
@@ -57,8 +58,8 @@ public class ProductReadService {
                 ? productRepository.findProductsByPopularityAndRating(middleCategory, pageable)
                 : productRepository.findProductsByPopularityAndRating(middleCategory, subCategory, pageable);
 
-        Slice<ProductResponse> responseSlice =
-                productService.buildProductResponseSliceWithReviewData(slice, userId);
+        Slice<ProductMainImageResponse> responseSlice =
+                productService.buildMainImageResponseSliceWithReviewData(slice, userId);
 
         return CategoryProductPageResponse.builder()
                 .searchQuery(subCategory == null

--- a/src/main/java/com/lokoko/domain/product/service/ProductService.java
+++ b/src/main/java/com/lokoko/domain/product/service/ProductService.java
@@ -4,10 +4,12 @@ import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 import com.lokoko.domain.image.entity.ProductImage;
 import com.lokoko.domain.image.repository.ProductImageRepository;
 import com.lokoko.domain.like.repository.ProductLikeRepository;
+import com.lokoko.domain.product.dto.ProductMainImageResponse;
 import com.lokoko.domain.product.dto.response.NameBrandProductResponse;
 import com.lokoko.domain.product.dto.response.ProductResponse;
 import com.lokoko.domain.product.dto.response.ProductSummary;
@@ -47,7 +49,7 @@ public class ProductService {
         List<String> tokens = kuromojiService.tokenize(keyword);
         Pageable pageable = PageRequest.of(page, size);
         Slice<Product> slice = productRepository.searchByTokens(tokens, pageable);
-        Slice<ProductResponse> responseSlice = buildProductResponseSliceWithReviewData(slice, userId);
+        Slice<ProductMainImageResponse> responseSlice = buildMainImageResponseSliceWithReviewData(slice, userId);
 
         return new NameBrandProductResponse(
                 keyword,
@@ -56,73 +58,110 @@ public class ProductService {
         );
     }
 
-    public List<ProductResponse> buildProductResponseWithReviewData(
+    public Slice<ProductMainImageResponse> buildMainImageResponseSliceWithReviewData(
+            Slice<Product> slice, Long userId
+    ) {
+        List<ProductMainImageResponse> content = buildMainImageResponsesWithReviewData(slice.getContent(), userId);
+        return new SliceImpl<>(content, slice.getPageable(), slice.hasNext());
+    }
+
+    public List<ProductMainImageResponse> buildMainImageResponsesWithReviewData(
             List<Product> products, Long userId
     ) {
-        List<Long> productIds = products.stream()
-                .map(Product::getId)
-                .toList();
-        Map<Long, String> imageMap = createProductImageMap(
-                productImageRepository.findByProductIdIn(productIds)
-        );
+        List<Long> productIds = products.stream().map(Product::getId).toList();
+        Map<Long, String> imageMap = createProductImageMap(productImageRepository.findByProductIdIn(productIds));
 
         List<RatingCount> stats = reviewRepository.countByProductIdsAndRating(productIds);
         Map<Long, Long> reviewCountMap = new HashMap<>();
         Map<Long, Long> weightedSumMap = new HashMap<>();
+
         for (RatingCount rc : stats) {
             Long pid = rc.productId();
             int score = rc.rating().getValue();
             Long cnt = rc.count();
-
             reviewCountMap.merge(pid, cnt, Long::sum);
             weightedSumMap.merge(pid, score * cnt, Long::sum);
         }
-        Map<Long, Double> avgMap = productIds.stream()
-                .collect(Collectors.toMap(
-                        pid -> pid,
-                        pid -> {
-                            long total = reviewCountMap.getOrDefault(pid, 0L);
-                            long sum = weightedSumMap.getOrDefault(pid, 0L);
-                            double raw = total == 0 ? 0.0 : (double) sum / total;
-                            return Math.round(raw * 10) / 10.0;
-                        }
-                ));
-        Map<Long, ProductSummary> summaryMap = createProductSummaryMap(
-                products, imageMap, reviewCountMap, avgMap
-        );
 
-        return makeProductResponse(products, summaryMap, userId);
+        Map<Long, Double> avgMap = productIds.stream().collect(toMap(
+                pid -> pid,
+                pid -> {
+                    long total = reviewCountMap.getOrDefault(pid, 0L);
+                    long sum = weightedSumMap.getOrDefault(pid, 0L);
+                    double raw = total == 0 ? 0.0 : (double) sum / total;
+                    return Math.round(raw * 10) / 10.0;
+                }
+        ));
+
+        Map<Long, ProductSummary> summaryMap = createProductSummaryMap(products, imageMap, reviewCountMap, avgMap);
+        return makeMainImageResponses(products, summaryMap, userId);
     }
 
-    public Slice<ProductResponse> buildProductResponseSliceWithReviewData(Slice<Product> slice, Long userId) {
-        List<ProductResponse> content = buildProductResponseWithReviewData(slice.getContent(), userId);
-
-        return new SliceImpl<>(content, slice.getPageable(), slice.hasNext());
-    }
-
-    public Map<Long, ProductSummary> createProductSummaryMap(List<Product> products,
-                                                             Map<Long, String> productIdToImageUrl,
-                                                             Map<Long, Long> productIdToReviewCount,
-                                                             Map<Long, Double> productIdToAvgRating) {
-        Map<Long, ProductSummary> summaryMap = new HashMap<>();
-        for (Product product : products) {
-            Long productId = product.getId();
-            String imageUrl = productIdToImageUrl.getOrDefault(productId, "");        // null 대신 빈 문자열
-            Long reviewCnt = productIdToReviewCount.getOrDefault(productId, 0L);
-            Double avg = productIdToAvgRating.getOrDefault(productId, 0.0);
-
-            summaryMap.put(productId, new ProductSummary(imageUrl, reviewCnt, avg));
-        }
-        return summaryMap;
-    }
-
-    public List<ProductResponse> makeProductResponse(List<Product> products,
-                                                     Map<Long, ProductSummary> summaryMap, Long userId) {
+    public List<ProductMainImageResponse> makeMainImageResponses(
+            List<Product> products, Map<Long, ProductSummary> summaryMap, Long userId
+    ) {
         Set<Long> likedIds = productLikeRepository.findAllByUserId(userId).stream()
                 .map(pl -> pl.getProduct().getId())
                 .collect(Collectors.toSet());
 
-        // 2) ProductResponse.of(...) 으로 매핑
+        return products.stream()
+                .map(product -> {
+                    ProductSummary summary = summaryMap.getOrDefault(
+                            product.getId(),
+                            new ProductSummary("", 0L, 0.0)
+                    );
+                    boolean isLiked = likedIds.contains(product.getId());
+                    return ProductMainImageResponse.of(product, summary, isLiked);
+                })
+                .toList();
+    }
+
+    public List<ProductResponse> buildProductResponseWithReviewData(
+            List<Product> products, Long userId
+    ) {
+        List<Long> productIds = products.stream().map(Product::getId).toList();
+        Map<Long, String> imageMap = createProductImageMap(productImageRepository.findByProductIdIn(productIds));
+
+        List<RatingCount> stats = reviewRepository.countByProductIdsAndRating(productIds);
+        Map<Long, Long> reviewCountMap = new HashMap<>();
+        Map<Long, Long> weightedSumMap = new HashMap<>();
+
+        for (RatingCount rc : stats) {
+            Long pid = rc.productId();
+            int score = rc.rating().getValue();
+            Long cnt = rc.count();
+            reviewCountMap.merge(pid, cnt, Long::sum);
+            weightedSumMap.merge(pid, score * cnt, Long::sum);
+        }
+
+        Map<Long, Double> avgMap = productIds.stream().collect(toMap(
+                pid -> pid,
+                pid -> {
+                    long total = reviewCountMap.getOrDefault(pid, 0L);
+                    long sum = weightedSumMap.getOrDefault(pid, 0L);
+                    double raw = total == 0 ? 0.0 : (double) sum / total;
+                    return Math.round(raw * 10) / 10.0;
+                }
+        ));
+
+        Map<Long, ProductSummary> summaryMap = createProductSummaryMap(products, imageMap, reviewCountMap, avgMap);
+        return makeProductResponse(products, summaryMap, userId);
+    }
+
+    public Slice<ProductResponse> buildProductResponseSliceWithReviewData(
+            Slice<Product> slice, Long userId
+    ) {
+        List<ProductResponse> content = buildProductResponseWithReviewData(slice.getContent(), userId);
+        return new SliceImpl<>(content, slice.getPageable(), slice.hasNext());
+    }
+
+    public List<ProductResponse> makeProductResponse(
+            List<Product> products, Map<Long, ProductSummary> summaryMap, Long userId
+    ) {
+        Set<Long> likedIds = productLikeRepository.findAllByUserId(userId).stream()
+                .map(pl -> pl.getProduct().getId())
+                .collect(Collectors.toSet());
+
         return products.stream()
                 .map(product -> {
                     ProductSummary summary = summaryMap.getOrDefault(
@@ -135,25 +174,40 @@ public class ProductService {
                 .toList();
     }
 
+    public Map<Long, ProductSummary> createProductSummaryMap(
+            List<Product> products,
+            Map<Long, String> productIdToImageUrl,
+            Map<Long, Long> productIdToReviewCount,
+            Map<Long, Double> productIdToAvgRating
+    ) {
+        Map<Long, ProductSummary> summaryMap = new HashMap<>();
+        for (Product product : products) {
+            Long productId = product.getId();
+            String imageUrl = productIdToImageUrl.getOrDefault(productId, "");
+            Long reviewCnt = productIdToReviewCount.getOrDefault(productId, 0L);
+            Double avg = productIdToAvgRating.getOrDefault(productId, 0.0);
+            summaryMap.put(productId, new ProductSummary(imageUrl, reviewCnt, avg));
+        }
+        return summaryMap;
+    }
+
     public Map<Long, String> createProductImageMap(List<ProductImage> images) {
-        return images.stream()
-                .collect(groupingBy(
-                        img -> img.getProduct().getId(),
-                        collectingAndThen(toList(), list ->
-                                list.stream()
-                                        .filter(ProductImage::isMain)
-                                        .findFirst()
-                                        .orElse(list.get(0))
-                                        .getUrl()
-                        )
-                ));
+        return images.stream().collect(groupingBy(
+                img -> img.getProduct().getId(),
+                collectingAndThen(toList(), list ->
+                        list.stream()
+                                .filter(ProductImage::isMain)
+                                .findFirst()
+                                .orElse(list.get(0))
+                                .getUrl()
+                )
+        ));
     }
 
     public Map<Long, List<String>> createProductImageUrlsMap(List<ProductImage> images) {
-        return images.stream()
-                .collect(groupingBy(
-                        img -> img.getProduct().getId(),
-                        mapping(ProductImage::getUrl, toList())
-                ));
+        return images.stream().collect(groupingBy(
+                img -> img.getProduct().getId(),
+                mapping(ProductImage::getUrl, toList())
+        ));
     }
 }

--- a/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.lokoko.domain.review.dto.request.ReviewAdminRequest;
 import com.lokoko.domain.review.dto.request.ReviewMediaRequest;
 import com.lokoko.domain.review.dto.request.ReviewReceiptRequest;
 import com.lokoko.domain.review.dto.request.ReviewRequest;
+import com.lokoko.domain.review.dto.response.ImageReviewDetailResponse;
 import com.lokoko.domain.review.dto.response.ImageReviewsProductDetailResponse;
 import com.lokoko.domain.review.dto.response.MainImageReviewResponse;
 import com.lokoko.domain.review.dto.response.MainVideoReviewResponse;
@@ -47,8 +48,7 @@ public class ReviewController {
             @RequestBody @Valid ReviewReceiptRequest request) {
         ReviewReceiptResponse response = reviewService.createReceiptPresignedUrl(userId, request);
 
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_RECEIPT_PRESIGNED_URL_SUCCESS.getMessage(),
-                response);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_RECEIPT_PRESIGNED_URL_SUCCESS.getMessage(), response);
     }
 
 
@@ -59,8 +59,7 @@ public class ReviewController {
             @RequestBody @Valid ReviewMediaRequest request) {
         ReviewMediaResponse response = reviewService.createMediaPresignedUrl(userId, request);
 
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_MEDIA_PRESIGNED_URL_SUCCESS.getMessage(),
-                response);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_MEDIA_PRESIGNED_URL_SUCCESS.getMessage(), response);
     }
 
     @Operation(summary = "리뷰 작성")
@@ -94,9 +93,10 @@ public class ReviewController {
 
     @Operation(summary = "제품 상세 페이지에서 유저 리뷰 조회")
     @GetMapping("/details/image")
-    public ApiResponse<ImageReviewsProductDetailResponse> getImageReviewsInProductDetail(@RequestParam Long productId,
-                                                                                         @RequestParam(defaultValue = "0") int page,
-                                                                                         @RequestParam(defaultValue = "5") int size
+    public ApiResponse<ImageReviewsProductDetailResponse> getImageReviewsInProductDetail(
+            @RequestParam Long productId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
     ) {
         ImageReviewsProductDetailResponse response = reviewService.getImageReviewsInProductDetail(productId, page,
                 size);
@@ -121,6 +121,15 @@ public class ReviewController {
         VideoReviewDetailResponse response = reviewDetailsService.getVideoReviewDetails(reviewId, userId);
 
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.VIDEO_REVIEW_DETAIL_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "사진 리뷰 상세 조회 (가장 마지막 뎁스")
+    @GetMapping("/details/{reviewId}/image")
+    public ApiResponse<ImageReviewDetailResponse> getImageReviewDetails(@PathVariable Long reviewId,
+                                                                        @Parameter(hidden = true) @CurrentUser Long userId) {
+        ImageReviewDetailResponse response = reviewDetailsService.getImageReviewDetails(reviewId, userId);
+
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.IMAGE_REVIEW_DETAIL_SUCCESS.getMessage(), response);
     }
 
     @Operation(summary = "어드민용 리뷰 작성 (기획 전용)")

--- a/src/main/java/com/lokoko/domain/review/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/review/controller/enums/ResponseMessage.java
@@ -13,7 +13,8 @@ public enum ResponseMessage {
     REVIEW_UPLOAD_SUCCESS("리뷰가 성공적으로 작성되었습니다."),
     MAIN_REVIEW_IMAGE_SUCCESS("메인페이지 상세 리뷰 이미지 조회에 성공했습니다."),
     MAIN_REVIEW_VIDEO_SUCCESS("메인페이지 상세 리뷰 비디오 조회에 성공했습니다."),
-    VIDEO_REVIEW_DETAIL_SUCCESS("영상 리뷰 상세 조회에 성공했습니다.");
+    VIDEO_REVIEW_DETAIL_SUCCESS("영상 리뷰 상세 조회에 성공했습니다."),
+    IMAGE_REVIEW_DETAIL_SUCCESS("사진 리뷰 상세 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
@@ -1,0 +1,49 @@
+package com.lokoko.domain.review.dto.response;
+
+import com.lokoko.domain.image.entity.ReviewImage;
+import com.lokoko.domain.product.entity.Product;
+import com.lokoko.domain.review.entity.Review;
+import com.lokoko.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ImageReviewDetailResponse(
+        Long reviewId,
+        LocalDateTime writtenTime,
+        Boolean receiptUploaded,
+        String positiveComment,
+        String negativeComment,
+        String authorName,
+        String profileImageUrl,
+        String rating,
+        String option,
+        long likeCount,
+        List<String> images,
+        String brandName,
+        String productName
+) {
+    public static ImageReviewDetailResponse from(User author, Review review, List<ReviewImage> reviewImages,
+                                                 long totalLikes) {
+        Product product = review.getProduct();
+
+        List<String> images = reviewImages.stream()
+                .map(reviewImage -> reviewImage.getMediaFile().getFileUrl())
+                .toList();
+
+        return new ImageReviewDetailResponse(
+                review.getId(),
+                review.getModifiedAt(),
+                review.isReceiptUploaded(),
+                review.getPositiveContent(),
+                review.getNegativeContent(),
+                author.getNickname(),
+                author.getProfileImageUrl(),
+                review.getRating().name(),
+                review.getProductOption().getOptionName(),
+                totalLikes,
+                images,
+                product.getBrandName(),
+                product.getProductName()
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/review/service/ReviewDetailsService.java
+++ b/src/main/java/com/lokoko/domain/review/service/ReviewDetailsService.java
@@ -1,14 +1,20 @@
 package com.lokoko.domain.review.service;
 
+import com.lokoko.domain.image.entity.ReviewImage;
+import com.lokoko.domain.image.repository.ReviewImageRepository;
 import com.lokoko.domain.like.repository.ReviewLikeRepository;
+import com.lokoko.domain.review.dto.response.ImageReviewDetailResponse;
 import com.lokoko.domain.review.dto.response.VideoReviewDetailResponse;
+import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.review.exception.ReviewNotFoundException;
 import com.lokoko.domain.review.exception.ReviewVideoNotFoundException;
 import com.lokoko.domain.review.repository.ReviewRepository;
+import com.lokoko.domain.user.entity.User;
 import com.lokoko.domain.user.exception.UserNotFoundException;
 import com.lokoko.domain.user.repository.UserRepository;
 import com.lokoko.domain.video.entity.ReviewVideo;
 import com.lokoko.domain.video.repository.ReviewVideoRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +27,8 @@ public class ReviewDetailsService {
     private final ReviewRepository reviewRepository;
     private final ReviewVideoRepository reviewVideoRepository;
     private final ReviewLikeRepository reviewLikeRepository;
+    private final ReviewImageRepository reviewImageRepository;
+
 
     public VideoReviewDetailResponse getVideoReviewDetails(Long reviewId,
                                                            Long userId) {
@@ -36,5 +44,23 @@ public class ReviewDetailsService {
         long totalLikes = reviewLikeRepository.countByReviewId(reviewId);
 
         return VideoReviewDetailResponse.from(video, totalLikes);
+    }
+
+
+    public ImageReviewDetailResponse getImageReviewDetails(Long reviewId, Long userId) {
+
+        User author = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(ReviewNotFoundException::new);
+
+        List<ReviewImage> reviewImages = reviewImageRepository.findByReviewId(reviewId);
+
+        long totalLikes = reviewLikeRepository.countByReviewId(reviewId);
+
+        return ImageReviewDetailResponse.from(author, review, reviewImages, totalLikes);
+
+
     }
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #87 

## 작업 내용 💻

- [ 사진 리뷰 상세조회 API 구현 완료하였습니다.] 
- [ 상품 검색 결과에 imageUrls 배열을 전달해주던 방식에서 String url 을 전달해주는 방식으로 수정하였습니다. ] 

## 스크린샷 📷

1. 사진 리뷰 상세 조회 성공 이미지

<img width="791" height="442" alt="image" src="https://github.com/user-attachments/assets/5b125789-6b85-4e7e-9230-69c4f518423c" />


2. imageUrls -> url

<img width="1013" height="496" alt="image" src="https://github.com/user-attachments/assets/c427e6e1-4790-42c0-a225-9796578c17b2" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

