### PR TITLE
[REFACTOR] #136 메인페이지 인기상품 조회 쿼리 성능 개선

### DIFF
--- a/src/main/java/com/lokoko/domain/image/repository/ProductImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/repository/ProductImageRepository.java
@@ -12,5 +12,7 @@ public interface ProductImageRepository extends JpaRepository<ProductImage, Long
 
     List<ProductImage> findByProductIdIn(List<Long> productIds);
 
+    List<ProductImage> findByProductIdInAndIsRepresentativeTrue(List<Long> productIds);
+
     Optional<ProductImage> findByProduct(Product product);
 }

--- a/src/main/java/com/lokoko/domain/product/service/ProductService.java
+++ b/src/main/java/com/lokoko/domain/product/service/ProductService.java
@@ -124,7 +124,8 @@ public class ProductService {
             List<Product> products, Long userId
     ) {
         List<Long> productIds = products.stream().map(Product::getId).toList();
-        Map<Long, String> imageMap = createProductImageMap(productImageRepository.findByProductIdIn(productIds));
+        Map<Long, String> imageMap = createProductImageMap(
+                productImageRepository.findByProductIdInAndIsRepresentativeTrue(productIds));
 
         List<RatingCount> stats = reviewRepository.countByProductIdsAndRating(productIds);
         Map<Long, Long> reviewCountMap = new HashMap<>();

--- a/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/review/repository/ReviewRepositoryImpl.java
@@ -274,14 +274,13 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     public List<RatingCount> countByProductIdsAndRating(List<Long> productIds) {
         List<Tuple> tuples = queryFactory
                 .select(
-                        product.id,
+                        review.product.id,
                         review.rating,
                         review.id.count()
                 )
                 .from(review)
-                .join(review.product, product)
-                .where(product.id.in(productIds))
-                .groupBy(product.id, review.rating)
+                .where(review.product.id.in(productIds))
+                .groupBy(review.product.id, review.rating)
                 .fetch();
 
         return tuples.stream()


### PR DESCRIPTION
## Related issue 🛠

- closed #135 

## 작업 내용 💻

- [x] 리뷰 조회시 불필요한 조인을 삭제하고, 바로 리뷰 엔티티에서 아이디로 조회해오도록 쿼리 `dsl` 쿼리문 개선
- [x] 단일 이미지만 필요한 경우 메서드 분리해서 조회해오도록 수정

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

