### PR TITLE
[Feat] #206 소셜클립 엔티티 초기 세팅

### DIFF
--- a/src/main/java/com/lokoko/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/lokoko/domain/product/domain/entity/Product.java
@@ -5,8 +5,15 @@ import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
 import com.lokoko.domain.product.domain.entity.enums.Tag;
 import com.lokoko.global.common.entity.BaseEntity;
-import jakarta.persistence.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,7 +23,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @Entity
 @Table(name = "product", indexes = {
-    @Index(name = "idx_product_middle_category_created", columnList = "middle_category, created_at DESC")
+        @Index(name = "idx_product_middle_category_created", columnList = "middle_category, created_at DESC")
 })
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -77,7 +84,6 @@ public class Product extends BaseEntity {
 
     private String searchToken;
 
-
     public void updateYoutubeUrls(List<String> urls) {
         this.youtubeUrl = String.join(",", urls);
     }
@@ -85,6 +91,4 @@ public class Product extends BaseEntity {
     public void updateSearchToken(String join) {
         this.searchToken = join;
     }
-
-
 }

--- a/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
+++ b/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
@@ -1,6 +1,6 @@
 package com.lokoko.domain.socialclip.domain;
 
-import com.lokoko.domain.socialclip.domain.entity.enums.SocialClipContent;
+import com.lokoko.domain.socialclip.domain.entity.enums.Content;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,6 +8,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,31 +25,22 @@ public class SocialClip {
     @Column(name = "social_clip_id")
     private Long id;
 
-    @Column
-    Long instaPlays;
+    @Column(nullable = false)
+    Long plays;
 
-    @Column
-    Long instaLikes;
+    @Column(nullable = false)
+    Long likes;
 
-    @Column
-    Long instaComments;
+    @Column(nullable = false)
+    Long comments;
 
-    @Column
-    Long instaShares;
+    @Column(nullable = false)
+    Long shares;
 
-    @Column
-    Long youtubePlays;
-
-    @Column
-    Long youtubeLikes;
-
-    @Column
-    Long youtubeComments;
-
-    @Column
-    Long youtubeShares;
+    @Column(nullable = false)
+    private LocalDateTime uploadedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private SocialClipContent socialClipContent;
+    private Content content;
 }

--- a/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
+++ b/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
@@ -1,6 +1,7 @@
 package com.lokoko.domain.socialclip.domain;
 
 import com.lokoko.domain.socialclip.domain.entity.enums.Content;
+import com.lokoko.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -18,7 +19,7 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SocialClip {
+public class SocialClip extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
+++ b/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
@@ -18,6 +18,6 @@ public class SocialClip {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "socialclip_id")
+    @Column(name = "social_clip_id")
     private Long id;
 }

--- a/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
+++ b/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
@@ -1,7 +1,10 @@
 package com.lokoko.domain.socialclip.domain;
 
+import com.lokoko.domain.socialclip.domain.entity.enums.SocialClipContent;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,4 +23,32 @@ public class SocialClip {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "social_clip_id")
     private Long id;
+
+    @Column
+    Long instaPlays;
+
+    @Column
+    Long instaLikes;
+
+    @Column
+    Long instaComments;
+
+    @Column
+    Long instaShares;
+
+    @Column
+    Long youtubePlays;
+
+    @Column
+    Long youtubeLikes;
+
+    @Column
+    Long youtubeComments;
+
+    @Column
+    Long youtubeShares;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SocialClipContent socialClipContent;
 }

--- a/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
+++ b/src/main/java/com/lokoko/domain/socialclip/domain/SocialClip.java
@@ -1,0 +1,23 @@
+package com.lokoko.domain.socialclip.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialClip {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "socialclip_id")
+    private Long id;
+}

--- a/src/main/java/com/lokoko/domain/socialclip/domain/entity/enums/Content.java
+++ b/src/main/java/com/lokoko/domain/socialclip/domain/entity/enums/Content.java
@@ -5,10 +5,11 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum SocialClipContent {
+public enum Content {
 
-    Reels("릴스"),
-    Shorts("쇼츠");
+    REELS("릴스"),
+    VIDEO("비디오"),
+    POST("게시물");
 
     private final String displayName;
 }

--- a/src/main/java/com/lokoko/domain/socialclip/domain/entity/enums/SocialClipContent.java
+++ b/src/main/java/com/lokoko/domain/socialclip/domain/entity/enums/SocialClipContent.java
@@ -1,0 +1,14 @@
+package com.lokoko.domain.socialclip.domain.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SocialClipContent {
+
+    Reels("릴스"),
+    Shorts("쇼츠");
+
+    private final String displayName;
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #202 

## 작업 내용 💻

- [x] 소셜 클립 엔티티 추가
- [x] 릴스, 쇼츠 `enum` 타입 추가

## 스크린샷 📷

- x

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

크리에이터 관련 `ENUM` 도 추가해줘야하는데, 해당 내용은 효은이꺼 PR 머지되면 비즈니스 로직이랑 같이 작업하는걸로 하겠습니다
추가된 필드들이랑 빠진 필드 없는지, 꼼꼼히 봐주시면 감사하겠습니다 🙇🏻‍♂️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새 기능
  - 소셜 클립 엔터티 추가: 재생수, 좋아요, 댓글, 공유 수, 업로드 시각과 콘텐츠 유형(릴스/비디오/게시물) 지원.
  - 콘텐츠 유형별 한글 표시명 제공.

- 스타일
  - 임포트 및 주석/들여쓰기 정리로 코드 일관성 개선(기능 영향 없음).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->