### PR TITLE
[FEAT] #167 디스코드 웹훅 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ java {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 def querydslDir = 'src/main/generated'
@@ -69,6 +70,20 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // logging
+    implementation 'org.springframework.boot:spring-boot-starter-logging'
+
+    // AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // discord
+    implementation 'com.github.napstr:logback-discord-appender:1.0.0'
+
+    // JSON
+    implementation 'org.json:json:20230227'
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.3'
 
     // Netty DNS Resolver
     runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.94.Final:osx-aarch_64")

--- a/src/main/java/com/lokoko/global/auth/authentication/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/lokoko/global/auth/authentication/CustomAccessDeniedHandler.java
@@ -24,7 +24,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
 
-        log.error(LOG_FORMAT, accessDeniedException.getClass().getSimpleName(), accessDeniedException.getMessage(),
+        log.warn(LOG_FORMAT, accessDeniedException.getClass().getSimpleName(), accessDeniedException.getMessage(),
                 accessDeniedException);
 
         response.setStatus(HttpStatus.FORBIDDEN.value());

--- a/src/main/java/com/lokoko/global/auth/authentication/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/lokoko/global/auth/authentication/CustomAuthenticationEntryPoint.java
@@ -1,7 +1,6 @@
 package com.lokoko.global.auth.authentication;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.lokoko.global.auth.jwt.exception.JwtErrorMessage;
 import com.lokoko.global.common.response.ApiResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -45,7 +44,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             logTarget = authException;
         }
 
-        log.error(LOG_FORMAT, exceptionClass, errorMessage, logTarget);
+        log.warn(LOG_FORMAT, exceptionClass, errorMessage, logTarget);
 
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(CONTENT_TYPE);

--- a/src/main/java/com/lokoko/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/lokoko/global/common/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import com.lokoko.global.common.exception.response.ValidErrorResponse;
 import com.lokoko.global.common.response.ApiResponse;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     private <T> ResponseEntity<ApiResponse<T>> buildError(
@@ -57,26 +59,27 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
         ErrorCode errorCode = ErrorCode.INVALID_ARGUMENT;
 
-        return buildError(errorCode.getStatus(), e.getMessage(), null);
+        return buildError(errorCode.getStatus(), errorCode.getMessage(), null);
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleNoResourceFound(NoResourceFoundException e) {
         ErrorCode errorCode = ErrorCode.RESOURCE_NOT_FOUND;
 
-        return buildError(errorCode.getStatus(), e.getMessage(), null);
+        return buildError(errorCode.getStatus(), errorCode.getMessage(), null);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
         ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
 
-        return buildError(errorCode.getStatus(), e.getMessage(), null);
+        return buildError(errorCode.getStatus(), errorCode.getMessage(), null);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<List<JsonErrorResponseDetail>>> handleJsonParseException(
             HttpMessageNotReadableException ex) {
+
         Throwable cause = ex.getMostSpecificCause();
         List<JsonErrorResponseDetail> details = new ArrayList<>();
 
@@ -109,6 +112,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleAll(Exception e) {
+        log.error("서버 내부 에러 발생 : {}", e.getMessage(), e);
+
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
 
         return buildError(errorCode.getStatus(), e.getMessage(), null);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -53,3 +53,8 @@ cloud:
       auto: false
     stack:
       auto: false
+
+logging:
+  discord-error:
+    webhook-url: ${DISCORD_ERROR_WEBHOOK_URL}
+    config: classpath:logback-spring.xml

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -53,3 +53,8 @@ cloud:
       auto: false
     stack:
       auto: false
+
+logging:
+  discord-error:
+    webhook-url: ${DISCORD_ERROR_WEBHOOK_URL}
+    config: classpath:logback-spring.xml

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -53,3 +53,8 @@ cloud:
       auto: false
     stack:
       auto: false
+
+logging:
+  discord-error:
+    webhook-url: ${DISCORD_ERROR_WEBHOOK_URL}
+    config: classpath:logback-spring.xml

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/discord-error-appender.xml
+++ b/src/main/resources/discord-error-appender.xml
@@ -1,0 +1,23 @@
+<included>
+    <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+        <webhookUri>${DISCORD_ERROR_WEBHOOK_URL}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern><![CDATA[
+🚨**[에러 로그]**🚨%n
+⏰**시간** : %d{yyyy-MM-dd HH:mm:ss.SSS}%n
+📍**위치** : %logger{36}.%M:%L%n
+💬**에러 메시지** : %msg%n
+```%ex{short}```%n
+]]></pattern>
+        </layout>
+        <username>[Lococo-Server]</username>
+        <tts>false</tts>
+    </appender>
+
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <include resource="console-appender.xml"/>
+    <include resource="discord-error-appender.xml"/>
+
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+    <springProperty name="DISCORD_ERROR_WEBHOOK_URL" source="logging.discord-error.webhook-url"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="ASYNC_DISCORD"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Related issue 🛠

- closed #166 

## 작업 내용 💻

- [x] 디스코드 웹훅 xml 파일 추가
- [x] 관련 yml 환경변수 설정
- [x] 배포 서버, 운영서버  log level이 `ERROR` (500 에러)만 디스코드로 알림 전송

## 스크린샷 📷

<img width="580" height="305" alt="image" src="https://github.com/user-attachments/assets/b77a91f4-06c6-4404-9b01-9b6cb0deb075" />

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- ⭐️ 로컬 환경 환경변수는 등록만 해놓고, 사진처럼 비워놔야합니다 ! 
이유 : 로컬 환경에서 테스트하는 내용들이 디스코드 웹훅으로 모두 전송되게되면, 개발서버랑 운영서버의 에러 로그 관리가 어렵기때문

<img width="471" height="31" alt="image" src="https://github.com/user-attachments/assets/834b1437-3414-4a89-b61f-cf0710f1d26d" />


