### PR TITLE
[REFACTOR] #138 : 제품 상세페이지 사진 리뷰 조회 응답 DTO 에 isAdmin flag 추가

### DIFF
--- a/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewsProductDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/review/dto/response/ImageReviewsProductDetailResponse.java
@@ -1,13 +1,14 @@
 package com.lokoko.domain.review.dto.response;
 
-import com.lokoko.global.common.response.PageableResponse;
-import io.swagger.v3.oas.annotations.media.Schema;
-
-import java.util.List;
-
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import com.lokoko.global.common.response.PageableResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
 public record ImageReviewsProductDetailResponse(
+        @Schema(requiredMode = REQUIRED)
+        Boolean isAdmin,
         @Schema(requiredMode = REQUIRED)
         List<ImageReviewProductDetailResponse> imageReviews,
         @Schema(requiredMode = REQUIRED)


### PR DESCRIPTION
## Related issue 🛠

- closed #137 

## 작업 내용 💻

- [ 제품 상세페이지 사진 리뷰 조회에서, 어드민이 유저의 리뷰를 삭제할 수 있으려면, 현재 사용자가 admin 인지 여부를 알아야합니다.] 
- [ 응답 DTO 에 isAdmin 이라는 flag 를 추가해주었습니다. ] 

## 스크린샷 📷

<img width="1057" height="517" alt="image" src="https://github.com/user-attachments/assets/f49c7a2a-66d4-4927-ae14-a906471cd8e9" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢


