### PR TITLE
[FIX] #138 : 어드민 리뷰 삭제 API 에서 userId 를 hidden 으로 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/user/admin/controller/AdminController.java
+++ b/src/main/java/com/lokoko/domain/user/admin/controller/AdminController.java
@@ -5,6 +5,7 @@ import com.lokoko.domain.user.admin.service.AdminReviewService;
 import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,7 +24,8 @@ public class AdminController {
 
     @Operation(summary = "어드민 리뷰 삭제")
     @DeleteMapping("/reviews/{reviewId}")
-    public ApiResponse<Void> deleteReviewByAdmin(@CurrentUser Long userId, @PathVariable Long reviewId) {
+    public ApiResponse<Void> deleteReviewByAdmin(@Parameter(hidden = true) @CurrentUser Long userId,
+                                                 @PathVariable Long reviewId) {
         adminReviewService.deleteReview(userId, reviewId);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_REVIEW_DELETE_SUCCESS.getMessage());
     }


### PR DESCRIPTION
## Related issue 🛠

- closed #137 

## 작업 내용 💻

- [ 기존에는 SWAGGER 에서 userId 파라미터를 받도록 되어 있었습니다.]
- [ userId 에 대해 @Parameter(hidden = true) 를 설정하여, 클라이언트에서 userId 를 직접 전달해주지 않아도 되도록 수정해습니다.]
==> AccessToken 만 전달해주면 @CurrentUser 를 통해 userId 를 가져올 수 있기 때문입니다.
 

## 스크린샷 📷

수정 전 
<img width="435" height="316" alt="image" src="https://github.com/user-attachments/assets/07c0f125-6ad1-43bb-bb7b-94077c79ff27" />

수정 후
<img width="996" height="408" alt="image" src="https://github.com/user-attachments/assets/86c052d1-3f2d-48d2-8c38-adb3d772f70d" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 관리자 리뷰 삭제 API에서 사용자 ID 파라미터가 API 문서에 노출되지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->