### PR TITLE
[REFACTOR] #110 리뷰 조회 로직 리팩토링

### DIFF
--- a/src/main/java/com/lokoko/domain/image/repository/ProductImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ProductImageRepository.java
@@ -1,7 +1,9 @@
 package com.lokoko.domain.image.repository;
 
 import com.lokoko.domain.image.entity.ProductImage;
+import com.lokoko.domain.product.entity.Product;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
 
     List<ProductImage> findByProductIdIn(List<Long> productIds);
+
+    Optional<ProductImage> findByProduct(Product product);
 }

--- a/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/lokoko/domain/like/repository/ReviewLikeRepository.java
@@ -1,6 +1,8 @@
 package com.lokoko.domain.like.repository;
 
 import com.lokoko.domain.like.entity.ReviewLike;
+import com.lokoko.domain.review.entity.Review;
+import com.lokoko.domain.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +12,6 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
     Optional<ReviewLike> findByReviewIdAndUserId(Long reviewId, Long userId);
 
     long countByReviewId(Long reviewId);
+
+    boolean existsByUserAndReview(User user, Review review);
 }

--- a/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/lokoko/domain/review/controller/ReviewController.java
@@ -48,7 +48,8 @@ public class ReviewController {
             @RequestBody @Valid ReviewReceiptRequest request) {
         ReviewReceiptResponse response = reviewService.createReceiptPresignedUrl(userId, request);
 
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_RECEIPT_PRESIGNED_URL_SUCCESS.getMessage(), response);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_RECEIPT_PRESIGNED_URL_SUCCESS.getMessage(),
+                response);
     }
 
 
@@ -59,7 +60,8 @@ public class ReviewController {
             @RequestBody @Valid ReviewMediaRequest request) {
         ReviewMediaResponse response = reviewService.createMediaPresignedUrl(userId, request);
 
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_MEDIA_PRESIGNED_URL_SUCCESS.getMessage(), response);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_MEDIA_PRESIGNED_URL_SUCCESS.getMessage(),
+                response);
     }
 
     @Operation(summary = "리뷰 작성")
@@ -91,15 +93,16 @@ public class ReviewController {
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.MAIN_REVIEW_VIDEO_SUCCESS.getMessage(), response);
     }
 
-    @Operation(summary = "제품 상세 페이지에서 유저 리뷰 조회")
+    @Operation(summary = "제품 상세 페이지에서 사진 리뷰 조회")
     @GetMapping("/details/image")
     public ApiResponse<ImageReviewsProductDetailResponse> getImageReviewsInProductDetail(
             @RequestParam Long productId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size
+            @RequestParam(defaultValue = "5") int size,
+            @Parameter(hidden = true) @CurrentUser Long userId
     ) {
         ImageReviewsProductDetailResponse response = reviewService.getImageReviewsInProductDetail(productId, page,
-                size);
+                size, userId);
 
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.IMAGE_REVIEW_GET_SUCCESS.getMessage(),
                 response);

--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
@@ -2,6 +2,7 @@ package com.lokoko.domain.review.dto.response;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import com.lokoko.domain.image.entity.ProductImage;
 import com.lokoko.domain.image.entity.ReviewImage;
 import com.lokoko.domain.product.entity.Product;
 import com.lokoko.domain.review.entity.Review;
@@ -36,10 +37,16 @@ public record ImageReviewDetailResponse(
         String brandName,
         @Schema(requiredMode = REQUIRED)
         String productName,
-        String receiptImageUrl
+        @Schema(requiredMode = REQUIRED)
+        String productImageUrl,
+        String receiptImageUrl,
+        @Schema(requiredMode = REQUIRED)
+        Boolean isLiked
+
 ) {
     public static ImageReviewDetailResponse from(Review review, List<ReviewImage> reviewImages,
-                                                 long totalLikes, String receiptImage) {
+                                                 long totalLikes, String receiptImage, ProductImage productImage,
+                                                 Boolean isLiked) {
         Product product = review.getProduct();
         User author = review.getAuthor();
 
@@ -61,7 +68,9 @@ public record ImageReviewDetailResponse(
                 images,
                 product.getBrandName(),
                 product.getProductName(),
-                receiptImage
+                productImage.getUrl(),
+                receiptImage,
+                isLiked
         );
     }
 }

