### PR TITLE
[REFACTOR] #102 비로그인 접근 권한 고도화

### DIFF
--- a/src/main/java/com/lokoko/domain/product/service/ProductService.java
+++ b/src/main/java/com/lokoko/domain/product/service/ProductService.java
@@ -9,8 +9,8 @@ import static java.util.stream.Collectors.toMap;
 import com.lokoko.domain.image.entity.ProductImage;
 import com.lokoko.domain.image.repository.ProductImageRepository;
 import com.lokoko.domain.like.repository.ProductLikeRepository;
-import com.lokoko.domain.product.dto.response.ProductMainImageResponse;
 import com.lokoko.domain.product.dto.response.NameBrandProductResponse;
+import com.lokoko.domain.product.dto.response.ProductMainImageResponse;
 import com.lokoko.domain.product.dto.response.ProductResponse;
 import com.lokoko.domain.product.dto.response.ProductSummary;
 import com.lokoko.domain.product.entity.Product;
@@ -19,6 +19,7 @@ import com.lokoko.domain.review.dto.request.RatingCount;
 import com.lokoko.domain.review.repository.ReviewRepository;
 import com.lokoko.global.common.response.PageableResponse;
 import com.lokoko.global.kuromoji.service.KuromojiService;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,15 +95,18 @@ public class ProductService {
         ));
 
         Map<Long, ProductSummary> summaryMap = createProductSummaryMap(products, imageMap, reviewCountMap, avgMap);
+
         return makeMainImageResponses(products, summaryMap, userId);
     }
 
     public List<ProductMainImageResponse> makeMainImageResponses(
             List<Product> products, Map<Long, ProductSummary> summaryMap, Long userId
     ) {
-        Set<Long> likedIds = productLikeRepository.findAllByUserId(userId).stream()
+        Set<Long> likedIds = (userId != null)
+                ? productLikeRepository.findAllByUserId(userId).stream()
                 .map(pl -> pl.getProduct().getId())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toSet())
