### PR TITLE
CHORE #156 분산락 기본 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.18.0'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/lokoko/global/common/annotation/DistributedLock.java
+++ b/src/main/java/com/lokoko/global/common/annotation/DistributedLock.java
@@ -1,0 +1,20 @@
+package com.lokoko.global.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 3L;
+}

--- a/src/main/java/com/lokoko/global/common/aop/lock/CustomSpringELParser.java
+++ b/src/main/java/com/lokoko/global/common/aop/lock/CustomSpringELParser.java
@@ -1,11 +1,9 @@
 package com.lokoko.global.common.aop.lock;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
-@RequiredArgsConstructor
 public class CustomSpringELParser {
     public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
         ExpressionParser parser = new SpelExpressionParser();

--- a/src/main/java/com/lokoko/global/common/aop/lock/CustomSpringELParser.java
+++ b/src/main/java/com/lokoko/global/common/aop/lock/CustomSpringELParser.java
@@ -1,0 +1,20 @@
+package com.lokoko.global.common.aop.lock;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+@RequiredArgsConstructor
+public class CustomSpringELParser {
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/com/lokoko/global/common/aop/lock/RedissonLockAspect.java
+++ b/src/main/java/com/lokoko/global/common/aop/lock/RedissonLockAspect.java
@@ -1,0 +1,73 @@
+package com.lokoko.global.common.aop.lock;
+
+import com.lokoko.global.common.annotation.DistributedLock;
+import com.lokoko.global.common.aop.transaction.AopForTransaction;
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedissonLockAspect {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(com.lokoko.global.common.annotation.DistributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock lockAnno = method.getAnnotation(DistributedLock.class);
+
+        String key = buildKey(signature.getParameterNames(), joinPoint.getArgs(), lockAnno.key());
+        RLock rLock = redissonClient.getLock(key);
+
+        boolean acquired;
+        try {
+            acquired = tryAcquireLock(rLock, lockAnno);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        }
+        if (!acquired) {
+            return false;
+        }
+
+        try {
+            return executeWithTransaction(joinPoint);
+        } finally {
+            releaseLock(rLock, method, key);
+        }
+    }
+
+    private String buildKey(String[] names, Object[] args, String spel) {
+        return REDISSON_LOCK_PREFIX
+                + CustomSpringELParser.getDynamicValue(names, args, spel);
+    }
+
+    private boolean tryAcquireLock(RLock lock, DistributedLock anno) throws InterruptedException {
+        return lock.tryLock(anno.waitTime(), anno.leaseTime(), anno.timeUnit());
+    }
+
+    private Object executeWithTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+        return aopForTransaction.execute(joinPoint);
+    }
+
+    private void releaseLock(RLock lock, Method method, String key) {
+        try {
+            lock.unlock();
+        } catch (IllegalMonitorStateException e) {
+            log.warn("서비스={}, 키={} 락 해제 실패", method.getName(), key);
+        }
+    }
+}

--- a/src/main/java/com/lokoko/global/common/aop/transaction/AopForTransaction.java
+++ b/src/main/java/com/lokoko/global/common/aop/transaction/AopForTransaction.java
@@ -1,0 +1,15 @@
+package com.lokoko.global.common.aop.transaction;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object execute(ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/lokoko/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/lokoko/global/config/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.lokoko.global.config;
+package com.lokoko.global.config.redis;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -9,8 +9,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 
 @Configuration
 public class RedisConfig {
-
-    public static final String WILD_CARD = "*";
 
     @Value("${spring.data.redis.host}")
     private String host;

--- a/src/main/java/com/lokoko/global/config/redis/RedissonConfig.java
+++ b/src/main/java/com/lokoko/global/config/redis/RedissonConfig.java
@@ -1,0 +1,32 @@
+package com.lokoko.global.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort)
+                .setPassword(redisPassword);
+        return Redisson.create(config);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #155 

## 작업 내용 💻

- [x] `Redisson Config 구현` 
- [x] 분산락 커스텀 어노테이션 추가
- [x] AOP에서 락 키를 동적으로 생성할때 사용할 Spring EL 파서 추가
- [x] 분산락 AOP 구현 

## 스크린샷 📷

- x

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 메서드에 분산 락을 선언적으로 적용할 수 있는 `@DistributedLock` 어노테이션이 추가되었습니다.
  * Redisson 기반의 분산 락 처리를 위한 AOP 기능이 도입되었습니다.
  * 분산 락 실행 시 새로운 트랜잭션 컨텍스트를 적용하는 기능이 추가되었습니다.
  * Redisson 클라이언트 설정 및 관련 Spring Bean 구성이 추가되었습니다.

* **구성 변경**
  * Redisson Spring Boot Starter가 새롭게 추가되어 고급 Redis 클라이언트 기능을 사용할 수 있습니다.
  * Redis 및 Redisson 설정이 분리 및 개선되었습니다.

* **기타**
  * 일부 설정 클래스의 패키지 위치가 변경되고 불필요한 상수가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->