### PR TITLE
FIX #150 : 리뷰 조회 실패 예외 메시지 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/review/exception/ReviewNotFoundException.java
+++ b/src/main/java/com/lokoko/domain/review/exception/ReviewNotFoundException.java
@@ -1,6 +1,6 @@
 package com.lokoko.domain.review.exception;
 
-import static com.lokoko.domain.review.exception.ErrorMessage.RATING_NOT_FOUND;
+import static com.lokoko.domain.review.exception.ErrorMessage.REVIEW_NOT_FOUND;
 
 import com.lokoko.global.common.exception.BaseException;
 import org.springframework.http.HttpStatus;
@@ -8,6 +8,6 @@ import org.springframework.http.HttpStatus;
 public class ReviewNotFoundException extends BaseException {
 
     public ReviewNotFoundException() {
-        super(HttpStatus.NOT_FOUND, RATING_NOT_FOUND.getMessage());
+        super(HttpStatus.NOT_FOUND, REVIEW_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #149 

## 작업 내용 💻

<img width="601" height="207" alt="image" src="https://github.com/user-attachments/assets/c2b78b85-3c33-4277-89a6-fea8466ec290" />

영상 / 사진 리뷰 상세조회에서 리뷰가 없을 경우 "리뷰가 존재하지 않습니다" 라는 메시지가 떠야하지만,
"존재하지 않는 평점입니다" 라는 메시지가 뜨고 있었습니다.

메시지를 수정하였습니다.


## 스크린샷 📷

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢


