### PR TITLE
[FEAT] #98 사진 및 영상 리뷰 상세조회에서 영수증 조회 기능 추가(어드민)

### DIFF
--- a/src/main/java/com/lokoko/domain/image/repository/ReceiptImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ReceiptImageRepository.java
@@ -2,10 +2,13 @@ package com.lokoko.domain.image.repository;
 
 import com.lokoko.domain.image.entity.ReceiptImage;
 import com.lokoko.domain.review.entity.Review;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReceiptImageRepository extends JpaRepository<ReceiptImage, Long> {
     void deleteAllByReview(Review review);
+
+    Optional<ReceiptImage> findByReviewId(Long reviewId);
 }

--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
@@ -1,9 +1,11 @@
 package com.lokoko.domain.review.dto.response;
 
+import com.lokoko.domain.image.entity.ReceiptImage;
 import com.lokoko.domain.image.entity.ReviewImage;
 import com.lokoko.domain.product.entity.Product;
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.user.entity.User;
+import com.lokoko.domain.user.entity.enums.Role;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -20,11 +22,13 @@ public record ImageReviewDetailResponse(
         long likeCount,
         List<String> images,
         String brandName,
-        String productName
+        String productName,
+        String receiptImageUrl
 ) {
-    public static ImageReviewDetailResponse from(User author, Review review, List<ReviewImage> reviewImages,
-                                                 long totalLikes) {
+    public static ImageReviewDetailResponse from(Review review, List<ReviewImage> reviewImages,
+                                                 long totalLikes, ReceiptImage receiptImage, Role requestUserRole) {
         Product product = review.getProduct();
+        User author = review.getAuthor();
 
         List<String> images = reviewImages.stream()
                 .map(reviewImage -> reviewImage.getMediaFile().getFileUrl())
@@ -43,7 +47,9 @@ public record ImageReviewDetailResponse(
                 totalLikes,
                 images,
                 product.getBrandName(),
-                product.getProductName()
+                product.getProductName(),
+                requestUserRole == Role.ADMIN && receiptImage != null ?
+                        receiptImage.getMediaFile().getFileUrl() : null
         );
     }
 }

--- a/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
@@ -1,7 +1,9 @@
 package com.lokoko.domain.review.dto.response;
 
+import com.lokoko.domain.image.entity.ReceiptImage;
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.user.entity.User;
+import com.lokoko.domain.user.entity.enums.Role;
 import com.lokoko.domain.video.entity.ReviewVideo;
 import java.time.LocalDateTime;
 
@@ -16,9 +18,11 @@ public record VideoReviewDetailResponse(
         String profileImageUrl,
         String authorName,
         String rating,
-        LocalDateTime uploadAt
+        LocalDateTime uploadAt,
+        String receiptImageUrl
 ) {
-    public static VideoReviewDetailResponse from(ReviewVideo reviewVideo, long likeCount) {
+    public static VideoReviewDetailResponse from(ReviewVideo reviewVideo, long likeCount,
+                                                 ReceiptImage receiptImage, Role requestUserRole) {
         Review review = reviewVideo.getReview();
         User author = review.getAuthor();
         LocalDateTime uploadAt = reviewVideo.getCreatedAt();
@@ -34,7 +38,10 @@ public record VideoReviewDetailResponse(
                 author.getProfileImageUrl(),
                 author.getNickname(),
                 review.getRating().name(),
-                uploadAt
+                uploadAt,
+                requestUserRole == Role.ADMIN && receiptImage != null ?
+                        receiptImage.getMediaFile().getFileUrl() : null
+
         );
     }
 }

--- a/src/main/java/com/lokoko/domain/review/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/domain/review/exception/ErrorMessage.java
@@ -16,7 +16,8 @@ public enum ErrorMessage {
     TOO_MANY_IMAGE_FILES("image는 최대 5개까지만 업로드할 수 있습니다."),
     INVALID_PRESIGNED_URL("Presigned URL 파싱에 실패했습니다."),
     REVIEW_NOT_FOUND("존재하지 않는 리뷰입니다."),
-    REVIEW_VIDEO_NOT_FOUND("존재하지 않는 리뷰 영상입니다.");
+    REVIEW_VIDEO_NOT_FOUND("존재하지 않는 리뷰 영상입니다."),
+    RECEIPT_IMAGE_NOT_FOUND("존재하지 않는 영수증 입니다");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/review/exception/ReceiptNotFoundException.java
+++ b/src/main/java/com/lokoko/domain/review/exception/ReceiptNotFoundException.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.review.exception;
+
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class ReceiptNotFoundException extends BaseException {
+    public ReceiptNotFoundException() {
+        super(HttpStatus.NOT_FOUND, ErrorMessage.RECEIPT_IMAGE_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #97 

## 작업 내용 💻

어드민이 리뷰를 조회할 때와, 일반 유저가 리뷰를 조회하는 경우에는 차이가 존재합니다.
어드민이 리뷰를 조회할 때는, 유저가 올린 영수증까지 조회할 수 있어야 합니다.
일반 유저가 리뷰를 조회할때는, 영수증을 조회할 수 없습니다.

해당 요구사항을 반영하기 위해서, 기존 상세조회 로직에 유저 권한 검증을 추가적으로 진행하였습니다.


## 스크린샷 📷

1. 일반 유저 - 영상 리뷰 상세 조회
<img width="1052" height="376" alt="image" src="https://github.com/user-attachments/assets/50bb7501-5ea2-4c1d-b047-5457f73c4184" />


2. 일반 유저 - 사진 리뷰 상세 조회
<img width="975" height="476" alt="image" src="https://github.com/user-attachments/assets/bf87927d-cab1-49b7-b91d-c0e1079cd9ba" />


3. 어드민 - 영상 리뷰 상세 조회
<img width="887" height="351" alt="image" src="https://github.com/user-attachments/assets/dd8bc01d-3283-4690-86e9-90b3439bcc0e" />

reciptImageUrl 이 포함되어 있습니다.


4.  어드민 - 사진 리뷰 상세 조회
<img width="1057" height="463" alt="image" src="https://github.com/user-attachments/assets/66b085ed-59a6-42d2-a5e1-c277dce33af0" />

reciptImageUrl 이 포함되어 있습니다.


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 권한 사용자는 리뷰 상세 정보에서 영수증 이미지 URL을 확인할 수 있습니다.
  * 영수증 이미지가 존재하지 않을 경우, 관련 오류 메시지가 추가되었습니다.

* **버그 수정**
  * 리뷰 상세 조회 시 역할에 따라 영수증 이미지 노출 여부가 달라집니다.

* **기타**
  * 관리자 전용 영수증 이미지 조회 예외가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->