--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewProductDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewProductDetailResponse.java
@@ -1,12 +1,11 @@
 package com.lokoko.domain.review.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 public record ImageReviewProductDetailResponse(
         @Schema(requiredMode = REQUIRED)
@@ -22,31 +21,40 @@ public record ImageReviewProductDetailResponse(
         @Schema(requiredMode = REQUIRED)
         String authorName,
         @Schema(requiredMode = REQUIRED)
+        Long authorId,
+        @Schema(requiredMode = REQUIRED)
         Double rating,
         @Schema(requiredMode = REQUIRED)
         String option,
         @Schema(requiredMode = REQUIRED)
         Integer likeCount,
         @Schema(requiredMode = REQUIRED)
-        List<String> images
+        List<String> images,
+        @Schema(requiredMode = REQUIRED)
+        Boolean isLiked,
+        @Schema(requiredMode = REQUIRED)
+        Boolean isMine
 ) {
 
     public ImageReviewProductDetailResponse(Long reviewId, LocalDateTime writtenTime,
                                             Boolean receiptUploaded, String positiveComment,
                                             String negativeComment, String authorName,
-                                            Double rating, String option,
-                                            Integer likeCount, List<String> images) {
+                                            Long authorId, Double rating, String option,
+                                            Integer likeCount, List<String> images,
+                                            Boolean isLiked, Boolean isMine
+    ) {
         this.reviewId = reviewId;
         this.writtenTime = writtenTime;
         this.receiptUploaded = receiptUploaded;
         this.positiveComment = positiveComment;
         this.negativeComment = negativeComment;
         this.authorName = authorName;
+        this.authorId = authorId;
         this.rating = rating;
         this.option = option;
         this.likeCount = likeCount;
-        this.images = new ArrayList<>(images);
+        this.images = images != null ? new ArrayList<>(images) : new ArrayList<>();
+        this.isLiked = isLiked;
+        this.isMine = isMine;
     }
-
-
 }

--- a/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
@@ -2,6 +2,7 @@ package com.lokoko.domain.review.dto.response;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import com.lokoko.domain.image.entity.ProductImage;
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.user.entity.User;
 import com.lokoko.domain.video.entity.ReviewVideo;
@@ -30,10 +31,15 @@ public record VideoReviewDetailResponse(
         String rating,
         @Schema(requiredMode = REQUIRED)
         LocalDateTime uploadAt,
-        String receiptImageUrl
+        @Schema(requiredMode = REQUIRED)
+        String productImageUrl,
+        String receiptImageUrl,
+        @Schema(requiredMode = REQUIRED)
+        Boolean isLiked
 ) {
     public static VideoReviewDetailResponse from(ReviewVideo reviewVideo, long likeCount,
-                                                 String receiptImageUrl) {
+                                                 String receiptImageUrl, ProductImage productImage,
+                                                 Boolean isLiked) {
         Review review = reviewVideo.getReview();
         User author = review.getAuthor();
         LocalDateTime uploadAt = reviewVideo.getCreatedAt();
@@ -50,7 +56,9 @@ public record VideoReviewDetailResponse(
                 author.getNickname(),
                 review.getRating().name(),
                 uploadAt,
-                receiptImageUrl
+                productImage.getUrl(),
+                receiptImageUrl,
+                isLiked
         );
     }
 }

--- a/src/main/java/com/lokoko/domain/review/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/domain/review/exception/ErrorMessage.java
@@ -17,7 +17,8 @@ public enum ErrorMessage {
     INVALID_PRESIGNED_URL("Presigned URL 파싱에 실패했습니다."),
     REVIEW_NOT_FOUND("존재하지 않는 리뷰입니다."),
     REVIEW_VIDEO_NOT_FOUND("존재하지 않는 리뷰 영상입니다."),
-    RECEIPT_IMAGE_NOT_FOUND("존재하지 않는 영수증 입니다");
+    RECEIPT_IMAGE_NOT_FOUND("존재하지 않는 영수증 입니다"),
+    PRODUCT_IMAGE_NOT_FOUND("제품 이미지가 존재하지 않습니다");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/review/exception/ProductImageNotFoundException.java
+++ b/src/main/java/com/lokoko/domain/review/exception/ProductImageNotFoundException.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.review.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class ProductImageNotFoundException extends BaseException {
+    public ProductImageNotFoundException() {
+        super(HttpStatus.NOT_FOUND, ErrorMessage.PRODUCT_IMAGE_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryCustom.java
@@ -29,7 +29,7 @@ public interface ReviewRepositoryCustom {
                                                           Pageable pageable
     );
 
-    ImageReviewsProductDetailResponse findImageReviewsByProductId(Long productId, Pageable pageable);
+    ImageReviewsProductDetailResponse findImageReviewsByProductId(Long productId, Long userId, Pageable pageable);
 
 
     Slice<VideoReviewResponse> findVideoReviewsByKeyword(List<String> tokens, Pageable pageable);

--- a/src/main/java/com/lokoko/domain/review/service/ReviewService.java
+++ b/src/main/java/com/lokoko/domain/review/service/ReviewService.java
@@ -124,10 +124,10 @@ public class ReviewService {
 
     }
 
-    public ImageReviewsProductDetailResponse getImageReviewsInProductDetail(Long productId, int page, int size) {
-
+    public ImageReviewsProductDetailResponse getImageReviewsInProductDetail(Long productId, int page,
+                                                                            int size, Long userId) {
         Pageable pageable = PageRequest.of(page, size);
-        return reviewRepository.findImageReviewsByProductId(productId, pageable);
+        return reviewRepository.findImageReviewsByProductId(productId, userId, pageable);
     }
 
     @Transactional


### PR DESCRIPTION
## Related issue 🛠

- closed #110 

## 작업 내용 💻

이번 PR 에서는, 리뷰 조회 로직을 전반적으로 리팩토링 하였습니다.

큰 수정사항은 아래와 같습니다.

## 영상 / 사진 리뷰 상세 조회에서의 수정 사항

1. 영상 / 사진 리뷰 상세 조회의 응답 DTO 에, "상품 이미지 URL"  필드를 추가하였습니다.
<img width="663" height="392" alt="image" src="https://github.com/user-attachments/assets/fdfe7072-85f1-48db-9336-85d901f80cda" />
사진에서 볼 수 있듯이, 우측 하단에 제품 이미지가 포함되어야 합니다.
이전에 제가 코드를 짤 때, 이를 누락한 것을 확인하여 바로 추가해주었습니다.



2.  영상 / 사진 리뷰 상세 조회의 응답 DTO에, "isLiked" 필드를 추가하였습니다.
서비스 이용자가 리뷰에 좋아요를 눌렀는지 여부를 확인해야 하기 때문입니다.


------

## 제품 상세 조회페이지 사진 리뷰 조회에서의 수정 사항

기존에 제품 상세 조회페이지에서 사진 리뷰를 조회하는 메소드에는 @CurrentUser 가 포함되어 있지 않았습니다.
그러나, "서비스 사용자가 좋아요 눌렀는지 여부를 확인하고" , "자신이 작성한 리뷰인지 여부를 확인하려면"
@CurrentUser 를 통해 userId 를 받아오는 것이 필수적이라고 생각했습니다.

0.  getImageReviewsInProductDetail 메소드의 매개변수에 userId 를 추가해주었습니다.

1. 추후 리뷰 작성자 상세조회를 위한 authorId 필드를 추가 (기존에는 누락되어 있었습니다) 하였습니다.

2. 현재 서비스 사용자가 좋아요 눌렀는지 여부를 확인하기 위한 isLiked 필드를 추가하였습니다.

3. 현재 서비스 사용자가 자신이 작성한 리뷰인지 여부를 확인하기 위한 isMine 필드를 추가하였습니다.
이 기능은, 유저가 자신이 작성한 리뷰를 삭제할 수 있도록 하기 위해 필요합니다.


## 스크린샷 📷

- 사진 리뷰 상세 조회 결과 
<img width="675" height="477" alt="image" src="https://github.com/user-attachments/assets/d6a3c060-f08f-4f7f-9b20-c181e389167b" />

- 영상 리뷰 상세 조회 결과
<img width="568" height="382" alt="image" src="https://github.com/user-attachments/assets/b43ec516-dc89-4f1a-963b-094e90e9b3c7" />


- 제품 상세 페이지에서 사진 리뷰 조회 결과 
<img width="1262" height="500" alt="image" src="https://github.com/user-attachments/assets/e5d104d3-1f83-459e-ab53-de0adda3a1dc" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

