### PR TITLE
[REFACTOR] #132 사진/영상 리뷰 상세 조회 응답에 productId 추가

### DIFF
--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewDetailResponse.java
@@ -40,7 +40,9 @@ public record ImageReviewDetailResponse(
         String productImageUrl,
         String receiptImageUrl,
         @Schema(requiredMode = REQUIRED)
-        Boolean isLiked
+        Boolean isLiked,
+        @Schema(requiredMode = REQUIRED)
+        Long productId
 
 ) {
     public static ImageReviewDetailResponse from(Review review, List<ReviewImage> reviewImages,
@@ -73,7 +75,8 @@ public record ImageReviewDetailResponse(
                 product.getProductName(),
                 productImage.getUrl(),
                 receiptImage,
-                isLiked
+                isLiked,
+                product.getId()
         );
     }
 }

--- a/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/VideoReviewDetailResponse.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.review.dto.response;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.lokoko.domain.image.entity.ProductImage;
+import com.lokoko.domain.product.entity.Product;
 import com.lokoko.domain.review.entity.Review;
 import com.lokoko.domain.user.entity.User;
 import com.lokoko.domain.video.entity.ReviewVideo;
@@ -35,19 +36,22 @@ public record VideoReviewDetailResponse(
         String productImageUrl,
         String receiptImageUrl,
         @Schema(requiredMode = REQUIRED)
-        Boolean isLiked
+        Boolean isLiked,
+        @Schema(requiredMode = REQUIRED)
+        Long productId
 ) {
     public static VideoReviewDetailResponse from(ReviewVideo reviewVideo, long likeCount,
                                                  String receiptImageUrl, ProductImage productImage,
                                                  Boolean isLiked) {
         Review review = reviewVideo.getReview();
+        Product product = review.getProduct();
         User author = review.getAuthor();
         LocalDateTime uploadAt = reviewVideo.getCreatedAt();
 
         return new VideoReviewDetailResponse(
                 review.getId(),
-                review.getProduct().getBrandName(),
-                review.getProduct().getProductName(),
+                product.getBrandName(),
+                product.getProductName(),
                 review.getPositiveContent(),
                 review.getNegativeContent(),
                 likeCount,
@@ -58,7 +62,8 @@ public record VideoReviewDetailResponse(
                 uploadAt,
                 productImage.getUrl(),
                 receiptImageUrl,
-                isLiked
+                isLiked,
+                product.getId()
         );
     }
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #131 

## 작업 내용 💻

- [ 사진 리뷰 상세 조회 결과에 productId 를 추가하였습니다.]
- [ 영상 리뷰 상세 조회 결과에 productId 를 추가하였습니다.] 

추가 이유 : 

<img width="587" height="345" alt="image" src="https://github.com/user-attachments/assets/86550206-b3f8-48f9-a99f-44d541d42288" />


위 화면에서 볼 수 있듯이, 리뷰 상세 조회결과에서 파란색 부분을 클릭 시 , 제품 상세 조회 페이지로 이동할 수 있어야 하기 때문입니다.

## 스크린샷 📷

<img width="1370" height="500" alt="image" src="https://github.com/user-attachments/assets/38f6b0a9-0a80-4031-b8e2-318db03e8a8b" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 이미지 리뷰 및 영상 리뷰 상세 응답에 상품 ID 정보가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->