### PR TITLE
[DOCS] LCO-8  ProductController 에서 스웨거 형식 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/product/api/ProductController.java
+++ b/src/main/java/com/lokoko/domain/product/api/ProductController.java
@@ -70,12 +70,13 @@ public class ProductController {
 
     }
 
-    @Operation(summary = "카테고리 별 상품 검색")
+    @Operation(summary = "카테고리 별 상품 및 리뷰 검색")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
-                    description = "카테고리별 상품 검색 성공",
+                    description = "카테고리별 상품 또는 리뷰 검색 성공",
                     content = @Content(
+                            mediaType = "application/json",
                             schema = @Schema(oneOf = {
                                     ProductsByCategoryResponse.class,
                                     VideoReviewListResponse.class,
@@ -123,6 +124,7 @@ public class ProductController {
                     responseCode = "200",
                     description = "상품명/브랜드명 검색 성공",
                     content = @Content(
+                            mediaType = "application/json",
                             schema = @Schema(oneOf = {
                                     SearchProductsResponse.class,
                                     KeywordVideoReviewListResponse.class,

--- a/src/main/java/com/lokoko/domain/product/api/ProductController.java
+++ b/src/main/java/com/lokoko/domain/product/api/ProductController.java
@@ -35,6 +35,9 @@ import com.lokoko.global.kuromoji.service.ProductMigrationService;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -68,6 +71,19 @@ public class ProductController {
     }
 
     @Operation(summary = "카테고리 별 상품 검색")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "카테고리별 상품 검색 성공",
+                    content = @Content(
+                            schema = @Schema(oneOf = {
+                                    ProductsByCategoryResponse.class,
+                                    VideoReviewListResponse.class,
+                                    ImageReviewListResponse.class
+                            })
+                    )
+            )
+    })
     @GetMapping("/categories/search")
     public ApiResponse<?> searchProductsByCategory(
             @RequestParam MiddleCategory middleCategory,
@@ -102,6 +118,19 @@ public class ProductController {
     }
 
     @Operation(summary = "상품명 또는 브랜드명 상품 및 리뷰 검색")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "상품명/브랜드명 검색 성공",
+                    content = @Content(
+                            schema = @Schema(oneOf = {
+                                    SearchProductsResponse.class,
+                                    KeywordVideoReviewListResponse.class,
+                                    KeywordImageReviewListResponse.class
+                            })
+                    )
+            )
+    })
     @GetMapping("/search")
     public ApiResponse<?> search(
             @RequestParam String keyword,

--- a/src/main/java/com/lokoko/domain/product/api/dto/response/ProductsByCategoryResponse.java
+++ b/src/main/java/com/lokoko/domain/product/api/dto/response/ProductsByCategoryResponse.java
@@ -2,13 +2,21 @@ package com.lokoko.domain.product.api.dto.response;
 
 import com.lokoko.global.common.response.PageableResponse;
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Builder
 public record ProductsByCategoryResponse(
+        @Schema(requiredMode = REQUIRED)
         String searchQuery,
+        @Schema(requiredMode = REQUIRED)
         String parentCategoryName,
+        @Schema(requiredMode = REQUIRED)
         List<ProductListItemResponse> products,
+        @Schema(requiredMode = REQUIRED)
         PageableResponse pageInfo
 ) {
 }


### PR DESCRIPTION
카테고리별 상품 / 리뷰 검색 API 와,
상품명/브랜드명 상품 / 리뷰 검색 API 의 스웨거 구조를 수정하였습니다.

## Related issue 🛠

- closed #191 

## 작업 내용 💻

- 두 api 의 스웨거 형식을 수정하였습니다.


## 스크린샷 📷

이제 정상적으로 표시됩니다.

<img width="401" height="578" alt="스크린샷 2025-08-12 오후 6 21 09" src="https://github.com/user-attachments/assets/7fb1d84b-6d4a-408d-baca-37cbdc38509f" />



## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 문서화
  * 검색 관련 두 엔드포인트(/api/products/search, /api/products/categories/search)의 OpenAPI/Swagger 문서를 보강해 200 응답에 가능한 응답 형태를 명확히 표시했습니다.
  * 카테고리 검색 응답의 주요 필드들이 필수로 문서화되어 응답 스키마 가시성이 향상되었습니다.
  * 런타임 동작 변경은 없으며 기존 인터페이스와 호환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->