### PR TITLE
[FEAT] #212 캠페인 CRU(생성/조회/수정) API 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -1,0 +1,75 @@
+package com.lokoko.domain.brand.api;
+import com.lokoko.domain.brand.api.message.ResponseMessage;
+import com.lokoko.domain.campaign.api.dto.request.CampaignDraftRequest;
+import com.lokoko.domain.campaign.api.dto.request.CampaignPublishRequest;
+import com.lokoko.domain.campaign.api.dto.response.CampaignCreateResponse;
+
+import com.lokoko.domain.campaign.application.service.CampaignService;
+import com.lokoko.global.auth.annotation.CurrentUser;
+import com.lokoko.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "BRAND")
+@RestController
+@RequestMapping("/api/brands")
+@RequiredArgsConstructor
+public class BrandController {
+
+    private final CampaignService campaignService;
+
+    @Operation(summary = "캠페인 생성 - 임시저장",
+            description = "브랜드 마이페이지에서 브랜드가 캠패인을 임시저장 상태로 생성하는 API 입니다.")
+    @PostMapping("/my/campaigns/drafts")
+    public ApiResponse<CampaignCreateResponse> createDraftCampaign(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @Valid @RequestBody CampaignDraftRequest draftRequest) {
+
+        CampaignCreateResponse response = campaignService.createCampaignDraft(brandId, draftRequest);
+        return ApiResponse.success(HttpStatus.CREATED,
+                ResponseMessage.CAMPAIGN_DRAFT_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "캠페인 생성 - 발행",
+            description = "브랜드 마이페이지에서 브랜드가 캠페인을 발행 상태로 생성하는 API 입니다.")
+    @PostMapping("/my/campaigns/publish")
+    public ApiResponse<CampaignCreateResponse> createAndPublishCampaign(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @Valid @RequestBody CampaignPublishRequest publishRequest) {
+
+        CampaignCreateResponse response = campaignService.createAndPublishCampaign(brandId, publishRequest);
+        return ApiResponse.success(HttpStatus.CREATED,
+                ResponseMessage.CAMPAIGN_PUBLISH_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "캠페인 수정 - 임시저장",
+            description = "브랜드 마이페이지에서 브랜드가 기존에 존재하는 캠페인에 대한 임시저장을 수행하는 API 입니다.")
+    @PutMapping("/my/campaigns/{campaignId}/draft")
+    public ApiResponse<CampaignCreateResponse> updateCampaignDraft(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @PathVariable Long campaignId,
+            @Valid @RequestBody CampaignDraftRequest draftRequest) {
+
+        CampaignCreateResponse response = campaignService.updateCampaignToDraft(brandId, campaignId, draftRequest);
+        return ApiResponse.success(HttpStatus.OK,
+                ResponseMessage.CAMPAIGN_UPDATE_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "캠페인 수정 - 발행",
+            description = "브랜드 마이페이지에서 브랜드가 기존에 존재하는 캠페인에 대한 발행을 수행하는 API 입니다.")
+    @PatchMapping("/my/campaigns/{campaignId}/publish")
+    public ApiResponse<CampaignCreateResponse> publishCampaign(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @PathVariable Long campaignId,
+            @Valid @RequestBody CampaignPublishRequest publishRequest) {
+
+        CampaignCreateResponse response = campaignService.updateAndPublishCampaign(brandId, campaignId, publishRequest);
+        return ApiResponse.success(HttpStatus.OK,
+                ResponseMessage.CAMPAIGN_PUBLISH_SUCCESS.getMessage(), response);
+    }
+}

--- a/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
@@ -1,0 +1,15 @@
+package com.lokoko.domain.brand.api.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    CAMPAIGN_PUBLISH_SUCCESS("캠페인이 발행되었습니다."),
+    CAMPAIGN_DRAFT_SUCCESS("캠페인 임시저장이 완료되었습니다."),
+    CAMPAIGN_UPDATE_SUCCESS("캠페인 수정이 완료되었습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/lokoko/domain/brand/exception/BrandNotFoundException.java
+++ b/src/main/java/com/lokoko/domain/brand/exception/BrandNotFoundException.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.brand.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class BrandNotFoundException extends BaseException {
+    public BrandNotFoundException() {
+        super(HttpStatus.NOT_FOUND, ErrorMessage.BRAND_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/domain/brand/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/domain/brand/exception/ErrorMessage.java
@@ -1,0 +1,12 @@
+package com.lokoko.domain.brand.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    BRAND_NOT_FOUND("존재하지 않는 브랜드입니다.");
+    private final String message;
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
@@ -1,9 +1,18 @@
 package com.lokoko.domain.campaign.api;
 
+import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
+import com.lokoko.domain.campaign.api.message.ResponseMessage;
 import com.lokoko.domain.campaign.application.service.CampaignReadService;
 import com.lokoko.domain.campaign.application.service.CampaignService;
+import com.lokoko.global.auth.annotation.CurrentUser;
+import com.lokoko.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,5 +24,17 @@ public class CampaignController {
 
     private final CampaignService campaignService;
     private final CampaignReadService campaignReadService;
+
+    @Operation(summary = "캠페인 상세 조회")
+    @GetMapping("/{campaignId}")
+    public ApiResponse<CampaignDetailResponse> getCampaignDetail(
+            @Parameter(hidden = true) @CurrentUser Long creatorId,
+            @PathVariable Long campaignId) {
+
+        CampaignDetailResponse response = campaignReadService.getCampaignDetail(creatorId, campaignId);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CAMPAIGN_DETAIL_GET_SUCCESS.getMessage(), response);
+    }
+
+
 
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
@@ -1,6 +1,8 @@
 package com.lokoko.domain.campaign.api;
 
+import com.lokoko.domain.campaign.api.dto.request.CampaignMediaRequest;
 import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
+import com.lokoko.domain.campaign.api.dto.response.CampaignMediaResponse;
 import com.lokoko.domain.campaign.api.message.ResponseMessage;
 import com.lokoko.domain.campaign.application.service.CampaignReadService;
 import com.lokoko.domain.campaign.application.service.CampaignService;
@@ -9,12 +11,10 @@ import com.lokoko.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "CAMPAIGN")
 @RestController
@@ -34,6 +34,18 @@ public class CampaignController {
         CampaignDetailResponse response = campaignReadService.getCampaignDetail(creatorId, campaignId);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.CAMPAIGN_DETAIL_GET_SUCCESS.getMessage(), response);
     }
+
+    @Operation(summary = "사진 presignedUrl 발급")
+    @PostMapping("/media")
+    public ApiResponse<CampaignMediaResponse> createMediaPresignedUrl(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @RequestBody @Valid CampaignMediaRequest mediaRequest) {
+
+        CampaignMediaResponse response = campaignService.createMediaPresignedUrl(brandId, mediaRequest);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CAMPAIGN_MEDIA_PRESIGNED_URL_SUCCESS.getMessage(), response);
+    }
+
+
 
 
 

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignCreateRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignCreateRequest.java
@@ -1,0 +1,67 @@
+package com.lokoko.domain.campaign.api.dto.request;
+
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.global.common.enums.Language;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CampaignCreateRequest(
+        String campaignTitle,
+        Language language,
+        CampaignType campaignType,
+        CampaignProductType campaignProductType,
+        @Size(max = 5, message = "상단 이미지는 최대 5개까지 가능합니다")
+        List<CampaignImageRequest> topImages,
+        @Size(max = 15, message = "하단 이미지는 최대 15개까지 가능합니다")
+        List<CampaignImageRequest> bottomImages,
+        Instant applyStartDate,
+        Instant applyDeadline,
+        Instant creatorAnnouncementDate,
+        Instant reviewSubmissionDeadline,
+        Integer recruitmentNumber,
+        List<String> participationRewards,
+        List<String> deliverableRequirements,
+        List<String> eligibilityRequirements
+) {
+
+    public static CampaignCreateRequest convertPublishToCreateRequest(CampaignPublishRequest publishRequest) {
+        return new CampaignCreateRequest(
+                publishRequest.campaignTitle(),
+                publishRequest.language(),
+                publishRequest.campaignType(),
+                publishRequest.campaignProductType(),
+                publishRequest.topImages(),
+                publishRequest.bottomImages(),
+                publishRequest.applyStartDate(),
+                publishRequest.applyDeadline(),
+                publishRequest.creatorAnnouncementDate(),
+                publishRequest.reviewSubmissionDeadline(),
+                publishRequest.recruitmentNumber(),
+                publishRequest.participationRewards(),
+                publishRequest.deliverableRequirements(),
+                publishRequest.eligibilityRequirements()
+        );
+    }
+
+    public static CampaignCreateRequest convertDraftToCreateRequest(CampaignDraftRequest draftRequest) {
+        return new CampaignCreateRequest(
+                draftRequest.campaignTitle(),
+                draftRequest.language(),
+                draftRequest.campaignType(),
+                draftRequest.campaignProductType(),
+                draftRequest.topImages(),
+                draftRequest.bottomImages(),
+                draftRequest.applyStartDate(),
+                draftRequest.applyDeadline(),
+                draftRequest.creatorAnnouncementDate(),
+                draftRequest.reviewSubmissionDeadline(),
+                draftRequest.recruitmentNumber(),
+                draftRequest.participationRewards(),
+                draftRequest.deliverableRequirements(),
+                draftRequest.eligibilityRequirements()
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignDraftRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignDraftRequest.java
@@ -1,0 +1,29 @@
+package com.lokoko.domain.campaign.api.dto.request;
+
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.global.common.enums.Language;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CampaignDraftRequest(
+        String campaignTitle,
+        Language language,
+        CampaignType campaignType,
+        CampaignProductType campaignProductType,
+        @Size(max = 5, message = "상단 이미지는 최대 5개까지 가능합니다")
+        List<CampaignImageRequest> topImages,
+        @Size(max = 15, message = "하단 이미지는 최대 15개까지 가능합니다")
+        List<CampaignImageRequest> bottomImages,
+        Instant applyStartDate,
+        Instant applyDeadline,
+        Instant creatorAnnouncementDate,
+        Instant reviewSubmissionDeadline,
+        Integer recruitmentNumber,
+        List<String> participationRewards,
+        List<String> deliverableRequirements,
+        List<String> eligibilityRequirements
+) {
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignImageRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignImageRequest.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.campaign.api.dto.request;
+
+import com.lokoko.domain.image.domain.entity.enums.ImageType;
+
+public record CampaignImageRequest(
+        String url,
+        int displayOrder,
+        ImageType imageType
+) {
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignMediaRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignMediaRequest.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.campaign.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CampaignMediaRequest(
+        @NotNull List<String> mediaType
+) {
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignPublishRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignPublishRequest.java
@@ -1,0 +1,60 @@
+package com.lokoko.domain.campaign.api.dto.request;
+
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.global.common.enums.Language;
+import jakarta.validation.constraints.*;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CampaignPublishRequest(
+        @NotBlank(message = "캠페인 제목은 필수입니다")
+        String campaignTitle,
+        
+        @NotNull(message = "언어 설정은 필수입니다")
+        Language language,
+        
+        @NotNull(message = "캠페인 타입은 필수입니다")
+        CampaignType campaignType,
+        
+        @NotNull(message = "캠페인 상품 타입은 필수입니다")
+        CampaignProductType campaignProductType,
+        
+        @NotEmpty(message = "상단 이미지는 최소 1개 이상 필요합니다")
+        @Size(max = 5, message = "상단 이미지는 최대 5개까지 가능합니다")
+        List<CampaignImageRequest> topImages,
+        
+        @Size(max = 15, message = "하단 이미지는 최대 15개까지 가능합니다")
+        List<CampaignImageRequest> bottomImages,
+        
+        @NotNull(message = "신청 시작일은 필수입니다")
+        @Future(message = "신청 시작일은 미래 날짜여야 합니다")
+        Instant applyStartDate,
+        
+        @NotNull(message = "신청 마감일은 필수입니다")
+        @Future(message = "신청 마감일은 미래 날짜여야 합니다")
+        Instant applyDeadline,
+        
+        @NotNull(message = "크리에이터 발표일은 필수입니다")
+        @Future(message = "크리에이터 발표일은 미래 날짜여야 합니다")
+        Instant creatorAnnouncementDate,
+        
+        @NotNull(message = "리뷰 제출 마감일은 필수입니다")
+        @Future(message = "리뷰 제출 마감일은 미래 날짜여야 합니다")
+        Instant reviewSubmissionDeadline,
+        
+        @NotNull(message = "모집 인원은 필수입니다")
+        @Min(value = 1, message = "모집 인원은 최소 1명 이상이어야 합니다")
+        Integer recruitmentNumber,
+        
+        @NotEmpty(message = "참여 혜택은 최소 1개 이상 필요합니다")
+        List<String> participationRewards,
+        
+        @NotEmpty(message = "전달 요구사항은 최소 1개 이상 필요합니다")
+        List<String> deliverableRequirements,
+        
+        // 선택사항
+        List<String> eligibilityRequirements
+) {
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignCreateResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignCreateResponse.java
@@ -1,0 +1,46 @@
+package com.lokoko.domain.campaign.api.dto.response;
+
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.global.common.enums.Language;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CampaignCreateResponse(
+        Long campaignId,
+        String campaignTitle,
+        Language language,
+        CampaignType campaignType,
+        List<CampaignImageResponse> topImages,
+        List<CampaignImageResponse> bottomImages,
+        Instant applyStartDate,
+        Instant applyDeadline,
+        Instant creatorAnnouncementDate,
+        Instant reviewSubmissionDeadline,
+        int recruitmentNumber,
+        List<String> participationRewards,
+        List<String> deliverableRequirements,
+        List<String> eligibilityRequirements
+) {
+    public static CampaignCreateResponse of(Campaign campaign, List<CampaignImageResponse> topImages,
+                                            List<CampaignImageResponse> bottomImages) {
+        return new CampaignCreateResponse(
+                campaign.getId(),
+                campaign.getTitle(),
+                campaign.getLanguage(),
+                campaign.getCampaignType(),
+                topImages,
+                bottomImages,
+                campaign.getApplyStartDate(),
+                campaign.getApplyDeadline(),
+                campaign.getCreatorAnnouncementDate(),
+                campaign.getReviewSubmissionDeadline(),
+                campaign.getRecruitmentNumber(),
+                campaign.getParticipationRewards(),
+                campaign.getDeliverableRequirements(),
+                campaign.getEligibilityRequirements()
+
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignDetailResponse.java
@@ -1,0 +1,54 @@
+package com.lokoko.domain.campaign.api.dto.response;
+
+import com.lokoko.domain.brand.domain.entity.Brand;
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CampaignDetailResponse(
+
+        Long campaignId,
+        CampaignType campaignType,
+        String title,
+        String brandImageUrl,
+        String brandName,
+        String language,
+        Instant applyStartDate,
+        Instant applyDeadline,
+        Instant creatorAnnouncementDate,
+        Instant reviewSubmissionDeadline,
+        List<String> deliverableRequirements,
+        List<String> participationRewards,
+        List<String> eligibilityRequirements,
+        List<CampaignImageResponse> topImages,
+        List<CampaignImageResponse> bottomImages,
+        String campaignStatusCode
+) {
+
+    public static CampaignDetailResponse of(Campaign campaign, List<CampaignImageResponse> topImages,
+                                            List<CampaignImageResponse> bottomImages,
+                                            String campaignStatusCode) {
+
+        Brand brand = campaign.getBrand();
+        return new CampaignDetailResponse(
+                campaign.getId(),
+                campaign.getCampaignType(),
+                campaign.getTitle(),
+                brand.getProfileImageUrl(),
+                brand.getBrandName(),
+                campaign.getLanguage().name(),
+                campaign.getApplyStartDate(),
+                campaign.getApplyDeadline(),
+                campaign.getCreatorAnnouncementDate(),
+                campaign.getReviewSubmissionDeadline(),
+                campaign.getDeliverableRequirements(),
+                campaign.getParticipationRewards(),
+                campaign.getEligibilityRequirements(),
+                topImages,
+                bottomImages,
+                campaignStatusCode
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignImageResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignImageResponse.java
@@ -1,0 +1,17 @@
+package com.lokoko.domain.campaign.api.dto.response;
+
+import com.lokoko.domain.image.domain.entity.CampaignImage;
+
+public record CampaignImageResponse(
+        Long id,
+        String url,
+        int displayOrder
+) {
+    public static CampaignImageResponse from(CampaignImage image) {
+        return new CampaignImageResponse(
+                image.getId(),
+                image.getUrl(),
+                image.getDisplayOrder()
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignMediaResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignMediaResponse.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.campaign.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record CampaignMediaResponse(
+        @Schema(requiredMode = REQUIRED)
+        List<String> mediaUrl
+) {
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/message/ResponseMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ResponseMessage {
-    CAMPAIGN_DETAIL_GET_SUCCESS("캠페인 상세조회에 성공했습니다");
+    CAMPAIGN_DETAIL_GET_SUCCESS("캠페인 상세조회에 성공했습니다"),
+    CAMPAIGN_MEDIA_PRESIGNED_URL_SUCCESS("캠페인 사진의 Presigned Url이 성공적으로 발급되었습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignService.java
@@ -1,9 +1,38 @@
 package com.lokoko.domain.campaign.application.service;
 
+import com.lokoko.domain.brand.domain.entity.Brand;
+import com.lokoko.domain.brand.domain.repository.BrandRepository;
+import com.lokoko.domain.brand.exception.BrandNotFoundException;
+import com.lokoko.domain.campaign.api.dto.request.CampaignCreateRequest;
+import com.lokoko.domain.campaign.api.dto.request.CampaignDraftRequest;
+import com.lokoko.domain.campaign.api.dto.request.CampaignPublishRequest;
+import com.lokoko.domain.campaign.api.dto.request.CampaignMediaRequest;
+import com.lokoko.domain.campaign.api.dto.response.CampaignCreateResponse;
+import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
+import com.lokoko.domain.campaign.api.dto.response.CampaignMediaResponse;
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaign.domain.entity.enums.ActionType;
 import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
+import com.lokoko.domain.campaign.exception.CampaignNotEditableException;
+import com.lokoko.domain.campaign.exception.CampaignNotFoundException;
+import com.lokoko.domain.campaign.exception.DraftNotFilledException;
+import com.lokoko.domain.campaign.exception.NotCampaignOwnershipException;
+import com.lokoko.domain.image.domain.entity.CampaignImage;
+import com.lokoko.domain.image.domain.entity.enums.ImageType;
+import com.lokoko.domain.image.domain.repository.CampaignImageRepository;
+import com.lokoko.domain.review.exception.ErrorMessage;
+import com.lokoko.domain.review.exception.InvalidMediaTypeException;
+import com.lokoko.global.common.dto.PresignedUrlResponse;
+import com.lokoko.global.common.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static com.lokoko.global.utils.AllowedMediaType.ALLOWED_MEDIA_TYPES;
 
 @Service
 @RequiredArgsConstructor
@@ -11,5 +40,144 @@ import org.springframework.transaction.annotation.Transactional;
 public class CampaignService {
 
     private final CampaignRepository campaignRepository;
+    private final CampaignImageRepository campaignImageRepository;
+    private final BrandRepository brandRepository;
+    private final S3Service s3Service;
+
+    public CampaignMediaResponse createMediaPresignedUrl(Long brandId, CampaignMediaRequest request) {
+
+        Brand brand = brandRepository.findById(brandId)
+                .orElseThrow(BrandNotFoundException::new);
+
+        List<String> mediaTypes = request.mediaType();
+        // 허용되지 않은 형식이 있는지 검증
+        for (String type : mediaTypes) {
+            if (!ALLOWED_MEDIA_TYPES.contains(type)) {
+                throw new InvalidMediaTypeException(ErrorMessage.UNSUPPORTED_MEDIA_TYPE);
+            }
+        }
+        // presigned URL 발급
+        List<String> urls = mediaTypes.stream()
+                .map(s3Service::generatePresignedUrl)
+                .map(PresignedUrlResponse::presignedUrl)
+                .toList();
+
+        return new CampaignMediaResponse(urls);
+    }
+
+    @Transactional
+    public CampaignCreateResponse createCampaignWithAction(Long brandId, ActionType actionType, CampaignCreateRequest createRequest) {
+        Brand brand = brandRepository.findById(brandId)
+                .orElseThrow(BrandNotFoundException::new);
+
+        Campaign campaign = Campaign.createCampaign(createRequest, brand);
+
+        if (actionType == ActionType.PUBLISH) {
+            if(campaign.isDraft()) throw new DraftNotFilledException();
+            campaign.publish();
+        }
+
+        Campaign savedCampaign = campaignRepository.save(campaign);
+        List<CampaignImage> savedImages = saveImages(createRequest, savedCampaign);
+
+        return buildCampaignCreateResponse(savedCampaign, savedImages);
+    }
+
+    private List<CampaignImage> saveImages(CampaignCreateRequest createRequest, Campaign campaign) {
+
+        List<CampaignImage> toSaveImages = new ArrayList<>();
+
+        createRequest.topImages()
+                .forEach(img -> toSaveImages.add(CampaignImage.createCampaignImage(
+                        img.url(), img.displayOrder(), img.imageType(), campaign)));
+
+        createRequest.bottomImages()
+                .forEach(img -> toSaveImages.add(CampaignImage.createCampaignImage(
+                        img.url(), img.displayOrder(), img.imageType(), campaign)));
+
+        return campaignImageRepository.saveAll(toSaveImages);
+    }
+
+    private CampaignCreateResponse buildCampaignCreateResponse(
+            Campaign campaign, List<CampaignImage> savedImages) {
+
+        List<CampaignImageResponse> topImages = savedImages.stream()
+                .filter(img -> img.getImageType() == ImageType.TOP)
+                .sorted(Comparator.comparing(CampaignImage::getDisplayOrder))
+                .map(CampaignImageResponse::from)
+                .toList();
+
+        List<CampaignImageResponse> bottomImages = savedImages.stream()
+                .filter(img -> img.getImageType() == ImageType.BOTTOM)
+                .sorted(Comparator.comparing(CampaignImage::getDisplayOrder))
+                .map(CampaignImageResponse::from)
+                .toList();
+
+        return CampaignCreateResponse.of(campaign, topImages, bottomImages);
+
+    }
+
+    @Transactional
+    public CampaignCreateResponse updateCampaign(Long brandId, Long campaignId, ActionType actionType, CampaignCreateRequest updateRequest) {
+
+        Brand brand = brandRepository.findById(brandId)
+                .orElseThrow(BrandNotFoundException::new);
+
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        validateBrandOwnsCampaign(campaign, brand);
+
+        validateEditableCampaign(campaign);
+
+        campaign.updateCampaign(updateRequest);
+
+        if (actionType == ActionType.PUBLISH) {
+            if (campaign.isDraft()) throw new DraftNotFilledException();
+            campaign.publish();
+        }
+
+        // 기존에 존재하는 이미지 삭제후 갈아끼우기
+        campaignImageRepository.deleteByCampaignId(campaignId);
+        List<CampaignImage> savedImages = saveImages(updateRequest, campaign);
+
+        return buildCampaignCreateResponse(campaign, savedImages);
+    }
+
+    private void validateEditableCampaign(Campaign campaign) {
+        if (campaign.isPublished()) {
+            throw new CampaignNotEditableException();
+        }
+    }
+
+    private static void validateBrandOwnsCampaign(Campaign campaign, Brand brand) {
+        if (!campaign.getBrand().getId().equals(brand.getId())) {
+            throw new NotCampaignOwnershipException();
+        }
+    }
+
+    @Transactional
+    public CampaignCreateResponse createCampaignDraft(Long brandId, CampaignDraftRequest draftRequest) {
+        CampaignCreateRequest createRequest = CampaignCreateRequest.convertDraftToCreateRequest(draftRequest);
+        return createCampaignWithAction(brandId, ActionType.SAVE_DRAFT, createRequest);
+    }
+
+    @Transactional
+    public CampaignCreateResponse createAndPublishCampaign(Long brandId, CampaignPublishRequest publishRequest) {
+        CampaignCreateRequest createRequest = CampaignCreateRequest.convertPublishToCreateRequest(publishRequest);
+        return createCampaignWithAction(brandId, ActionType.PUBLISH, createRequest);
+    }
+
+    @Transactional
+    public CampaignCreateResponse updateCampaignToDraft(Long brandId, Long campaignId, CampaignDraftRequest draftRequest) {
+        CampaignCreateRequest updateRequest = CampaignCreateRequest.convertDraftToCreateRequest(draftRequest);
+        return updateCampaign(brandId, campaignId, ActionType.SAVE_DRAFT, updateRequest);
+    }
+
+    @Transactional
+    public CampaignCreateResponse updateAndPublishCampaign(Long brandId, Long campaignId, CampaignPublishRequest publishRequest) {
+        CampaignCreateRequest updateRequest = CampaignCreateRequest.convertPublishToCreateRequest(publishRequest);
+        return updateCampaign(brandId, campaignId, ActionType.PUBLISH, updateRequest);
+    }
 
 }

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignStatusManager.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignStatusManager.java
@@ -4,11 +4,14 @@ import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.domain.entity.CreatorCampaign;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.ParticipationStatus;
+import com.lokoko.domain.campaign.exception.CampaignNotAccessibleException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -18,9 +21,10 @@ import java.time.temporal.ChronoUnit;
 public class CampaignStatusManager {
 
     /**
-     * 브랜드 관점에서 보는 Campagin 의 상태(피그마 뷰 - [브랜드] 마이페이지의 상태표 참고)
+     * 브랜드 관점에서 보는 Campaign 의 상태(피그마 뷰 - [브랜드] 마이페이지의 상태표 참고)
+     * 날짜 기반으로 실제 상태를 계산
      * @param campaign
-     * @return 브랜드 마이페이지에서 확인할 수 있는 캠페인의 상태
+     * @return 캠페인 자체 상태
      */
     public CampaignStatus determineCampaignStatus(Campaign campaign) {
 
@@ -57,5 +61,109 @@ public class CampaignStatusManager {
         // 리뷰 제출 마감시간부터 ~ 그 이후
         // 캠페인 종료
         return CampaignStatus.COMPLETED;
+    }
+
+    /**
+     * DB 업데이트 없이 실시간 상태만 계산
+     * 비즈니스 로직에서 상태 검증이 필요할 때 사용
+     * @param campaign
+     * @return 현재 시점의 실제 캠페인 상태
+     */
+    public CampaignStatus calculateRealTimeStatus(Campaign campaign) {
+        // determineCampaignStatus와 동일한 로직이지만 DB 업데이트 없음
+        return determineCampaignStatus(campaign);
+    }
+
+    /**
+     * @param campaign 상태를 동기화할 캠페인
+     * @return 업데이트된 상태
+     */
+    @Transactional
+    public CampaignStatus syncCampaignStatus(Campaign campaign) {
+        CampaignStatus calculatedStatus = determineCampaignStatus(campaign);
+
+        if (campaign.getCampaignStatus() != calculatedStatus) {
+            campaign.changeStatus(calculatedStatus);
+        }
+        return calculatedStatus;
+    }
+
+    /**
+     * 캠페인 상세조회 페이지에서, 캠페인의 상태 판단
+     * db 와 상태 대조후, 동기화.
+     */
+    @Transactional
+    public String determineStatusInDetailPage(Campaign campaign, Optional<CreatorCampaign> creatorCampaign) {
+
+        // 상태 동기화 먼저
+        CampaignStatus campaignStatus = syncCampaignStatus(campaign);
+
+        if (campaignStatus == CampaignStatus.DRAFT || campaignStatus == CampaignStatus.WAITING_APPROVAL) {
+            throw new CampaignNotAccessibleException(); // DRAFT 상태와, WAITING_APPROVAL 상태인 캠페인은 보여지면 안 된다.
+        }
+
+        String returnStatus = null;
+
+        // 크리에이터의 지원 없는 상태
+        if (creatorCampaign.isEmpty()) {
+            if (campaignStatus == CampaignStatus.OPEN_RESERVED){ // 캠페인 승인 받고, 오픈 예정인 상태
+                returnStatus = "OPEN_RESERVED";
+            }
+            if (campaignStatus == CampaignStatus.RECRUITING){  // 캠페인 모집 중인데, 크리에이터 지원 아직 안한 경우
+                returnStatus = "RECRUITING";
+            }
+            if (campaignStatus == CampaignStatus.RECRUITMENT_CLOSED
+                    || campaignStatus == CampaignStatus.IN_REVIEW
+                    || campaignStatus == CampaignStatus.COMPLETED) {
+                returnStatus = "NOT_APPLIED_ENDED";
+            }
+        } else { // 크리에이터 지원 있는 상태
+            CreatorCampaign participation = creatorCampaign.get(); // 크리에이터의 참여 정보
+            ParticipationStatus participationStatus = participation.getStatus(); // 참여 상태
+
+            // 결과 나오기 전
+            // 대기 상태
+            if (participationStatus == ParticipationStatus.PENDING) {
+                returnStatus = "PENDING";
+            }
+            // 거절됨
+            else if (participationStatus == ParticipationStatus.REJECTED) {
+                returnStatus = "REJECTED";
+            }
+            // 승인됨 - 초기 상태
+            else if (participationStatus == ParticipationStatus.APPROVED) {
+                returnStatus = "APPROVED_PENDING_ACTION";
+            }
+            // 승인됨 - 진행 상태들
+            else if (participationStatus == ParticipationStatus.APPROVED_ADDRESS_CONFIRMED) {
+                returnStatus = "APPROVED_ADDRESS_CONFIRMED";
+            }
+            else if (participationStatus == ParticipationStatus.APPROVED_FIRST_REVIEW_DONE) {
+                returnStatus = "APPROVED_FIRST_REVIEW_DONE";
+            }
+            else if (participationStatus == ParticipationStatus.APPROVED_REVISION_REQUESTED) {
+                returnStatus = "APPROVED_REVISION_REQUESTED";
+            }
+            else if (participationStatus == ParticipationStatus.APPROVED_REVISION_CONFIRMED) {
+                returnStatus = "APPROVED_REVISION_CONFIRMED";
+            }
+            // 완료 상태
+            else if (participationStatus == ParticipationStatus.APPROVED_SECOND_REVIEW_DONE) {
+                returnStatus = "APPROVED_SECOND_REVIEW_DONE";
+            }
+            // 만료 상태들
+            else if (participationStatus == ParticipationStatus.APPROVED_ADDRESS_NOT_CONFIRMED) {
+                returnStatus = "APPROVED_ADDRESS_NOT_CONFIRMED";
+            }
+            else if (participationStatus == ParticipationStatus.APPROVED_REVIEW_NOT_CONFIRMED) {
+                returnStatus = "APPROVED_REVIEW_NOT_CONFIRMED";
+            }
+        }
+
+        if (returnStatus == null) {
+            returnStatus = "UNKNOWN";
+        }
+
+        return returnStatus;
     }
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -1,6 +1,7 @@
 package com.lokoko.domain.campaign.domain.entity;
 
 import com.lokoko.domain.brand.domain.entity.Brand;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
 import com.lokoko.global.common.entity.BaseEntity;
@@ -10,10 +11,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.BatchSize;
 
 import java.time.Instant;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static jakarta.persistence.FetchType.LAZY;
@@ -59,6 +59,14 @@ public class Campaign extends BaseEntity {
     @Column(nullable = false)
     private CampaignStatus campaignStatus;
 
+    /**
+     * 캠페인을 진행할 상품의 카테고리
+     */
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    private CampaignProductType campaignProductType;
+
+
     @Column(nullable = false)
     private Instant applyStartDate;
 
@@ -72,7 +80,11 @@ public class Campaign extends BaseEntity {
     private Instant reviewSubmissionDeadline;
 
     @Column(nullable = false)
-    private int recruitmentNumber;
+    private int recruitmentNumber; // 모집 인원
+
+    private int applicantNumber; // 지원 인원
+
+    private int approvedNumber; // 승인 인원
 
     /**
      * 크리에이터 참여 보상 목록
@@ -82,8 +94,7 @@ public class Campaign extends BaseEntity {
             name = "campaign_participation_rewards",
             joinColumns = @JoinColumn(name = "campaign_id")
     )
-    @BatchSize(size = 5)
-    private Set<String> participationRewards;
+    private List<String> participationRewards;
 
     /**
      * 크리에이터 제출 콘텐츠 목록
@@ -93,8 +104,7 @@ public class Campaign extends BaseEntity {
             name = "campaign_deliverable_requirements",
             joinColumns = @JoinColumn(name = "campaign_id")
     )
-    @BatchSize(size = 5)
-    private Set<String> deliverableRequirements;
+    private List<String> deliverableRequirements;
 
     /**
      * 크리에이터 참여 조건 목록
@@ -104,8 +114,28 @@ public class Campaign extends BaseEntity {
             name = "campaign_eligibility_requirements",
             joinColumns = @JoinColumn(name = "campaign_id")
     )
-    @BatchSize(size = 5)
-    private Set<String> eligibilityRequirements;
+    private List<String> eligibilityRequirements;
+
+
+    @Column(nullable = false)
+    private boolean isPublished = false;
+
+    @Column
+    private Instant publishedAt;
+
+    /**
+     * 캠페인 지원자 수 증가 메소드
+     */
+    public void increaseApplicant() {
+        this.applicantNumber += 1;
+    }
+
+    /**
+     * 승인 인원 수 증가 메소드
+     */
+    public void increaseApprovedNumber(int toUpdateCount){
+        this.approvedNumber += toUpdateCount;
+    }
 
     /**
      * 캠페인 상태 변경
@@ -135,4 +165,7 @@ public class Campaign extends BaseEntity {
                 this.eligibilityRequirements == null || this.eligibilityRequirements.isEmpty()
         ).anyMatch(condition -> condition);
     }
+
+
+
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -1,6 +1,7 @@
 package com.lokoko.domain.campaign.domain.entity;
 
 import com.lokoko.domain.brand.domain.entity.Brand;
+import com.lokoko.domain.campaign.api.dto.request.CampaignCreateRequest;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
@@ -79,8 +80,7 @@ public class Campaign extends BaseEntity {
     @Column(nullable = false)
     private Instant reviewSubmissionDeadline;
 
-    @Column(nullable = false)
-    private int recruitmentNumber; // 모집 인원
+    private Integer recruitmentNumber; // 모집 인원
 
     private int applicantNumber; // 지원 인원
 
@@ -145,6 +145,57 @@ public class Campaign extends BaseEntity {
         this.campaignStatus = newStatus;
     }
 
+    public void updateCampaign(CampaignCreateRequest request) {
+
+        if (request.campaignTitle() != null) {
+            this.title = request.campaignTitle();
+        }
+        if (request.language() != null) {
+            this.language = request.language();
+        }
+        if (request.campaignType() != null) {
+            this.campaignType = request.campaignType();
+        }
+        if (request.applyStartDate() != null) {
+            this.applyStartDate = request.applyStartDate();
+        }
+        if (request.applyDeadline() != null) {
+            this.applyDeadline = request.applyDeadline();
+        }
+        if (request.creatorAnnouncementDate() != null) {
+            this.creatorAnnouncementDate = request.creatorAnnouncementDate();
+        }
+        if (request.reviewSubmissionDeadline() != null) {
+            this.reviewSubmissionDeadline = request.reviewSubmissionDeadline();
+        }
+        if (request.recruitmentNumber() != null) {
+            this.recruitmentNumber = request.recruitmentNumber();
+        }
+
+        if (request.participationRewards() != null) {
+            this.participationRewards.clear();
+            this.participationRewards.addAll(request.participationRewards());
+        }
+        if (request.deliverableRequirements() != null) {
+            this.deliverableRequirements.clear();
+            this.deliverableRequirements.addAll(request.deliverableRequirements());
+        }
+        if (request.eligibilityRequirements() != null) {
+            this.eligibilityRequirements.clear();
+            this.eligibilityRequirements.addAll(request.eligibilityRequirements());
+        }
+    }
+
+
+    /**
+     * 캠페인 발행 처리
+     */
+    public void publish() {
+        this.isPublished = true;
+        this.publishedAt = Instant.now();
+        this.campaignStatus = CampaignStatus.WAITING_APPROVAL;
+    }
+
     /**
      * 임시 저장 여부 반환
      * 필수 필드 중 하나라도 비어있으면 임시저장으로 간주.
@@ -159,11 +210,30 @@ public class Campaign extends BaseEntity {
                 this.applyDeadline == null,
                 this.creatorAnnouncementDate == null,
                 this.reviewSubmissionDeadline == null,
-                this.recruitmentNumber <= 0,
+                this.recruitmentNumber == null,
                 this.participationRewards == null || this.participationRewards.isEmpty(),
-                this.deliverableRequirements == null || this.deliverableRequirements.isEmpty(),
-                this.eligibilityRequirements == null || this.eligibilityRequirements.isEmpty()
+                this.deliverableRequirements == null || this.deliverableRequirements.isEmpty()
         ).anyMatch(condition -> condition);
+    }
+
+    public static Campaign createCampaign(CampaignCreateRequest request, Brand brand) {
+
+        return Campaign.builder()
+                .brand(brand)
+                .title(request.campaignTitle())
+                .language(request.language())
+                .campaignType(request.campaignType())
+                .campaignStatus(CampaignStatus.DRAFT) // DRAFT 가 기본값
+                .campaignProductType(request.campaignProductType())
+                .applyStartDate(request.applyStartDate())
+                .applyDeadline(request.applyDeadline())
+                .creatorAnnouncementDate(request.creatorAnnouncementDate())
+                .reviewSubmissionDeadline(request.reviewSubmissionDeadline())
+                .recruitmentNumber(request.recruitmentNumber())
+                .participationRewards(request.participationRewards())
+                .deliverableRequirements(request.deliverableRequirements())
+                .eligibilityRequirements(request.eligibilityRequirements())
+                .build();
     }
 
 

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/ActionType.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/ActionType.java
@@ -1,0 +1,5 @@
+package com.lokoko.domain.campaign.domain.entity.enums;
+
+public enum ActionType {
+    SAVE_DRAFT , PUBLISH
+}

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignProductType.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignProductType.java
@@ -1,0 +1,8 @@
+package com.lokoko.domain.campaign.domain.entity.enums;
+
+public enum CampaignProductType {
+    SKINCARE,
+    SUNCARE,
+    FACE_MAKEUP,
+    LIP_MAKEUP
+}

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
@@ -1,7 +1,18 @@
 package com.lokoko.domain.campaign.domain.repository;
 
 import com.lokoko.domain.campaign.domain.entity.Campaign;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CampaignRepository extends JpaRepository<Campaign, Long> {
+
+    /**
+     * Campaign 과 brand 를 fetch join
+     */
+    @EntityGraph(attributePaths = {"brand"})
+    @Query("SELECT c FROM Campaign c WHERE c.id = :id")
+    Optional<Campaign> findCampaignWithBrandById(Long id);
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CreatorCampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CreatorCampaignRepository.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.campaign.domain.repository;
+
+import com.lokoko.domain.campaign.domain.entity.CreatorCampaign;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CreatorCampaignRepository extends JpaRepository<CreatorCampaign, Long> {
+    Optional<CreatorCampaign> findByCreatorIdAndCampaignId(Long creatorId, Long campaignId);
+}

--- a/src/main/java/com/lokoko/domain/campaign/exception/CampaignNotAccessibleException.java
+++ b/src/main/java/com/lokoko/domain/campaign/exception/CampaignNotAccessibleException.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.campaign.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class CampaignNotAccessibleException extends BaseException {
+    public CampaignNotAccessibleException() {
+        super(HttpStatus.BAD_REQUEST, ErrorMessage.INVALID_CAMPAIGN_STATUS.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/exception/CampaignNotEditableException.java
+++ b/src/main/java/com/lokoko/domain/campaign/exception/CampaignNotEditableException.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.campaign.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class CampaignNotEditableException extends BaseException {
+
+    public CampaignNotEditableException() {
+        super(HttpStatus.BAD_REQUEST, ErrorMessage.NOT_EDITABLE_CAMPAIGN.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/exception/CampaignNotFoundException.java
+++ b/src/main/java/com/lokoko/domain/campaign/exception/CampaignNotFoundException.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.campaign.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class CampaignNotFoundException extends BaseException {
+    public CampaignNotFoundException() {
+        super(HttpStatus.NOT_FOUND, ErrorMessage.CAMPAIGN_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/exception/DraftNotFilledException.java
+++ b/src/main/java/com/lokoko/domain/campaign/exception/DraftNotFilledException.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.campaign.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class DraftNotFilledException extends BaseException {
+    public DraftNotFilledException() {
+        super(HttpStatus.BAD_REQUEST, ErrorMessage.DRAFT_NOT_FILLED.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/domain/campaign/exception/ErrorMessage.java
@@ -8,7 +8,11 @@ import lombok.Getter;
 public enum ErrorMessage {
 
     CAMPAIGN_NOT_FOUND("존재하지 않는 캠페인입니다."),
-    INVALID_CAMPAIGN_STATUS("해당 캠페인은 조회 가능한 상태가 아닙니다. (미승인 / 작성 상태)");
+    INVALID_CAMPAIGN_STATUS("해당 캠페인은 조회 가능한 상태가 아닙니다. (미승인 / 작성 상태)"),
+    NOT_CAMPAIGN_OWNER("캠페인을 등록한 브랜드가 아닙니다"),
+    DRAFT_NOT_FILLED("캠페인 등록을 위한 정보가 모두 입력되지 않았습니다"),
+    NOT_EDITABLE_CAMPAIGN("발행된 캠페인은 수정할 수 없습니다.");
+
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/campaign/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/domain/campaign/exception/ErrorMessage.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorMessage {
 
-    CAMPAIGN_NOT_FOUND("존재하지 않는 캠페인입니다.");
+    CAMPAIGN_NOT_FOUND("존재하지 않는 캠페인입니다."),
+    INVALID_CAMPAIGN_STATUS("해당 캠페인은 조회 가능한 상태가 아닙니다. (미승인 / 작성 상태)");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/campaign/exception/NotCampaignOwnershipException.java
+++ b/src/main/java/com/lokoko/domain/campaign/exception/NotCampaignOwnershipException.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.campaign.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class NotCampaignOwnershipException extends BaseException {
+    public NotCampaignOwnershipException() {
+        super(HttpStatus.FORBIDDEN, ErrorMessage.NOT_CAMPAIGN_OWNER.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/domain/image/domain/entity/CampaignImage.java
+++ b/src/main/java/com/lokoko/domain/image/domain/entity/CampaignImage.java
@@ -1,6 +1,7 @@
 package com.lokoko.domain.image.domain.entity;
 
 import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.image.domain.entity.enums.ImageType;
 import com.lokoko.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -27,6 +28,16 @@ public class CampaignImage extends BaseEntity {
     @JoinColumn(name = "campaign_id")
     private Campaign campaign;
 
-    @Column(name = "is_main")
-    private boolean isMain;
+    private int displayOrder;
+
+    private ImageType imageType;
+
+    public static CampaignImage createCampaignImage(String imageUrl, int displayOrder, ImageType imageType, Campaign campaign) {
+        return CampaignImage.builder()
+                .url(imageUrl)
+                .campaign(campaign)
+                .displayOrder(displayOrder)
+                .imageType(imageType)
+                .build();
+    }
 }

--- a/src/main/java/com/lokoko/domain/image/domain/entity/enums/ImageType.java
+++ b/src/main/java/com/lokoko/domain/image/domain/entity/enums/ImageType.java
@@ -1,0 +1,6 @@
+package com.lokoko.domain.image.domain.entity.enums;
+
+public enum ImageType{
+    TOP, BOTTOM
+}
+

--- a/src/main/java/com/lokoko/domain/image/domain/repository/CampaignImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/domain/repository/CampaignImageRepository.java
@@ -1,0 +1,26 @@
+package com.lokoko.domain.image.domain.repository;
+
+import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
+import com.lokoko.domain.image.domain.entity.CampaignImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CampaignImageRepository extends JpaRepository<CampaignImage, Long> {
+
+    @Query("SELECT new com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse(ci.id, ci.url, ci.displayOrder) " +
+            "FROM CampaignImage ci " +
+            "WHERE ci.campaign.id = :campaignId " +
+            "AND ci.imageType = com.lokoko.domain.image.domain.entity.enums.ImageType.TOP " +
+            "ORDER BY ci.displayOrder")
+    List<CampaignImageResponse> findTopImagesByCampaignId(@Param("campaignId") Long campaignId);
+
+    @Query("SELECT new com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse(ci.id, ci.url, ci.displayOrder) " +
+            "FROM CampaignImage ci " +
+            "WHERE ci.campaign.id = :campaignId " +
+            "AND ci.imageType = com.lokoko.domain.image.domain.entity.enums.ImageType.BOTTOM " +
+            "ORDER BY ci.displayOrder")
+    List<CampaignImageResponse> findBottomImagesByCampaignId(@Param("campaignId") Long campaignId);
+}

--- a/src/main/java/com/lokoko/domain/image/domain/repository/CampaignImageRepository.java
+++ b/src/main/java/com/lokoko/domain/image/domain/repository/CampaignImageRepository.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.image.domain.repository;
 import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
 import com.lokoko.domain.image.domain.entity.CampaignImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,4 +24,10 @@ public interface CampaignImageRepository extends JpaRepository<CampaignImage, Lo
             "AND ci.imageType = com.lokoko.domain.image.domain.entity.enums.ImageType.BOTTOM " +
             "ORDER BY ci.displayOrder")
     List<CampaignImageResponse> findBottomImagesByCampaignId(@Param("campaignId") Long campaignId);
+
+    @Modifying
+    @Query("DELETE FROM CampaignImage ci WHERE ci.campaign.id = :campaignId")
+    void deleteByCampaignId(@Param("campaignId") Long campaignId);
+
+
 }


### PR DESCRIPTION
# PR 작성중 ...

## Related issue 🛠

- closed #211 

## 작업 내용 💻

#### 캠페인 상세조회 API 를 구현하였습니다.
<img width="494" height="498" alt="image" src="https://github.com/user-attachments/assets/5db60e03-a773-433a-a60e-de60e7346f6d" />

#### 캠페인 생성 API를 구현하였습니다.

<img width="423" height="313" alt="image" src="https://github.com/user-attachments/assets/7d1b5ad3-919b-4e67-b09b-5d4f9e11ab63" />

생성이라고 하면, 존재하지 않던 리소스를 새롭게 생성하는 행위를 의미합니다.
저희 서비스 피그마 뷰에서 보면, 생성이 크게 두 가지 액션을 통해서 이루어집니다.
첫 번째는, "임시저장". 두 번째는, "발행하기" 입니다.


캠페인 생성 API 는 두 가지로 나누어집니다.
첫 번째는, 

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- API 한개 단위로 올리면, 시간이 너무 오래 걸릴 것 같아서, 여러개의 API 에 대한 커밋을 한 브랜치 안에서 진행했습니다.
그런데 리뷰할 내용이 너무 많아질 것 같네요.
시간이 걸리더라도, API 한 개 단위로 PR 을 올릴지, 아니면 지금 처럼 3~4개 씩 묶어서 올릴지 고민입니다.



