### PR TITLE
[Feat] #220 회원가입/마이페이지 관련 API 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -1,6 +1,10 @@
 package com.lokoko.domain.brand.api;
 
 import com.lokoko.domain.brand.api.dto.request.BrandInfoUpdateRequest;
+import com.lokoko.domain.brand.api.dto.request.BrandMyPageUpdateRequest;
+import com.lokoko.domain.brand.api.dto.request.BrandProfileImageRequest;
+import com.lokoko.domain.brand.api.dto.response.BrandMyPageResponse;
+import com.lokoko.domain.brand.api.dto.response.BrandProfileImageResponse;
 import com.lokoko.domain.brand.api.message.ResponseMessage;
 import com.lokoko.domain.brand.application.BrandService;
 import com.lokoko.domain.campaign.api.dto.request.CampaignDraftRequest;
@@ -15,6 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -90,5 +95,34 @@ public class BrandController {
         CampaignCreateResponse response = campaignService.updateAndPublishCampaign(brandId, campaignId, publishRequest);
         return ApiResponse.success(HttpStatus.OK,
                 ResponseMessage.CAMPAIGN_PUBLISH_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "브랜드 profile image presignedUrl 발급")
+    @PostMapping("/profile/image")
+    public ApiResponse<BrandProfileImageResponse> createBrandImagePresignedUrl(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @RequestBody @Valid BrandProfileImageRequest brandProfileImageRequest) {
+
+        BrandProfileImageResponse response = brandService.createBrandProfilePresignedUrl(brandId, brandProfileImageRequest);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_PROFILE_IMAGE_PRESIGNED_URL_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "브랜드 마이페이지(프로필) 정보 조회")
+    @GetMapping("/profile")
+    public ApiResponse<BrandMyPageResponse> getBrandMyPageInfo(
+            @Parameter(hidden = true) @CurrentUser Long brandId) {
+
+        BrandMyPageResponse response = brandService.getBrandMyPage(brandId);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_MYPAGE_INFO_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "브랜드 마이페이지(프로필) 정보 수정")
+    @PatchMapping("/profile")
+    public ApiResponse<Void> updateBrandMyPageProfile(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @RequestBody @Valid BrandMyPageUpdateRequest request) {
+
+        brandService.updateBrandMyPage(brandId, request);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_UPDATE_MYPAGE_INFO_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/lokoko/domain/brand/api/dto/request/BrandMyPageUpdateRequest.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/request/BrandMyPageUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.lokoko.domain.brand.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record BrandMyPageUpdateRequest(
+        @Schema(description = "프로필 이미지 URL")
+        String profileImageUrl,
+
+        @Size(max = 15, message = "브랜드명은 최대 15자까지 가능합니다")
+        String brandName,
+
+        @Size(max = 10, message = "담당자명은 최대 10자까지 가능합니다")
+        String managerName,
+
+        @Size(max = 10, message = "담당자 연락처는 최대 10자까지 가능합니다")
+        @Pattern(regexp = "^[0-9]+$", message = "연락처는 숫자만 입력 가능합니다")
+        String phoneNumber,
+
+        @Size(max = 30, message = "도로명 주소는 최대 30자까지 가능합니다")
+        String roadAddress,
+
+        @Size(max = 30, message = "상세 주소는 최대 30자까지 가능합니다")
+        String addressDetail
+) {
+}

--- a/src/main/java/com/lokoko/domain/brand/api/dto/request/BrandProfileImageRequest.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/request/BrandProfileImageRequest.java
@@ -1,0 +1,7 @@
+package com.lokoko.domain.brand.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record BrandProfileImageRequest(
+        @NotNull String mediaType) {
+}

--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyPageResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyPageResponse.java
@@ -1,0 +1,38 @@
+package com.lokoko.domain.brand.api.dto.response;
+
+import com.lokoko.domain.brand.domain.entity.Brand;
+import com.lokoko.domain.user.domain.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record BrandMyPageResponse(
+        @Schema(description = "프로필 이미지 URL")
+        String profileImageUrl,
+
+        @Schema(requiredMode = REQUIRED, description = "담당자 이름")
+        String managerName,
+
+        @Schema(requiredMode = REQUIRED, description = "브랜드 이메일 (구글 로그인 이메일)")
+        String email,
+
+        @Schema(requiredMode = REQUIRED, description = "전화번호")
+        String phoneNumber,
+
+        @Schema(requiredMode = REQUIRED, description = "도로명 주소")
+        String roadAddress,
+
+        @Schema(requiredMode = REQUIRED, description = "상세 주소")
+        String addressDetail
+) {
+    public static BrandMyPageResponse from(Brand brand, User user) {
+        return new BrandMyPageResponse(
+                user.getProfileImageUrl(),
+                brand.getManagerName(),
+                user.getEmail(),
+                brand.getPhoneNumber(),
+                brand.getRoadAddress(),
+                brand.getAddressDetail()
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandProfileImageResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandProfileImageResponse.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.brand.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record BrandProfileImageResponse(
+        @Schema(requiredMode = REQUIRED)
+        String profileImageUrl
+) {
+}

--- a/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
@@ -11,7 +11,11 @@ public enum ResponseMessage {
 
     CAMPAIGN_PUBLISH_SUCCESS("캠페인이 발행되었습니다."),
     CAMPAIGN_DRAFT_SUCCESS("캠페인 임시저장이 완료되었습니다."),
-    CAMPAIGN_UPDATE_SUCCESS("캠페인 수정이 완료되었습니다.");
+    CAMPAIGN_UPDATE_SUCCESS("캠페인 수정이 완료되었습니다."),
+
+    BRAND_PROFILE_IMAGE_PRESIGNED_URL_SUCCESS("브랜드 프로필 이미지 presigend url이 성공적으로 발급되었습니다."),
+    BRAND_MYPAGE_INFO_SUCCESS("브랜드 마이페이지 정보를 성공적으로 불러왔습니다."),
+    BRAND_UPDATE_MYPAGE_INFO_SUCCESS("브랜드 마이페이지 정보를 성공적으로 수정했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/brand/application/BrandService.java
+++ b/src/main/java/com/lokoko/domain/brand/application/BrandService.java
@@ -1,22 +1,35 @@
 package com.lokoko.domain.brand.application;
 
 import com.lokoko.domain.brand.api.dto.request.BrandInfoUpdateRequest;
+import com.lokoko.domain.brand.api.dto.request.BrandMyPageUpdateRequest;
+import com.lokoko.domain.brand.api.dto.request.BrandProfileImageRequest;
+import com.lokoko.domain.brand.api.dto.response.BrandMyPageResponse;
+import com.lokoko.domain.brand.api.dto.response.BrandProfileImageResponse;
 import com.lokoko.domain.brand.domain.entity.Brand;
 import com.lokoko.domain.brand.domain.repository.BrandRepository;
 import com.lokoko.domain.brand.exception.BrandNotFoundException;
+import com.lokoko.domain.productReview.exception.ErrorMessage;
+import com.lokoko.domain.productReview.exception.InvalidMediaTypeException;
 import com.lokoko.domain.user.domain.repository.UserRepository;
-import jakarta.transaction.Transactional;
+import com.lokoko.global.common.entity.MediaFile;
+import com.lokoko.global.common.service.S3Service;
+import com.lokoko.global.utils.S3UrlParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.lokoko.global.utils.AllowedMediaType.ALLOWED_MEDIA_TYPES;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class BrandService {
 
     private final UserRepository userRepository;
     private final BrandRepository brandRepository;
+    private final S3Service s3Service;
 
+    @Transactional
     public void updateBrandInfo(Long userId, BrandInfoUpdateRequest request) {
         Brand brand = brandRepository.findById(userId)
                 .orElseThrow(BrandNotFoundException::new);
@@ -28,6 +41,51 @@ public class BrandService {
         brand.assignRoadAddress(request.roadAddress());
         brand.assignAddressDetail(request.addressDetail());
 
-        brandRepository.save(brand);
     }
+
+    public BrandProfileImageResponse createBrandProfilePresignedUrl(Long brandId, BrandProfileImageRequest request) {
+
+        brandRepository.findById(brandId).orElseThrow(BrandNotFoundException::new);
+
+        String mediaType = request.mediaType();
+        if (!ALLOWED_MEDIA_TYPES.contains(mediaType)) {
+            throw new InvalidMediaTypeException(ErrorMessage.UNSUPPORTED_MEDIA_TYPE);
+        }
+
+        String presignedUrl = s3Service.generatePresignedUrl(mediaType).presignedUrl();
+
+        return new BrandProfileImageResponse(presignedUrl);
+    }
+
+    public BrandMyPageResponse getBrandMyPage(Long brandId) {
+        Brand brand = brandRepository.findBrandWithUserById(brandId)
+                .orElseThrow(BrandNotFoundException::new);
+
+        return BrandMyPageResponse.from(brand, brand.getUser());
+    }
+
+    @Transactional
+    public void updateBrandMyPage(Long brandId, BrandMyPageUpdateRequest request) {
+        Brand brand = brandRepository.findById(brandId)
+                .orElseThrow(BrandNotFoundException::new);
+
+        if (request.profileImageUrl() != null) {
+            MediaFile mediaFile = S3UrlParser.parsePresignedUrl(request.profileImageUrl());
+            brand.getUser().updateProfileImage(mediaFile.toString());
+        }
+        if (request.managerName() != null) {
+            brand.assignManagerName(request.managerName());
+        }
+        if (request.phoneNumber() != null) {
+            brand.assignPhoneNumber(request.phoneNumber());
+        }
+        if (request.roadAddress() != null) {
+            brand.assignRoadAddress(request.roadAddress());
+        }
+        if (request.addressDetail() != null) {
+            brand.assignAddressDetail(request.addressDetail());
+        }
+    }
+
+
 }

--- a/src/main/java/com/lokoko/domain/brand/domain/entity/Brand.java
+++ b/src/main/java/com/lokoko/domain/brand/domain/entity/Brand.java
@@ -31,8 +31,6 @@ public class Brand {
 
     private String brandName;
 
-    private String profileImageUrl;
-
     private String managerName;
 
     private String managerPosition;
@@ -48,10 +46,6 @@ public class Brand {
 
     public void assignBrandName(String brandName) {
         this.brandName = brandName;
-    }
-
-    public void assignProfileNImage(String profileImageUrl) {
-        this.profileImageUrl = profileImageUrl;
     }
 
     public void assignManagerName(String managerName) {

--- a/src/main/java/com/lokoko/domain/brand/domain/repository/BrandRepository.java
+++ b/src/main/java/com/lokoko/domain/brand/domain/repository/BrandRepository.java
@@ -1,9 +1,16 @@
 package com.lokoko.domain.brand.domain.repository;
 
 import com.lokoko.domain.brand.domain.entity.Brand;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface BrandRepository extends JpaRepository<Brand, Long> {
+    @Query("SELECT b FROM Brand b JOIN FETCH b.user WHERE b.id = :brandId")
+    Optional<Brand> findBrandWithUserById(@Param("brandId") Long brandId);
+
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignDetailResponse.java
@@ -38,7 +38,7 @@ public record CampaignDetailResponse(
                 campaign.getId(),
                 campaign.getCampaignType(),
                 campaign.getTitle(),
-                brand.getProfileImageUrl(),
+                brand.getUser().getProfileImageUrl(),
                 brand.getBrandName(),
                 campaign.getLanguage(),
                 campaign.getApplyStartDate(),

--- a/src/main/java/com/lokoko/domain/creator/api/CreatorController.java
+++ b/src/main/java/com/lokoko/domain/creator/api/CreatorController.java
@@ -1,6 +1,5 @@
 package com.lokoko.domain.creator.api;
 
-import com.lokoko.domain.creator.api.dto.request.CreatorIdCheckRequest;
 import com.lokoko.domain.creator.api.dto.request.CreatorInfoUpdateRequest;
 import com.lokoko.domain.creator.api.dto.request.CreatorMyPageUpdateRequest;
 import com.lokoko.domain.creator.api.dto.response.CreatorInfoResponse;
@@ -17,7 +16,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -61,15 +59,6 @@ public class CreatorController {
     }
 
     // 회원 가입
-    @GetMapping("/register/check-id")
-    public ApiResponse<Void> checkCreatorId(
-            @Validated CreatorIdCheckRequest request,
-            @Parameter(hidden = true) @CurrentUser Long userId) {
-
-        creatorUsecase.checkCreatorIdAvailable(request.creatorName(), userId);
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CREATOR_ID_CHECK_SUCCESS.getMessage());
-    }
-
     @PatchMapping("/register/info")
     @Operation(summary = "회원가입시 크리에이터의 추가 정보를 입력/수정하는 API입니다")
     public ApiResponse<Void> updateCreatorRegisterInfo(

--- a/src/main/java/com/lokoko/domain/creator/api/dto/request/CreatorInfoUpdateRequest.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/request/CreatorInfoUpdateRequest.java
@@ -18,8 +18,12 @@ public record CreatorInfoUpdateRequest(
                 message = "크리에이터 ID는 영문(소문자), 숫자, 점(.), 언더바(_)만 사용 가능합니다")
         String creatorName,
 
+        @NotBlank(message = "생년월일은 필수입니다")
+        @Schema(description = "생년월일", example = "2002-08-21")
         String birthDate,
 
+        @NotNull(message = "성별은 필수입니다")
+        @Schema(description = "성별", example = "MALE")
         Gender gender,
 
         @NotBlank(message = "이름은 필수입니다")

--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorGetService.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorGetService.java
@@ -39,17 +39,5 @@ public class CreatorGetService {
                 .orElseThrow(CreatorCampaignNotFoundException::new);
     }
 
-    public boolean isCreatorNameAvailable(String creatorName, Long currentCreatorId) {
-        Creator currentCreator = creatorRepository.findById(currentCreatorId).orElse(null);
-
-        // 자신의 현재 이름과 같으면 사용 가능
-        if (currentCreator != null &&
-                currentCreator.getCreatorName() != null &&
-                currentCreator.getCreatorName().equalsIgnoreCase(creatorName)) {
-            return true;
-        }
-
-        return !creatorRepository.existsByCreatorName(creatorName);
-    }
 }
 

--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorUpdateService.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorUpdateService.java
@@ -6,7 +6,7 @@ import com.lokoko.domain.campaignReview.application.service.CreatorCampaignUpdat
 import com.lokoko.domain.creator.api.dto.request.CreatorInfoUpdateRequest;
 import com.lokoko.domain.creator.api.dto.request.CreatorMyPageUpdateRequest;
 import com.lokoko.domain.creator.domain.entity.Creator;
-import com.lokoko.domain.creator.exception.CreatorIdAlreadyExistsException;
+import com.lokoko.domain.user.application.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +18,7 @@ public class CreatorUpdateService {
 
     private final CreatorGetService creatorGetService;
     private final CreatorCampaignUpdateService creatorCampaignUpdateService;
+    private final UserService userService;
 
     /**
      * 마이페이지 수정 - null 필드는 무시(부분 업데이트) - 유효성은 Request DTO(@NotBlank/@Size 등)에서 선검증
@@ -90,9 +91,7 @@ public class CreatorUpdateService {
 
     public void updateRegisterCreatorInfo(Creator creator, CreatorInfoUpdateRequest request) {
 
-        if (!creatorGetService.isCreatorNameAvailable(request.creatorName(), creator.getId())) {
-            throw new CreatorIdAlreadyExistsException();
-        }
+        userService.checkUserIdAvailable(request.creatorName(), creator.getId());
 
         creator.changeCreatorName(request.creatorName());
         creator.changeBirthDate(request.birthDate());

--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
@@ -8,7 +8,6 @@ import com.lokoko.domain.creator.api.dto.response.CreatorRegisterCompleteRespons
 import com.lokoko.domain.creator.api.dto.response.CreatorSnsConnectedResponse;
 import com.lokoko.domain.creator.application.mapper.CreatorMapper;
 import com.lokoko.domain.creator.domain.entity.Creator;
-import com.lokoko.domain.creator.exception.CreatorIdAlreadyExistsException;
 import com.lokoko.domain.creator.exception.CreatorInfoNotCompletedException;
 import com.lokoko.domain.creator.exception.NotCreatorRoleException;
 import com.lokoko.domain.creator.exception.SnsNotConnectedException;
@@ -55,23 +54,9 @@ public class CreatorUsecase {
     }
 
     // 회원 가입
-    @Transactional(readOnly = true)
-    public void checkCreatorIdAvailable(String creatorName, Long userId) {
-        Creator creator = creatorGetService.findByUserId(userId);
-
-        if (!creatorGetService.isCreatorNameAvailable(creatorName, creator.getId())) {
-            throw new CreatorIdAlreadyExistsException();
-        }
-    }
-
     @Transactional
     public void updateCreatorRegisterInfo(Long userId, CreatorInfoUpdateRequest request) {
         Creator creator = creatorGetService.findByUserId(userId);
-
-        if (!creatorGetService.isCreatorNameAvailable(request.creatorName(), creator.getId())) {
-            throw new CreatorIdAlreadyExistsException();
-        }
-
         creatorUpdateService.updateRegisterCreatorInfo(creator, request);
     }
 

--- a/src/main/java/com/lokoko/domain/creator/domain/repository/CreatorRepository.java
+++ b/src/main/java/com/lokoko/domain/creator/domain/repository/CreatorRepository.java
@@ -1,12 +1,15 @@
 package com.lokoko.domain.creator.domain.repository;
 
 import com.lokoko.domain.creator.domain.entity.Creator;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CreatorRepository extends JpaRepository<Creator, Long> {
-    boolean existsByCreatorName(String creatorName);
     Optional<Creator> findByUserId(Long userId);
+
+    boolean existsByCreatorNameIgnoreCase(String creatorName);
+
 }

--- a/src/main/java/com/lokoko/domain/customer/api/CustomerController.java
+++ b/src/main/java/com/lokoko/domain/customer/api/CustomerController.java
@@ -1,0 +1,73 @@
+package com.lokoko.domain.customer.api;
+
+import com.lokoko.domain.customer.api.dto.request.CustomerMyPageRequest;
+import com.lokoko.domain.customer.api.dto.request.CustomerProfileImageRequest;
+import com.lokoko.domain.customer.api.dto.response.CustomerMyPageResponse;
+import com.lokoko.domain.customer.api.dto.response.CustomerProfileImageResponse;
+import com.lokoko.domain.customer.api.dto.response.CustomerSnsConnectedResponse;
+import com.lokoko.domain.customer.api.message.ResponseMessage;
+import com.lokoko.domain.customer.application.CustomerService;
+import com.lokoko.global.auth.annotation.CurrentUser;
+import com.lokoko.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Tag(name = "CUSTOMER")
+@RestController
+@RequestMapping("/api/customer")
+@RequiredArgsConstructor
+public class CustomerController {
+
+    private final CustomerService customerService;
+
+
+    @PostMapping("/profile/image")
+    @Operation(summary = "Customer profile image presignedUrl 발급")
+    public ApiResponse<CustomerProfileImageResponse> createProfileImagePresignedUrl(
+            @Parameter(hidden = true) @CurrentUser Long customerId,
+            @Valid @RequestBody CustomerProfileImageRequest request) {
+
+        CustomerProfileImageResponse response = customerService.createCustomerProfilePresignedUrl(customerId, request);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CUSTOMER_PROFILE_IMAGE_PRESIGNED_URL_SUCCESS.getMessage(), response);
+    }
+
+
+    @Operation(summary = "Customer 마이페이지(프로필) 정보 조회")
+    @GetMapping("/profile")
+    public ApiResponse<CustomerMyPageResponse> getCustomerMyPageInfo(@Parameter(hidden = true) @CurrentUser Long customerId) {
+
+        CustomerMyPageResponse response = customerService.getCustomerMyPage(customerId);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CUSTOMER_GET_MYPAGE_INFO_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "Customer 마이페이지(프로필) 정보 수정")
+    @PatchMapping("/profile")
+    public ApiResponse<Void> updateCustomerMyPageProfile(
+            @Parameter(hidden = true) @CurrentUser Long customerId,
+            @Valid @RequestBody CustomerMyPageRequest request) {
+
+        customerService.updateCustomerMyPage(customerId, request);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CUSTOMER_UPDATE_MYPAGE_INFO_SUCCESS.getMessage());
+    }
+
+    @GetMapping("/sns-status")
+    @Operation(summary = "Customer SNS 연동 여부를 체크하는 API입니다")
+    public ApiResponse<CustomerSnsConnectedResponse> getCustomerSnsConnected(
+            @Parameter(hidden = true) @CurrentUser Long customer) {
+
+        CustomerSnsConnectedResponse response = customerService.getCustomerSnsStatus(customer);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CUSTOMER_GET_SNS_STATUS_SUCCESS.getMessage(), response);
+    }
+
+}

--- a/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerMyPageRequest.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerMyPageRequest.java
@@ -1,0 +1,82 @@
+package com.lokoko.domain.customer.api.dto.request;
+
+import com.lokoko.domain.creator.domain.entity.enums.ContentLanguage;
+import com.lokoko.domain.creator.domain.entity.enums.Gender;
+import com.lokoko.domain.creator.domain.entity.enums.SkinTone;
+import com.lokoko.domain.creator.domain.entity.enums.SkinType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record CustomerMyPageRequest(
+
+        @Schema(description = "Customer 프로필 이미지 url", example = "https://s3.example.com/profile/us-user-1001.jpg")
+        String profileImageUrl,
+
+        @Size(min = 1, max = 15, message = "ID는 1자 이상 15자 이하여야 합니다")
+        @Pattern(regexp = "^[a-z0-9._]+$",
+                message = "ID는 영문(소문자), 숫자, 점(.), 언더바(_)만 사용 가능합니다")
+        String customerName,
+
+        @Schema(description = "생년월일", example = "2002-08-21")
+        LocalDate birthDate,
+
+        @Schema(description = "성별", example = "MALE")
+        Gender gender,
+
+        @NotBlank(message = "이름은 필수입니다")
+        @Schema(description = "이름", example = "Jessica")
+        String firstName,
+
+        @NotBlank(message = "성은 필수입니다")
+        @Schema(description = "성", example = "Anderson")
+        String lastName,
+
+        @Schema(description = "국가번호 (선택, 최대 5자)", example = "+1")
+        @Size(max = 5)
+        String countryCode,
+
+        @Schema(description = "전화번호 (선택, 최대 20자)", example = "01012345678")
+        @Size(max = 20)
+        String phoneNumber,
+
+        @Schema(description = "콘텐츠 언어", example = "ENGLISH")
+        ContentLanguage contentLanguage,
+
+        @Schema(description = "구글 로그인시 받은 email", example = "lococo@example.com")
+        String email,
+
+        @Schema(description = "국가", example = "US")
+        String country,
+
+        @Schema(description = "State (텍스트 최대 20자)", example = "CA")
+        @Size(max = 20)
+        String stateOrProvince,
+
+        @Schema(description = "City/Town (텍스트, 최대 20자)", example = "San Francisco")
+        @Size(max = 20)
+        String cityOrTown,
+
+        @Schema(description = "Address Line 1 (최대 30자)", example = "1234 Market St")
+        @Size(max = 30)
+        String addressLine1,
+
+        @Schema(description = "Address Line 2 (최대 30자)", example = "Apt 5B")
+        @Size(max = 30)
+        String addressLine2,
+
+        @Schema(description = "ZIP Code (최대 10자)", example = "94103")
+        @Size(max = 10)
+        String postalCode,
+
+        @Schema(description = "피부 타입 (드롭다운 6개)", example = "COMBINATION")
+        SkinType skinType,
+
+        @Schema(description = "피부 톤 (드롭다운 20개)", example = "SHADE_12")
+        SkinTone skinTone
+
+) {
+}

--- a/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerProfileImageRequest.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerProfileImageRequest.java
@@ -1,0 +1,7 @@
+package com.lokoko.domain.customer.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CustomerProfileImageRequest(
+        @NotNull String mediaType) {
+}

--- a/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerMyPageResponse.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerMyPageResponse.java
@@ -1,0 +1,98 @@
+package com.lokoko.domain.customer.api.dto.response;
+
+import com.lokoko.domain.creator.domain.entity.enums.ContentLanguage;
+import com.lokoko.domain.creator.domain.entity.enums.Gender;
+import com.lokoko.domain.creator.domain.entity.enums.SkinTone;
+import com.lokoko.domain.creator.domain.entity.enums.SkinType;
+import com.lokoko.domain.customer.domain.entity.Customer;
+import com.lokoko.domain.user.domain.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record CustomerMyPageResponse(
+
+        @Schema(description = "Customer 프로필 이미지 url", example = "https://s3.example.com/profile/us-user-1001.jpg")
+        String profileImageUrl,
+
+        @Schema(requiredMode = REQUIRED, description = "구글 로그인시 받은 email", example = "lococo@example.com")
+        String email,
+
+        @Schema(requiredMode = REQUIRED, description = "이름", example = "Jessica")
+        String firstName,
+
+        @Schema(requiredMode = REQUIRED, description = "성", example = "Anderson")
+        String lastName,
+
+        @Schema(description = "customer id", example = "hyoeun")
+        String userName,
+
+        @Schema(description = "생년월일", example = "2002-08-21")
+        LocalDate birthDate,
+
+        @Schema(description = "성별", example = "MALE")
+        Gender gender,
+
+        @Schema(description = "국가번호 (선택, 최대 5자)", example = "+1")
+        String countryCode,
+
+        @Schema(description = "전화번호 (선택, 최대 20자)", example = "01012345678")
+        String phoneNumber,
+
+        @Schema(description = "콘텐츠 언어", example = "ENGLISH")
+        ContentLanguage contentLanguage,
+
+        @Schema(description = "국가", example = "US")
+        String country,
+
+        @Schema(description = "State (텍스트 최대 20자)", example = "CA")
+        String stateOrProvince,
+
+        @Schema(description = "City/Town (텍스트, 최대 20자)", example = "San Francisco")
+        String cityOrTown,
+
+        @Schema(description = "Address Line 1 (최대 30자)", example = "1234 Market St")
+        String addressLine1,
+
+        @Schema(description = "Address Line 2 (최대 30자)", example = "Apt 5B")
+        String addressLine2,
+
+        @Schema(description = "ZIP Code (최대 10자)", example = "94103")
+        String postalCode,
+
+        @Schema(description = "피부 타입 (드롭다운 6개)", example = "COMBINATION")
+        SkinType skinType,
+
+        @Schema(description = "피부 톤 (드롭다운 20개)", example = "SHADE_12")
+        SkinTone skinTone
+
+) {
+
+    public static CustomerMyPageResponse toMyPage(Customer customer
+    ) {
+        User user = customer.getUser();
+
+        return new CustomerMyPageResponse(
+                user.getProfileImageUrl(),
+                user.getEmail(),
+                user.getFirstName(),
+                user.getLastName(),
+                customer.getCustomerName(),
+                customer.getBirthDate(),
+                customer.getGender(),
+                customer.getCountryCode(),
+                customer.getPhoneNumber(),
+                customer.getContentLanguage(),
+                customer.getCountry(),
+                customer.getStateOrProvince(),
+                customer.getCityOrTown(),
+                customer.getAddressLine1(),
+                customer.getAddressLine2(),
+                customer.getPostalCode(),
+                customer.getSkinType(),
+                customer.getSkinTone()
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerProfileImageResponse.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerProfileImageResponse.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.customer.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record CustomerProfileImageResponse(
+        @Schema(requiredMode = REQUIRED)
+        String profileImageUrl
+) {
+}

--- a/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerSnsConnectedResponse.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerSnsConnectedResponse.java
@@ -1,0 +1,15 @@
+package com.lokoko.domain.customer.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record CustomerSnsConnectedResponse(
+
+        @Schema(requiredMode = REQUIRED)
+        boolean isInstaConnected,
+
+        @Schema(requiredMode = REQUIRED)
+        boolean isTiktokConnected
+) {
+}

--- a/src/main/java/com/lokoko/domain/customer/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/customer/api/message/ResponseMessage.java
@@ -1,0 +1,19 @@
+package com.lokoko.domain.customer.api.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+    //어드민
+    ADMIN_REVIEW_DELETE_SUCCESS("어드민 리뷰 삭제에 성공했습니다"),
+
+    //일반 유저
+    CUSTOMER_PROFILE_IMAGE_PRESIGNED_URL_SUCCESS("일반 유저 프로필 이미지 presigend url이 성공적으로 발급되었습니다."),
+    CUSTOMER_GET_MYPAGE_INFO_SUCCESS("일반 유저 마이페이지 정보를 성공적으로 불러왔습니다."),
+    CUSTOMER_UPDATE_MYPAGE_INFO_SUCCESS("일반 유저 마이페이지 정보를 성공적으로 수정했습니다."),
+    CUSTOMER_GET_SNS_STATUS_SUCCESS("일반 유저 SNS 연결 상태를 성공적으로 불러왔습니다");
+
+    private final String message;
+}

--- a/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
+++ b/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
@@ -1,0 +1,143 @@
+package com.lokoko.domain.customer.application;
+
+
+import com.lokoko.domain.customer.api.dto.request.CustomerMyPageRequest;
+import com.lokoko.domain.customer.api.dto.request.CustomerProfileImageRequest;
+import com.lokoko.domain.customer.api.dto.response.CustomerMyPageResponse;
+import com.lokoko.domain.customer.api.dto.response.CustomerProfileImageResponse;
+import com.lokoko.domain.customer.api.dto.response.CustomerSnsConnectedResponse;
+import com.lokoko.domain.customer.domain.entity.Customer;
+import com.lokoko.domain.customer.domain.repository.CustomerRepository;
+import com.lokoko.domain.customer.exception.CustomerNotFoundException;
+import com.lokoko.domain.productReview.exception.ErrorMessage;
+import com.lokoko.domain.productReview.exception.InvalidMediaTypeException;
+import com.lokoko.domain.user.application.service.UserService;
+import com.lokoko.domain.user.domain.entity.User;
+import com.lokoko.global.common.entity.MediaFile;
+import com.lokoko.global.common.service.S3Service;
+import com.lokoko.global.utils.S3UrlParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.lokoko.global.utils.AllowedMediaType.ALLOWED_MEDIA_TYPES;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomerService {
+
+    private final CustomerRepository customerRepository;
+    private final S3Service s3Service;
+    private final UserService userService;
+
+    public CustomerProfileImageResponse createCustomerProfilePresignedUrl(Long customerId, CustomerProfileImageRequest request) {
+        customerRepository.findById(customerId).orElseThrow(CustomerNotFoundException::new);
+
+        String mediaType = request.mediaType();
+        if (!ALLOWED_MEDIA_TYPES.contains(mediaType)) {
+            throw new InvalidMediaTypeException(ErrorMessage.UNSUPPORTED_MEDIA_TYPE);
+        }
+
+        String presignedUrl = s3Service.generatePresignedUrl(mediaType).presignedUrl();
+
+        return new CustomerProfileImageResponse(presignedUrl);
+
+    }
+
+    public CustomerMyPageResponse getCustomerMyPage(Long customerId) {
+        Customer customer = customerRepository.findCustomerWithUserById(customerId)
+                .orElseThrow(CustomerNotFoundException::new);
+
+        return CustomerMyPageResponse.toMyPage(customer);
+    }
+
+    @Transactional
+    public void updateCustomerMyPage(Long customerId, CustomerMyPageRequest request) {
+        Customer customer = customerRepository.findCustomerWithUserById(customerId)
+                .orElseThrow(CustomerNotFoundException::new);
+
+        User user = customer.getUser();
+
+        if (request.profileImageUrl() != null) {
+            MediaFile mediaFile = S3UrlParser.parsePresignedUrl(request.profileImageUrl());
+            user.updateProfileImage(mediaFile.toString());
+        }
+
+        if (request.customerName() != null) {
+            userService.checkUserIdAvailable(request.customerName(), customerId);
+            customer.assignCustomerName(request.customerName());
+        }
+
+        if (request.birthDate() != null) {
+            customer.assignBirthDate(request.birthDate());
+        }
+
+        if (request.gender() != null) {
+            customer.assignGender(request.gender());
+        }
+
+        if (request.firstName() != null) {
+            user.updateFirstName(request.firstName());
+        }
+
+        if (request.lastName() != null) {
+            user.updateLastName(request.lastName());
+        }
+
+        if (request.countryCode() != null) {
+            customer.assignCountryCode(request.countryCode());
+        }
+
+        if (request.phoneNumber() != null) {
+            customer.assignPhoneNumber(request.phoneNumber());
+        }
+
+        if (request.contentLanguage() != null) {
+            customer.assignContentLanguage(request.contentLanguage());
+        }
+
+        if (request.country() != null) {
+            customer.assignCountry(request.country());
+        }
+
+        if (request.stateOrProvince() != null) {
+            customer.assignStateOrProvince(request.stateOrProvince());
+        }
+
+        if (request.cityOrTown() != null) {
+            customer.assignCityOrTown(request.cityOrTown());
+        }
+
+        if (request.addressLine1() != null) {
+            customer.assignAddressLine1(request.addressLine1());
+        }
+
+        if (request.addressLine2() != null) {
+            customer.assignAddressLine2(request.addressLine2());
+        }
+
+        if (request.postalCode() != null) {
+            customer.assignPostalCode(request.postalCode());
+        }
+
+        if (request.skinType() != null) {
+            customer.assignSkinType(request.skinType());
+        }
+
+        if (request.skinTone() != null) {
+            customer.assignSkinTone(request.skinTone());
+        }
+    }
+
+    public CustomerSnsConnectedResponse getCustomerSnsStatus(Long customerId) {
+        Customer customer = customerRepository.findById(customerId)
+                .orElseThrow(CustomerNotFoundException::new);
+
+        return new CustomerSnsConnectedResponse(
+                customer.getInstaUserId() != null,
+                customer.getTikTokUserId() != null
+        );
+    }
+
+}

--- a/src/main/java/com/lokoko/domain/customer/domain/entity/Customer.java
+++ b/src/main/java/com/lokoko/domain/customer/domain/entity/Customer.java
@@ -1,7 +1,14 @@
 package com.lokoko.domain.customer.domain.entity;
 
+import com.lokoko.domain.creator.domain.entity.enums.ContentLanguage;
+import com.lokoko.domain.creator.domain.entity.enums.Gender;
+import com.lokoko.domain.creator.domain.entity.enums.SkinTone;
+import com.lokoko.domain.creator.domain.entity.enums.SkinType;
 import com.lokoko.domain.user.domain.entity.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
@@ -12,6 +19,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Getter
 @Entity
@@ -29,4 +38,114 @@ public class Customer {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Column
+    private String customerName;
+
+    @Column
+    private LocalDate birthDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private Gender gender;
+
+    @Column
+    private String countryCode;
+
+    @Column
+    private String phoneNumber;
+
+    @Column
+    private String country;
+
+    // 주/도/광역시 등
+    @Column
+    private String stateOrProvince;
+
+    @Column
+    private String cityOrTown;
+
+    @Column
+    private String addressLine1;
+
+    @Column
+    private String addressLine2;
+
+    @Column
+    private String postalCode;
+
+    @Enumerated(EnumType.STRING)
+    private SkinType skinType;
+
+    @Enumerated(EnumType.STRING)
+    private SkinTone skinTone;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private ContentLanguage contentLanguage = ContentLanguage.ENGLISH;
+
+    @Column
+    private String instaUserId;
+
+    @Column
+    private String tikTokUserId;
+
+    public String getCreatorPhoneNumber() {
+        return countryCode + phoneNumber;
+    }
+
+    public void assignCustomerName(String customerName) {
+        this.customerName = customerName;
+    }
+
+    public void assignBirthDate(LocalDate birthDate) {
+        this.birthDate = birthDate;
+    }
+
+    public void assignGender(Gender gender) {
+        this.gender = gender;
+    }
+
+    public void assignCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public void assignPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void assignCountry(String country) {
+        this.country = country;
+    }
+
+    public void assignStateOrProvince(String stateOrProvince) {
+        this.stateOrProvince = stateOrProvince;
+    }
+
+    public void assignCityOrTown(String cityOrTown) {
+        this.cityOrTown = cityOrTown;
+    }
+
+    public void assignAddressLine1(String addressLine1) {
+        this.addressLine1 = addressLine1;
+    }
+
+    public void assignAddressLine2(String addressLine2) {
+        this.addressLine2 = addressLine2;
+    }
+
+    public void assignPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public void assignSkinType(SkinType skinType) {
+        this.skinType = skinType;
+    }
+
+    public void assignSkinTone(SkinTone skinTone) {
+        this.skinTone = skinTone;
+    }
+
+    public void assignContentLanguage(ContentLanguage contentLanguage) {
+        this.contentLanguage = contentLanguage;
+    }
 }

--- a/src/main/java/com/lokoko/domain/customer/domain/repository/CustomerRepository.java
+++ b/src/main/java/com/lokoko/domain/customer/domain/repository/CustomerRepository.java
@@ -1,9 +1,19 @@
 package com.lokoko.domain.customer.domain.repository;
 
 import com.lokoko.domain.customer.domain.entity.Customer;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+    @Query("SELECT c FROM Customer c JOIN FETCH c.user WHERE c.id = :customerId")
+    Optional<Customer> findCustomerWithUserById(@Param("customerId") Long customerId);
+
+    boolean existsByCustomerNameIgnoreCase(String customerName);
+
 }

--- a/src/main/java/com/lokoko/domain/customer/exception/CustomerNotFoundException.java
+++ b/src/main/java/com/lokoko/domain/customer/exception/CustomerNotFoundException.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.customer.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+
+public class CustomerNotFoundException extends BaseException {
+    public CustomerNotFoundException() {
+        super(HttpStatus.NOT_FOUND, ErrorMessage.CUSTOMER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/domain/customer/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/domain/customer/exception/ErrorMessage.java
@@ -1,0 +1,13 @@
+package com.lokoko.domain.customer.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    CUSTOMER_NOT_FOUND("찾을 수 없는 일반 유저입니다.");
+
+    private final String message;
+}
+

--- a/src/main/java/com/lokoko/domain/user/api/UserController.java
+++ b/src/main/java/com/lokoko/domain/user/api/UserController.java
@@ -1,0 +1,35 @@
+package com.lokoko.domain.user.api;
+
+import com.lokoko.domain.user.api.dto.request.UserIdCheckRequest;
+import com.lokoko.domain.user.api.message.ResponseMessage;
+import com.lokoko.domain.user.application.service.UserService;
+import com.lokoko.global.auth.annotation.CurrentUser;
+import com.lokoko.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "USER")
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "사용자 ID 중복 체크 (Customer/Creator 공통)")
+    @GetMapping("/check-id")
+    public ApiResponse<Void> checkUserId(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @Validated UserIdCheckRequest request) {
+
+        userService.checkUserIdAvailable(request.userId(), userId);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.USER_ID_CHECK_SUCCESS.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/domain/user/api/dto/request/UserIdCheckRequest.java
+++ b/src/main/java/com/lokoko/domain/user/api/dto/request/UserIdCheckRequest.java
@@ -1,0 +1,13 @@
+package com.lokoko.domain.user.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserIdCheckRequest(
+        @NotBlank(message = "사용자 ID는 필수입니다")
+        @Size(min = 1, max = 15, message = "사용자 ID는 1자 이상 15자 이하여야 합니다")
+        @Pattern(regexp = "^[a-z0-9._]+$",
+                message = "사용자 ID는 소문자 영문, 숫자, 점(.), 언더바(_)만 사용 가능합니다")
+        String userId
+) {}

--- a/src/main/java/com/lokoko/domain/user/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/user/api/message/ResponseMessage.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ResponseMessage {
-    ADMIN_REVIEW_DELETE_SUCCESS("어드민 리뷰 삭제에 성공했습니다");
+    ADMIN_REVIEW_DELETE_SUCCESS("어드민 리뷰 삭제에 성공했습니다"),
+
+    USER_ID_CHECK_SUCCESS("사용 가능한 ID입니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/user/application/service/UserService.java
+++ b/src/main/java/com/lokoko/domain/user/application/service/UserService.java
@@ -1,0 +1,34 @@
+package com.lokoko.domain.user.application.service;
+
+
+import com.lokoko.domain.creator.domain.repository.CreatorRepository;
+import com.lokoko.domain.customer.domain.repository.CustomerRepository;
+import com.lokoko.domain.user.domain.repository.UserRepository;
+import com.lokoko.domain.user.exception.UserIdAlreadyExistsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+    private final UserRepository userRepository;
+    private final CreatorRepository creatorRepository;
+    private final CustomerRepository customerRepository;
+
+    public void checkUserIdAvailable(String requestedUserId, Long currentUserId) {
+        String currentUserName = userRepository.findCurrentUserName(currentUserId);
+
+        if (currentUserName != null && currentUserName.equalsIgnoreCase(requestedUserId)) {
+            return;
+        }
+
+        boolean existsInCreator = creatorRepository.existsByCreatorNameIgnoreCase(requestedUserId);
+        boolean existsInCustomer = customerRepository.existsByCustomerNameIgnoreCase(requestedUserId);
+
+        if (existsInCreator || existsInCustomer) {
+            throw new UserIdAlreadyExistsException();
+        }
+    }
+}

--- a/src/main/java/com/lokoko/domain/user/domain/entity/User.java
+++ b/src/main/java/com/lokoko/domain/user/domain/entity/User.java
@@ -59,6 +59,12 @@ public class User extends BaseEntity {
     private String name;
 
     @Column
+    private String firstName;
+
+    @Column
+    private String lastName;
+
+    @Column
     private String profileImageUrl;
 
     @Column
@@ -87,6 +93,17 @@ public class User extends BaseEntity {
         this.email = email;
     }
 
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public void updateLastName(String lastName) {
+        this.lastName = lastName;
+    }
 
     public static User createLineUser(String lineUserId, String email, String displayName) {
         return User.builder()
@@ -98,12 +115,15 @@ public class User extends BaseEntity {
                 .build();
     }
 
-    public static User createGoogleUser(String googleUserId, String email, String displayName) {
+    public static User createGoogleUser(String googleUserId, String email, String displayName, String firstName, String lastName, String profileImageUrl) {
         return User.builder()
                 .googleId(googleUserId)
                 .email(email)
+                .firstName(firstName)
+                .lastName(lastName)
                 .name(displayName)
                 .role(Role.PENDING)
+                .profileImageUrl(profileImageUrl)
                 .lastLoginAt(Instant.now())
                 .build();
     }

--- a/src/main/java/com/lokoko/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/lokoko/domain/user/domain/repository/UserRepository.java
@@ -1,7 +1,9 @@
 package com.lokoko.domain.user.domain.repository;
 
 import com.lokoko.domain.user.domain.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,6 +11,15 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByGoogleId(String googleId);
+
     Optional<User> findByLineId(String lineId);
 
+    @Query("""
+                SELECT COALESCE(c.creatorName, cu.customerName)
+                FROM User u
+                LEFT JOIN Creator c ON u.id = c.id
+                LEFT JOIN Customer cu ON u.id = cu.id
+                WHERE u.id = :userId
+            """)
+    String findCurrentUserName(@Param("userId") Long userId);
 }

--- a/src/main/java/com/lokoko/domain/user/exception/UserIdAlreadyExistsException.java
+++ b/src/main/java/com/lokoko/domain/user/exception/UserIdAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.user.exception;
+
+import com.lokoko.global.auth.exception.ErrorMessage;
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class UserIdAlreadyExistsException extends BaseException {
+    public UserIdAlreadyExistsException() {
+        super(HttpStatus.CONFLICT, ErrorMessage.USER_ID_ALREADY_EXIST.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/controller/AuthController.java
+++ b/src/main/java/com/lokoko/global/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.auth.google.dto.GoogleLoginResponse;
 import com.lokoko.global.auth.google.dto.RoleUpdateRequest;
 import com.lokoko.global.auth.google.dto.RoleUpdateResponse;
+import com.lokoko.global.auth.google.dto.response.AfterLoginUserNameResponse;
 import com.lokoko.global.auth.jwt.dto.JwtTokenResponse;
 import com.lokoko.global.auth.jwt.dto.LoginResponse;
 import com.lokoko.global.auth.jwt.service.JwtService;
@@ -97,6 +98,15 @@ public class AuthController {
         cookieUtil.setCookie(REFRESH_TOKEN_HEADER, roleResponse.refreshToken(), response);
 
         return ApiResponse.success(HttpStatus.OK, ROLE_ASSIGNED_SUCCESS.getMessage(), roleResponse);
+    }
+
+    @GetMapping("/name")
+    @Operation(summary = "로그인한 사용자의 이름을 표시하는 API입니다.")
+    public ApiResponse<AfterLoginUserNameResponse> getUserDisplayName(
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+
+        AfterLoginUserNameResponse response = authService.getUserName(userId);
+        return ApiResponse.success(HttpStatus.OK, GET_LOGIN_USER_NAME_SUCCESS.getMessage(), response);
     }
 
     /**

--- a/src/main/java/com/lokoko/global/auth/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/global/auth/controller/enums/ResponseMessage.java
@@ -12,7 +12,7 @@ public enum ResponseMessage {
     REFRESH_TOKEN_REISSUE("리프레시 토큰 재발급에 성공했습니다."),
     ROLE_ASSIGNED_SUCCESS("역할 설정이 완료되었습니다."),
 
-    ;
+    GET_LOGIN_USER_NAME_SUCCESS("로그인한 유저의 ID를 성공적으로 불러왔습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/global/auth/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/global/auth/exception/ErrorMessage.java
@@ -24,8 +24,14 @@ public enum ErrorMessage {
     // 역할 관련
     ROLE_INVALID_TYPE("선택할 수 없는 역할입니다", HttpStatus.BAD_REQUEST.value()),
     ROLE_ALREADY_EXIST("이미 역할이 설정된 사용자입니다", HttpStatus.BAD_REQUEST.value()),
-    ROLE_TRANSITION_NOT_ALLOWED ("역할 변경은 PENDING 상태에서만 가능합니다",HttpStatus.BAD_REQUEST.value()),
-    ROLE_TRANSITION_NOT_ALLOWED_AFTER_LOGIN("이미 모든 정보 입력이 완료된 사용자는 역할을 변경할 수 없습니다.",HttpStatus.BAD_REQUEST.value());
+    ROLE_TRANSITION_NOT_ALLOWED("역할 변경은 PENDING 상태에서만 가능합니다", HttpStatus.BAD_REQUEST.value()),
+    ROLE_TRANSITION_NOT_ALLOWED_AFTER_LOGIN("이미 모든 정보 입력이 완료된 사용자는 역할을 변경할 수 없습니다.", HttpStatus.BAD_REQUEST.value()),
+
+    // 로그인 후
+    USER_NOT_COMPLETED_SIGN_UP("회원가입을 완료하지 않은 사용자입니다.", HttpStatus.FORBIDDEN.value()),
+
+    // 유저 ID 중복 검사
+    USER_ID_ALREADY_EXIST("이미 존재하는 ID입니다.", HttpStatus.CONFLICT.value());
 
     private final String message;
     private final int httpStatus;

--- a/src/main/java/com/lokoko/global/auth/exception/UserNotCompletedSingUpException.java
+++ b/src/main/java/com/lokoko/global/auth/exception/UserNotCompletedSingUpException.java
@@ -1,0 +1,11 @@
+package com.lokoko.global.auth.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class UserNotCompletedSingUpException extends BaseException {
+
+    public UserNotCompletedSingUpException() {
+        super(HttpStatus.FORBIDDEN, ErrorMessage.USER_NOT_COMPLETED_SIGN_UP.getMessage());
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/google/dto/GoogleProfileDto.java
+++ b/src/main/java/com/lokoko/global/auth/google/dto/GoogleProfileDto.java
@@ -9,6 +9,8 @@ public record GoogleProfileDto(
         @JsonProperty("sub")
         String userId,        // 구글 사용자 ID
         String name,
+        String givenName,
+        String familyName,
         String picture,
         String email
 ) {

--- a/src/main/java/com/lokoko/global/auth/google/dto/response/AfterLoginUserNameResponse.java
+++ b/src/main/java/com/lokoko/global/auth/google/dto/response/AfterLoginUserNameResponse.java
@@ -1,0 +1,11 @@
+package com.lokoko.global.auth.google.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record AfterLoginUserNameResponse(
+        @Schema(requiredMode = REQUIRED, description = "로그인 후 표시되는 이름")
+        String displayName
+) {
+}

--- a/src/main/java/com/lokoko/global/auth/service/AuthService.java
+++ b/src/main/java/com/lokoko/global/auth/service/AuthService.java
@@ -4,8 +4,10 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.lokoko.domain.brand.domain.entity.Brand;
 import com.lokoko.domain.brand.domain.repository.BrandRepository;
+import com.lokoko.domain.brand.exception.BrandNotFoundException;
 import com.lokoko.domain.creator.domain.entity.Creator;
 import com.lokoko.domain.creator.domain.repository.CreatorRepository;
+import com.lokoko.domain.creator.exception.CreatorNotFoundException;
 import com.lokoko.domain.customer.domain.entity.Customer;
 import com.lokoko.domain.customer.domain.repository.CustomerRepository;
 import com.lokoko.domain.user.domain.entity.User;
@@ -18,11 +20,13 @@ import com.lokoko.global.auth.exception.InvalidRoleException;
 import com.lokoko.global.auth.exception.OauthException;
 import com.lokoko.global.auth.exception.RoleChangeNotAllowedException;
 import com.lokoko.global.auth.exception.StateValidationException;
+import com.lokoko.global.auth.exception.UserNotCompletedSingUpException;
 import com.lokoko.global.auth.google.GoogleOAuthClient;
 import com.lokoko.global.auth.google.GoogleProperties;
 import com.lokoko.global.auth.google.dto.GoogleProfileDto;
 import com.lokoko.global.auth.google.dto.GoogleTokenDto;
 import com.lokoko.global.auth.google.dto.RoleUpdateResponse;
+import com.lokoko.global.auth.google.dto.response.AfterLoginUserNameResponse;
 import com.lokoko.global.auth.jwt.dto.LoginResponse;
 import com.lokoko.global.auth.jwt.exception.TokenInvalidException;
 import com.lokoko.global.auth.jwt.utils.CookieUtil;
@@ -156,6 +160,10 @@ public class AuthService {
             String googleUserId = profile.userId();
             String email = profile.email();
             String displayName = profile.name();
+            String firstName = profile.givenName();
+            String lastName = profile.familyName();
+            String profileImageUrl = profile.picture();
+
 
             Optional<User> userOpt = userRepository.findByGoogleId(googleUserId);
             User user;
@@ -166,6 +174,9 @@ public class AuthService {
                 user.updateLastLoginAt();
                 user.updateEmail(email);
                 user.updateDisplayName(displayName);
+                user.updateFirstName(firstName);
+                user.updateLastName(lastName);
+                user.updateProfileImage(profileImageUrl);
 
                 if (user.getRole() == Role.PENDING) {
                     loginStatus = OauthLoginStatus.REGISTER;
@@ -180,7 +191,7 @@ public class AuthService {
                     loginStatus = OauthLoginStatus.LOGIN;
                 }
             } else {
-                user = User.createGoogleUser(googleUserId, email, displayName);
+                user = User.createGoogleUser(googleUserId, email, displayName,firstName,lastName,profileImageUrl);
                 loginStatus = OauthLoginStatus.REGISTER;
             }
 
@@ -373,5 +384,59 @@ public class AuthService {
                 user.assignBrand(brand);
             }
         }
+    }
+    @Transactional(readOnly = true)
+    public AfterLoginUserNameResponse getUserName(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        String displayName;
+
+        switch (user.getRole()) {
+            case CUSTOMER:
+                Customer customer = customerRepository.findById(userId).orElse(null);
+                if (customer != null && customer.getCustomerName() != null) {
+                    displayName = customer.getCustomerName();
+                } else {
+                    displayName = user.getFirstName() + " " + user.getLastName();
+                }
+                break;
+
+            case CREATOR:
+                Creator creator = creatorRepository.findById(userId)
+                        .orElseThrow(CreatorNotFoundException::new);
+
+                // Creator 필수 필드가 채워지지 않은 경우 (INFO_REQUIRED)
+                if (creator.getCreatorName() == null) {
+                    throw new UserNotCompletedSingUpException();
+                }
+
+                // 1개 이상의 SNS가 연동되지 않은 상태 (SNS_REQUIRED)
+                if (creator.getInstaLink() == null && creator.getTiktokLink() == null) {
+                    throw new UserNotCompletedSingUpException();
+                }
+
+                // LOGIN 상태 검증 완료
+                displayName = creator.getCreatorName();
+                break;
+
+            case BRAND:
+                Brand brand = brandRepository.findById(userId)
+                        .orElseThrow(BrandNotFoundException::new);
+
+                if (brand.getBrandName() == null) {
+                    throw new UserNotCompletedSingUpException();
+                }
+                displayName = brand.getBrandName();
+                break;
+
+            case PENDING:
+                throw new UserNotCompletedSingUpException();
+
+            default:
+                throw new InvalidRoleException();
+        }
+
+        return new AfterLoginUserNameResponse(displayName);
     }
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #218 

## 작업 내용 💻
* [x] 로그인 한 사용자 id 값 반환
   - User의 role에 따라 적절한 displayName을 반환하는 getUserName API 구현
   - PENDING 상태일 때 UserNotCompletedSingUpException 발생
   * [x] Customer와 Creator는 동일한 id를 가질 수  없음
      - UserService에 통합 중복 체크 로직 checkUserIdAvailable 구현
      - existsByCreatorNameIgnoreCase, existsByCustomerNameIgnoreCase 메서드 추가
      - 자기 자신의 ID 수정 시에는 중복 체크에서 제외
   * [x] 로그인 하지 않은 상태의 역할을 가진 유저가 접근할 때
      - role별 필수 정보 검증 로직 추가
      * [x] Creator같은 경우는 SNS가 연결됐는지 여부도 파악해야함
         - getInstaLink() == null && getTiktokLink() == null 체크
         - 하나 이상 연동 안 되어 있으면 UserNotCompletedSingUpException
      * [x] Customer는 ID 설정하기 전에는 구글 이름을 내려주고 ID 설정한 이후에는 ID를 내려줘야됨
         - customerName이 null이면 use r.getFirstName() + " " + user.getLastName() 반환
         - customerName이 있으면 해당 값 반환
 
* [x] 브랜드 프로필 이미지 url (S3 presigned URL 발급 로직)
* [x] 브랜드 마이페이지 정보 조회
* [x] 브랜드 마이페이지 정보 수정

* [x] customer프로필 이미지 url
* [x] customer 마이페이지 정보 조회
* [x] customer 마이페이지 정보 수정
* [x] Customer SNS 연동 상태 확인 API 추가 구현


Customer와 Creator 간 ID 중복 방지를 위해 UserRepository에 통합 중복 체크 로직을 구현했습니다. 기존에는 creator와 customer의 ID를 별개라고 생각하여 각 도메인에서 처리하던 중복 체크를 UserService로 통합하여, Creator와 Customer 전체에서 동일한 ID사용을 방지합니다. 이렇게 User 도메인에 구현한 이유는, User 도메인은 이미 모든 사용자의 기본 정보를 관리하고 있어 자연스럽게 통합 ID 관리의 책임을 가질 수 있었기 때문입니다. 추가로, 이미 자기의 ID를 DB에 넣은 사용자가 수정 화면에서 회원가입시 기입한 ID를 중복 체크할 때는 통과할 수 있게 했습니다.

기존 Brand 엔티티에 있던 profileImageUrl을 제거하고 공통 User 엔티티의 profileImageUrl을 사용하도록 리팩토링했습니다. Customer 마이페이지도 Brand와 동일한 구조로 조회 및 수정 API를 구현했으며, PATCH 방식으로 null이 아닌 필드만 업데이트하도록 처리했습니다.

Customer의 SNS 연동 확인 API도 추가로 구현했습니다. Creator와 동일한 구조로 Instagram과 TikTok 연동 여부를 확인할 수 있도록 했습니다. SNS 연동 확인 기능을 ID 중복 체크와 달리 각 도메인에 분리하여 구현한 이유는, SNS 연동은 각 도메인의 고유한 비즈니스 로직이라고 생각했기 때문입니다. Creator는 SNS 연동이 필수이지만 Customer는 선택사항이며, 향후 Brand나 다른 역할에서도 다른 형태의 SNS 연동 요구사항이 생길 수 있다고 생각했습니다.  따라서 각 도메인이 자신의 SNS 연동 여부를 독립적으로 관리하는 것이 더 적절하다고 판단했습니다.

Customer와 User 정보를 함께 조회할 때는 findCustomerWithUserById 쿼리를 사용하여 Fetch Join으로 한 번에 데이터를 가져오도록 했고, ID 중복 체크 시에는 JPA의 메서드 네이밍 규칙을 활용하여 existsByCreatorNameIgnoreCase, existsByCustomerNameIgnoreCase로 구현했습니다. 

프로필 이미지 Presigned URL 발급 기능은 현재 Brand, Customer에 각각 구현되어 있는데, 중복 코드가 많아 하나의 공통 API로 만드는 방법도 생각을 해봤습니다. 또한 폴더 경로명 지정해서 S3에서 폴더별(brand/creator/..등등)로 영상/사진을 확인할 수 있게끔 수정해도 괜찮겠다는 생각을 했습니다. (현재는 video/image로만 폴더가 나누어져있음) 좋은 아이디어가 있으시다면 언제든지 알려주세요 😄 


이것저것 수정 사항이 생겨서 같은 브랜치에서 고치다보니 짬뽕 PR이 됐습니다 😅 쭈글..
다음부터는 브랜치 별로 내용 잘 나눠서 작업하겠습니다!

## 스크린샷 📷
- 수업끝나고 업로드 예정..

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

