### PR TITLE
[REFACTOR] LCO-11 Product , Review 엔티티에 인덱스 추가

### DIFF
--- a/src/main/java/com/lokoko/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/lokoko/domain/product/domain/entity/Product.java
@@ -5,13 +5,8 @@ import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
 import com.lokoko.domain.product.domain.entity.enums.Tag;
 import com.lokoko.global.common.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,6 +15,9 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @Entity
+@Table(name = "product", indexes = {
+    @Index(name = "idx_product_middle_category_created", columnList = "middle_category, created_at DESC")
+})
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends BaseEntity {

--- a/src/main/java/com/lokoko/domain/review/domain/entity/Review.java
+++ b/src/main/java/com/lokoko/domain/review/domain/entity/Review.java
@@ -14,8 +14,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,6 +25,9 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @Entity
+@Table(name = "review", indexes = {
+    @Index(name = "idx_review_product_id", columnList = "product_id")
+})
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {


### PR DESCRIPTION
Product 와 Review 엔티티에
인덱스를 추가함으로써,
메인페이지에서 신상품 및 인기상품 조회 로직의 성능 개선을 진행했습니다.

## Related issue 🛠

- closed #193 

## 작업 내용 💻

- Product 테이블에 (middle_category, created_at) 복합 인덱스를 추가해주었습니다.
 where 절에 middle_category 가 들어가기 때문에 인덱스를 통한 성능 향상이 가능했습니다.

- Review 테이블에 product_id 단일 인덱스를 추가해주었습니다. 
Review.Product 와 product 를 조인 하는 경우 조인 조건은 product_id 로 설정됩니다.
Review 테이블에 product_id 인덱스를 추가해주면 조인 조건에 해당하는 row 들을 매우 빠르게 찾아 낼 수 있습니다.

 

## 스크린샷 📷

인덱스 적용 전 
조회 속도 1.02 초 

<img width="1219" height="294" alt="image" src="https://github.com/user-attachments/assets/7f5ea79c-2545-4919-8bd7-8eed4bd1876a" />

------

인덱스 적용 후 
조회 속도 0.37초

<img width="1597" height="287" alt="image" src="https://github.com/user-attachments/assets/7748622e-cf65-4bfc-b185-c390ebbda5ab" />


맨 밑에 보면 idx_product_image_main  이 인덱스가 표시되는데, 제 로컬 db 에만 적용된 인덱스이므로 무시하셔도 됩니다.



## 같이 얘기해보고 싶은 내용이 있다면 작성 📢


