### PR TITLE
[REFACTOR] #123 이미지, 영상 리뷰 업로드 세부로직 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/review/dto/request/ReviewAdminRequest.java
+++ b/src/main/java/com/lokoko/domain/review/dto/request/ReviewAdminRequest.java
@@ -10,7 +10,7 @@ public record ReviewAdminRequest(
         @NotNull Integer rating,
         @NotNull @Size(min = 15, max = 1500) String positiveComment,
         @NotNull @Size(min = 15, max = 1500) String negativeComment,
-        @NotNull MediaType mediaType,
+        MediaType mediaType,
         String videoUrl,           // mediaType == VIDEO 일 때 사용
         @Size(min = 1) List<String> imageUrl, // mediaType == IMAGE 일 때 사용
         String receiptUrl

--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
@@ -27,7 +27,6 @@ public record ImageReviewDetailResponse(
         String profileImageUrl,
         @Schema(requiredMode = REQUIRED)
         String rating,
-        @Schema(requiredMode = REQUIRED)
         String option,
         @Schema(requiredMode = REQUIRED)
         Long likeCount,


### PR DESCRIPTION
## Related issue 🛠

- closed #122 

## 작업 내용 💻

- [x] 기획분들이 사용할 이미지, 동영상 리뷰 데이터 작성 API를 수정해서, 이미지랑 동영상 둘다 없이도 리뷰를 작성할 수 있도록 로직을 수정했습니다 

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 관리 리뷰 생성 시 비디오와 이미지가 동시에 등록되지 않도록 검증 로직이 개선되었습니다.
  * 영수증 이미지 업로드 후 상태가 올바르게 반영되도록 수정되었습니다.

* **기타**
  * 일부 필드의 필수 입력 조건이 완화되어 선택적으로 입력할 수 있습니다.  
  * API 응답 문서에서 특정 필드의 필수 표시가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->