### PR TITLE
[REFACTOR] #171 : 메인페이지 신상품 조회의 정렬 조건 변경

### DIFF
--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
@@ -321,7 +321,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .groupBy(p.id, p.productName, p.brandName, p.unit, productImage.url, p.createdAt)
                 .orderBy(
                         r.id.count().desc(), //  리뷰 수
-                        ratingValue.avg().desc() // 별점
+                        ratingValue.avg().desc(), // 별점
+                        p.createdAt.desc()
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)

--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
@@ -320,8 +320,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 )
                 .groupBy(p.id, p.productName, p.brandName, p.unit, productImage.url, p.createdAt)
                 .orderBy(
-                        p.createdAt.desc(),  // 신상품은 최신 순으로 정렬
-                        r.id.count().desc()  // 그 다음 리뷰 개수 순
+                        r.id.count().desc(), //  리뷰 수
+                        ratingValue.avg().desc() // 별점
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)


### PR DESCRIPTION
## Related issue 🛠

- closed #170

## 작업 내용 💻
<img width="1782" height="855" alt="image" src="https://github.com/user-attachments/assets/6c455ca8-5ad8-4aef-af7d-2784e004798f" />

위 사진에서 보이는 것 처럼 리뷰 수가 0이고, 평점이 0인 상품이 상위 순위에 표시되고 있었습니다.

정렬로직을 점검해보니, 1순위 정렬조건이 p.createdAt (Product 엔티티가 db 에 insert 된 시간) 이었습니다.
1순위 정렬조건을 리뷰 수로, 2순위 정렬조건을 평점으로 수정하였습니다.

최신순으로 정렬되어야 하는 것이 아닌가? 라는 질문이 있을 수 있습니다.
그것은 이미 WHERE 절에서 NEW TAG 로 필터링하고 있습니다.

또한, 만약 기존에 p.createdAt 을 1순위 정렬 기준으로 사용한다면,
결국 상품을 크롤링한 시간이 기준이 되는 것이기 때문에 비즈니스 로직상 맞지 않습니다. 


## 스크린샷 📷

<img width="607" height="257" alt="image" src="https://github.com/user-attachments/assets/362e763a-e809-4f98-9220-eeaa8d6c43f6" />

리뷰 수 1순위 정렬, 평점 2순위 정렬 기준이 적용된 것을 정상적으로 확인하였습니다.

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 신상품 목록의 정렬 기준이 변경되어, 이제 리뷰 수가 많은 상품이 먼저 표시되고, 그 다음으로 평점이 높은 상품이 우선적으로 정렬됩니다. 상품의 등록일은 세 번째 기준으로 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->