### PR TITLE
[FIX] #126  사진/리뷰 상세조회 페이지에서 별점의 return type 을 String 에서 Double 로 변경

### DIFF
--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
@@ -26,7 +26,7 @@ public record ImageReviewDetailResponse(
         String authorName,
         String profileImageUrl,
         @Schema(requiredMode = REQUIRED)
-        String rating,
+        Double rating,
         String option,
         @Schema(requiredMode = REQUIRED)
         Long likeCount,
@@ -65,7 +65,7 @@ public record ImageReviewDetailResponse(
                 review.getNegativeContent(),
                 author.getNickname(),
                 author.getProfileImageUrl(),
-                review.getRating().name(),
+                (double) review.getRating().getValue(),
                 optionName,
                 totalLikes,
                 images,

--- a/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
@@ -28,7 +28,7 @@ public record VideoReviewDetailResponse(
         @Schema(requiredMode = REQUIRED)
         String authorName,
         @Schema(requiredMode = REQUIRED)
-        String rating,
+        Double rating,
         @Schema(requiredMode = REQUIRED)
         LocalDateTime uploadAt,
         @Schema(requiredMode = REQUIRED)
@@ -54,7 +54,7 @@ public record VideoReviewDetailResponse(
                 reviewVideo.getMediaFile().getFileUrl(),
                 author.getProfileImageUrl(),
                 author.getNickname(),
-                review.getRating().name(),
+                (double) review.getRating().getValue(),
                 uploadAt,
                 productImage.getUrl(),
                 receiptImageUrl,


### PR DESCRIPTION
## Related issue 🛠

- closed #125 

## 작업 내용 💻

사진/리뷰 상세조회 페이지에서 별점의 return type 을 String 에서 Double 로 변경하였습니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 이미지 및 비디오 리뷰 상세 응답에서 평점(rating) 정보가 문자열에서 숫자(Double) 값으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->