### PR TITLE
[CHORE] #175 jira 깃허브 연동

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: 새로운 기능 구현시 사용.
-title: "[FEAT] #이슈번호 blahblah "
+title: "LCO-00 blahblah "
 labels: 'Feature'
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -1,0 +1,48 @@
+name: '이슈 생성'
+description: '새로 생성된 이슈는 Jira와 연동'
+title: '이슈 이름을 작성해주세요'
+body:
+  - type: input
+    id: parentKey
+    attributes:
+      label: '🎟️ 상위 작업 (Ticket Number)'
+      description: '상위 작업의 Ticket Number를 기입해주세요'
+      placeholder: 'CRA-00'
+    validations:
+      required: true
+
+  - type: input
+    id: description
+    attributes:
+      label: '📋 참고사항(Description)'
+      description: '이슈를 간략히 설명'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issueLabel
+    attributes:
+      label: '🏷️ label'
+      description: '이슈의 라벨을 선택'
+      multiple: true
+      options:
+        - Feature
+        - Fix
+        - DOCS
+        - Refactor
+        - Setting
+        - Test
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: '📌 작업 내용(Tasks)'
+      description: '이슈에 대한 필요한 작업 목록을 작성'
+      value: |
+        - [ ] blabla1
+        - [ ] blabla2
+        - [ ] blabla3
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,7 +1,7 @@
 ---
 name: Refactor request
 about: 코드 리팩토링 및 로직 개선시 사용
-title: "[REFACTOR] #이슈번호 blahblah "
+title: "LCO-00 blahblah "
 labels: 'Refactor'
 assignees: ''
 ---

--- a/.github/workflows/close-jira-issue.yml
+++ b/.github/workflows/close-jira-issue.yml
@@ -1,0 +1,31 @@
+name: Close Jira issue
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  close-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Extract Jira issue key
+        id: extract-key
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const m = context.payload.issue.title.match(/[A-Z]+-\d+/);
+            return m ? m[0] : '';
+
+      - name: Close Jira issue
+        if: steps.extract-key.outputs.result != ''
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ steps.extract-key.outputs.result }}
+          transition: 완료

--- a/.github/workflows/close-jira-issue.yml
+++ b/.github/workflows/close-jira-issue.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Extract Jira issue key
         id: extract-key
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const m = context.payload.issue.title.match(/[A-Z]+-\d+/);

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -23,7 +23,7 @@ jobs:
           ref: dev
 
       - name: Issue Parser
-        uses: stefanbuck/github-issue-praser@v3
+        uses: stefanbuck/github-issue-parser@v3
         id: issue-parser
         with:
           template-path: .github/ISSUE_TEMPLATE/issue-form.yml

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,0 +1,88 @@
+name: Create Jira issue
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  create-issue:
+    name: Create Jira issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Checkout dev code
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Issue Parser
+        uses: stefanbuck/github-issue-praser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/issue-form.yml
+
+      - name: Convert markdown to Jira Syntax
+        uses: peter-evans/jira2md@v1
+        id: md2jira
+        with:
+          input-text: |
+            ### Github Issue Link
+            - ${{ github.event.issue.html_url }}
+            ${{ github.event.issue.body }}
+          mode: md2jira
+
+      - name: Create Issue
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: LCO
+          issuetype: 하위 작업
+          summary: ${{ github.event.issue.title }}
+          description: ${{ steps.md2jira.outputs.output-text }}
+          fields: |
+            {
+              "parent": {
+                "key": "${{ steps.issue-parser.outputs.issueparser_parentKey }}"
+              }
+            }
+
+      - name: Transition to In Progress
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ steps.create.outputs.issue }}
+          transition: 진행 중
+
+      - name: Log created issue
+        run: echo "Jira Issue ${{ steps.issue-parser.outputs.issueparser_parentKey }}/${{ steps.create.outputs.issue }} was created"
+
+      - name: Create branch with Ticket number
+        run: |
+          LABELS="${{ steps.issue-parser.outputs.issueparser_issueLabel }}"
+          BRANCH_PREFIX="${LABELS%%,*}"
+          ISSUE_NUMBER="${{ steps.create.outputs.issue }}"
+          BRANCH_NAME="${BRANCH_PREFIX}/${ISSUE_NUMBER}"
+          git checkout -b "${BRANCH_NAME}"
+          git push origin "${BRANCH_NAME}"
+
+      - name: Update issue title
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: update-issue
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "[${{ steps.create.outputs.issue }}] ${{ github.event.issue.title }}"
+
+      - name: Add comment with Jira issue link
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: create-comment
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Jira Issue Created: [${{ steps.create.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create.outputs.issue }})


### PR DESCRIPTION
## Related issue 🛠

- closed #173 

## 작업 내용 💻

- [x] 이슈 생성시, `Issue` 상위작업 아래에 하위작업 생성되도록 설정 (이슈 제목으로 하위작업 티켓 자동으로 추가)
- [x] 깃허브 이슈 닫힐시, 관련 Jira 이슈가 자동으로 완료 처리되도록 설정
- [x] 이슈 템플릿 형식 변경

## 스크린샷 📷

- x

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 지라에서 저희 로코코 깃허브 연동하고, 키 발급해서 환경변수로 깃헙 액션에 넣어놨습니다
- 변경된 템플릿 형식에서도 볼 수 있듯이, 이슈 제목 컨벤션이 변경될 예정입니다

1. LCO-1 테스크 코드 작성 (예시) 이라는 티켓을 지라에서 생성 

2. 깃허브에서 이슈를 생성할때 상위 작업의 티켓을 LCO-1로 입력

<img width="246" height="45" alt="image" src="https://github.com/user-attachments/assets/69abb1cd-8688-4e73-acf4-6674a0d0d94b" />

3. 작업 제목에는 **JWT 테스트 코드 작성** 이라고 입력하여 생성

4. 이슈 제목 자동으로 [LCO-2] JWT 테스트 코드 작성 으로 생성됨 (상위 티켓은 LCO-1로 설정됨)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 새로운 이슈 템플릿(이슈 생성 폼) 도입으로, Jira 연동 및 필수 정보 입력을 지원합니다.
  * GitHub 이슈 생성 시 자동으로 Jira 이슈를 생성하고, 브랜치 및 이슈 제목 동기화, Jira 이슈 링크 코멘트 추가 기능이 적용되었습니다.
  * GitHub 이슈 종료 시 Jira 이슈를 자동으로 완료 처리합니다.

* **Chores**
  * 빈 이슈 생성을 비활성화하도록 설정이 추가되었습니다.
  * 기존 이슈 및 리팩터 템플릿의 제목 형식이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->