+                : Collections.emptySet();
 
         return products.stream()
                 .map(product -> {

--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
@@ -1,17 +1,14 @@
 package com.lokoko.domain.review.dto.response;
 
-import com.lokoko.domain.image.entity.ReceiptImage;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.lokoko.domain.image.entity.ReviewImage;
 import com.lokoko.domain.product.entity.Product;
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.user.entity.User;
-import com.lokoko.domain.user.entity.enums.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 public record ImageReviewDetailResponse(
         @Schema(requiredMode = REQUIRED)
@@ -42,7 +39,7 @@ public record ImageReviewDetailResponse(
         String receiptImageUrl
 ) {
     public static ImageReviewDetailResponse from(Review review, List<ReviewImage> reviewImages,
-                                                 long totalLikes, ReceiptImage receiptImage, Role requestUserRole) {
+                                                 long totalLikes, String receiptImage) {
         Product product = review.getProduct();
         User author = review.getAuthor();
 
@@ -64,8 +61,7 @@ public record ImageReviewDetailResponse(
                 images,
                 product.getBrandName(),
                 product.getProductName(),
-                requestUserRole == Role.ADMIN && receiptImage != null ?
-                        receiptImage.getMediaFile().getFileUrl() : null
+                receiptImage
         );
     }
 }

--- a/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
@@ -1,15 +1,12 @@
 package com.lokoko.domain.review.dto.response;
 
-import com.lokoko.domain.image.entity.ReceiptImage;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.user.entity.User;
-import com.lokoko.domain.user.entity.enums.Role;
 import com.lokoko.domain.video.entity.ReviewVideo;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.time.LocalDateTime;
-
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 public record VideoReviewDetailResponse(
         @Schema(requiredMode = REQUIRED)
@@ -36,7 +33,7 @@ public record VideoReviewDetailResponse(
         String receiptImageUrl
 ) {
     public static VideoReviewDetailResponse from(ReviewVideo reviewVideo, long likeCount,
-                                                 ReceiptImage receiptImage, Role requestUserRole) {
+                                                 String receiptImageUrl) {
         Review review = reviewVideo.getReview();
         User author = review.getAuthor();
         LocalDateTime uploadAt = reviewVideo.getCreatedAt();
@@ -53,9 +50,7 @@ public record VideoReviewDetailResponse(
                 author.getNickname(),
                 review.getRating().name(),
                 uploadAt,
-                requestUserRole == Role.ADMIN && receiptImage != null ?
-                        receiptImage.getMediaFile().getFileUrl() : null
-
+                receiptImageUrl
         );
     }
 }

--- a/src/main/java/com/lokoko/global/auth/resolver/CurrentUserResolver.java
+++ b/src/main/java/com/lokoko/global/auth/resolver/CurrentUserResolver.java
@@ -1,7 +1,6 @@
 package com.lokoko.global.auth.resolver;
 
 import com.lokoko.global.auth.annotation.CurrentUser;
-import com.lokoko.global.auth.exception.OauthException;
 import com.lokoko.global.auth.jwt.utils.JwtProvider;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
@@ -29,8 +28,9 @@ public class CurrentUserResolver implements HandlerMethodArgumentResolver {
                                   WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null || !(authentication.getPrincipal() instanceof Jwt jwt)) {
-            throw new OauthException();
+        if (authentication == null || authentication.getPrincipal() == null
+                || !(authentication.getPrincipal() instanceof Jwt jwt)) {
+            return null;
         }
 
         return Long.valueOf(jwt.getClaimAsString(JwtProvider.ID_CLAIM));

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -5,28 +5,65 @@ import org.springframework.stereotype.Component;
 @Component
 public class PermitUrlConfig {
 
+    /**
+     * 1) 전체 공개 (Public) - 토큰, @CurrentUser 필요 없음
+     */
     public String[] getPublicUrl() {
         return new String[]{
                 "/swagger-ui/**",
                 "/v3/api-docs/**",
                 "/api/auth/**",
-                "/api/reviews/{productId}/{userId}"
+                "/api/youtube/trends",
+                "/api/reviews/image",
+                "/api/reviews/video",
+                "/api/reviews/details/image",
+                "/api/reviews/details/video",
+                "/api/reviews/{productId}/{userId}",
+                "/api/products/details/{productId}/youtube"
         };
     }
 
+    /**
+     * 2) 선택 인증 (Optional Auth) - 토큰 있으면 읽어서 @CurrentUser 주입, 없어도 접근은 가능
+     */
+    public String[] getOptionalUrl() {
+        return new String[]{
+                "/api/reviews/{reviewId}/image",
+                "/api/reviews/{reviewId}/video",
+                "/api/reviews/details/{reviewId}/image",
+                "/api/reviews/details/{reviewId}/video",
+                "/api/products/categories/search",
+                "/api/products/search",
+                "/api/products/categories/new",
+                "/api/products/categories/popular",
+                "/api/products/details/{productId}",
+        };
+    }
+
+    /**
+     * 3) 인증 필요 (User) - 회원가입한 유저만 접근 가능 (둘다 필요)
+     */
     public String[] getUserUrl() {
         return new String[]{
+                "/api/likes/**",
+                "/api/reviews/{productId}",
+                "/api/reviews/media",
+                "/api/reviews/receipt"
         };
     }
 
+    /**
+     * 4) 관리자 전용 (Admin) - ROLE_ADMIN
+     */
     public String[] getAdminUrl() {
         return new String[]{
                 "/api/admin/**",
                 "/api/products/crawl",
-                "/api/youtube/{productId}/crawl",
-                "/api/youtube/trends/crawl",
                 "/api/products/crawl/new",
-                "/api/products/crawl/options"
+                "/api/products/crawl/options",
+                "/api/products/search-fields/migrate",
+                "/api/youtube/{productId}/crawl",
+                "/api/youtube/trends/crawl"
         };
     }
 

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -28,8 +28,6 @@ public class PermitUrlConfig {
      */
     public String[] getOptionalUrl() {
         return new String[]{
-                "/api/reviews/{reviewId}/image",
-                "/api/reviews/{reviewId}/video",
                 "/api/reviews/details/{reviewId}/image",
                 "/api/reviews/details/{reviewId}/video",
                 "/api/products/categories/search",

--- a/src/main/java/com/lokoko/global/config/SecurityConfig.java
+++ b/src/main/java/com/lokoko/global/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers(permitUrlConfig.getPublicUrl()).permitAll()
+                .requestMatchers(permitUrlConfig.getOptionalUrl()).permitAll()
                 .requestMatchers(permitUrlConfig.getUserUrl()).hasAnyRole(USER.name(), ADMIN.name())
                 .requestMatchers(permitUrlConfig.getAdminUrl()).hasRole(ADMIN.name())
                 .anyRequest().authenticated());


### PR DESCRIPTION
## Related issue 🛠

- closed #101 

## 작업 내용 💻

- [x] `current User` 필요시 설정 변경
- [x] `securityFilterChain`에서 `permitUrlConfig` 추가 설정

## 스크린샷 📷

<img width="890" height="605" alt="image" src="https://github.com/user-attachments/assets/eeacbc13-ed69-4fdd-b1e3-12babb8a4b98" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- x



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 인증이 선택적으로 적용되는 API 엔드포인트(옵셔널 인증 URL) 그룹이 추가되어, 토큰 없이도 일부 서비스 접근이 가능해졌습니다.
  * 여러 공용, 사용자, 관리자 전용 API 엔드포인트가 세분화되어 관리됩니다.

* **버그 수정**
  * 인증 정보가 없거나 잘못된 경우 예외 대신 null을 반환하여 익명 사용자도 서비스 일부를 이용할 수 있게 개선되었습니다.
  * 사용자 ID가 없는 경우 좋아요 정보 조회 시 오류가 발생하지 않도록 처리되었습니다.

* **리팩터링**
  * 리뷰 상세 응답 생성 시 역할 기반 조건문이 제거되고, 영수증 이미지 URL을 직접 전달받도록 간소화되었습니다.
  * 리뷰 상세 조회에서 사용자 정보가 없을 때도 정상 동작하도록 내부 로직이 개선되었습니다.

* **문서화/스타일**
  * 접근 제어 URL 그룹에 대한 주석 및 설명이 추가되어 관리가 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->