### PR TITLE
[Feat] #226 메인페이지 캠페인 리스트 조회 API & Opening Soon 캠페인 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
@@ -3,9 +3,12 @@ package com.lokoko.domain.campaign.api;
 import com.lokoko.domain.campaign.api.dto.request.CampaignMediaRequest;
 import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignMediaResponse;
+import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
 import com.lokoko.domain.campaign.api.message.ResponseMessage;
 import com.lokoko.domain.campaign.application.service.CampaignGetService;
 import com.lokoko.domain.campaign.application.service.CampaignService;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
+import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
 import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,12 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "CAMPAIGN")
 @RestController
@@ -49,5 +47,19 @@ public class CampaignController {
         CampaignMediaResponse response = campaignService.createMediaPresignedUrl(brandId, mediaRequest);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.CAMPAIGN_MEDIA_PRESIGNED_URL_SUCCESS.getMessage(),
                 response);
+    }
+
+    @Operation(summary = "메인페이지에서 캠페인 리스트 조회")
+    @GetMapping
+    public ApiResponse<MainPageCampaignListResponse> getCampaignsInMainPage(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @RequestParam LanguageFilter lang,
+            @RequestParam CampaignProductTypeFilter category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "8") int size) {
+
+        MainPageCampaignListResponse response = campaignReadService.getCampaignsInMainPage(userId, lang, category, page, size);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.MAIN_PAGE_CAMPAIGNS_GET_SUCCESS.getMessage(), response);
+
     }
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
@@ -68,11 +68,9 @@ public class CampaignController {
     @GetMapping("/upcoming")
     public ApiResponse<MainPageUpcomingCampaignListResponse> getUpcomingCampaignsInMainPage(
             @RequestParam LanguageFilter lang,
-            @RequestParam CampaignProductTypeFilter category,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "6") int size){
+            @RequestParam CampaignProductTypeFilter category){
 
-        MainPageUpcomingCampaignListResponse response = campaignReadService.getUpcomingCampaignsInMainPage(lang, category, page, size);
+        MainPageUpcomingCampaignListResponse response = campaignReadService.getUpcomingCampaignsInMainPage(lang, category);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.MAIN_PAGE_UPCOMING_CAMPAIGNS_GET_SUCCESS.getMessage(), response);
     }
 

--- a/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
@@ -4,6 +4,7 @@ import com.lokoko.domain.campaign.api.dto.request.CampaignMediaRequest;
 import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignMediaResponse;
 import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
+import com.lokoko.domain.campaign.api.dto.response.MainPageUpcomingCampaignListResponse;
 import com.lokoko.domain.campaign.api.message.ResponseMessage;
 import com.lokoko.domain.campaign.application.service.CampaignGetService;
 import com.lokoko.domain.campaign.application.service.CampaignService;
@@ -56,10 +57,24 @@ public class CampaignController {
             @RequestParam LanguageFilter lang,
             @RequestParam CampaignProductTypeFilter category,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "8") int size) {
+            @RequestParam(defaultValue = "6") int size) {
 
         MainPageCampaignListResponse response = campaignReadService.getCampaignsInMainPage(userId, lang, category, page, size);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.MAIN_PAGE_CAMPAIGNS_GET_SUCCESS.getMessage(), response);
 
     }
+
+    @Operation(summary = "메인페이지 Opening Soon 캠페인 리스트 조회")
+    @GetMapping("/upcoming")
+    public ApiResponse<MainPageUpcomingCampaignListResponse> getUpcomingCampaignsInMainPage(
+            @RequestParam LanguageFilter lang,
+            @RequestParam CampaignProductTypeFilter category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "6") int size){
+
+        MainPageUpcomingCampaignListResponse response = campaignReadService.getUpcomingCampaignsInMainPage(lang, category, page, size);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.MAIN_PAGE_UPCOMING_CAMPAIGNS_GET_SUCCESS.getMessage(), response);
+    }
+
+
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignCreateRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignCreateRequest.java
@@ -1,8 +1,8 @@
 package com.lokoko.domain.campaign.api.dto.request;
 
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
-import com.lokoko.global.common.enums.Language;
 import jakarta.validation.constraints.Size;
 
 import java.time.Instant;
@@ -11,7 +11,7 @@ import java.util.List;
 
 public record CampaignCreateRequest(
         String campaignTitle,
-        Language language,
+        CampaignLanguage language,
         CampaignType campaignType,
         CampaignProductType campaignProductType,
         @Size(max = 5, message = "상단 이미지는 최대 5개까지 가능합니다")

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignCreateRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignCreateRequest.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.campaign.api.dto.request;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.domain.socialclip.domain.entity.enums.ContentType;
 import jakarta.validation.constraints.Size;
 
 import java.time.Instant;
@@ -25,7 +26,9 @@ public record CampaignCreateRequest(
         Integer recruitmentNumber,
         List<String> participationRewards,
         List<String> deliverableRequirements,
-        List<String> eligibilityRequirements
+        List<String> eligibilityRequirements,
+        ContentType firstContentType,
+        ContentType secondContentType
 ) {
 
     public static CampaignCreateRequest convertPublishToCreateRequest(CampaignPublishRequest publishRequest) {
@@ -43,7 +46,9 @@ public record CampaignCreateRequest(
                 publishRequest.recruitmentNumber(),
                 safeList(publishRequest.participationRewards()),
                 safeList(publishRequest.deliverableRequirements()),
-                safeList(publishRequest.eligibilityRequirements())
+                safeList(publishRequest.eligibilityRequirements()),
+                publishRequest.firstContentType(),
+                publishRequest.secondContentType()
         );
     }
 
@@ -62,9 +67,9 @@ public record CampaignCreateRequest(
                 draftRequest.recruitmentNumber(),
                 safeList(draftRequest.participationRewards()),
                 safeList(draftRequest.deliverableRequirements()),
-                safeList(draftRequest.eligibilityRequirements())
-
-
+                safeList(draftRequest.eligibilityRequirements()),
+                draftRequest.firstContentType(),
+                draftRequest.secondContentType()
         );
     }
 

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignDraftRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignDraftRequest.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.campaign.api.dto.request;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.domain.socialclip.domain.entity.enums.ContentType;
 import jakarta.validation.constraints.Size;
 
 import java.time.Instant;
@@ -24,6 +25,8 @@ public record CampaignDraftRequest(
         Integer recruitmentNumber,
         List<String> participationRewards,
         List<String> deliverableRequirements,
-        List<String> eligibilityRequirements
+        List<String> eligibilityRequirements,
+        ContentType firstContentType,
+        ContentType secondContentType
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignDraftRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignDraftRequest.java
@@ -1,8 +1,8 @@
 package com.lokoko.domain.campaign.api.dto.request;
 
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
-import com.lokoko.global.common.enums.Language;
 import jakarta.validation.constraints.Size;
 
 import java.time.Instant;
@@ -10,7 +10,7 @@ import java.util.List;
 
 public record CampaignDraftRequest(
         String campaignTitle,
-        Language language,
+        CampaignLanguage language,
         CampaignType campaignType,
         CampaignProductType campaignProductType,
         @Size(max = 5, message = "상단 이미지는 최대 5개까지 가능합니다")

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignPublishRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignPublishRequest.java
@@ -1,8 +1,8 @@
 package com.lokoko.domain.campaign.api.dto.request;
 
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
-import com.lokoko.global.common.enums.Language;
 import jakarta.validation.constraints.*;
 
 import java.time.Instant;
@@ -13,7 +13,7 @@ public record CampaignPublishRequest(
         String campaignTitle,
         
         @NotNull(message = "언어 설정은 필수입니다")
-        Language language,
+        CampaignLanguage language,
         
         @NotNull(message = "캠페인 타입은 필수입니다")
         CampaignType campaignType,

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignPublishRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignPublishRequest.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.campaign.api.dto.request;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.domain.socialclip.domain.entity.enums.ContentType;
 import jakarta.validation.constraints.*;
 
 import java.time.Instant;
@@ -55,6 +56,12 @@ public record CampaignPublishRequest(
         List<@NotBlank(message = "컨텐츠 요구사항 항목은 공백일 수 없습니다") String> deliverableRequirements,
         
         // 선택사항
-        List<String> eligibilityRequirements
+        List<String> eligibilityRequirements,
+
+        @NotNull(message = "컨텐츠 플랫폼 선택은 필수입니다")
+        ContentType firstContentType,
+
+        @NotNull(message = "컨텐츠 플랫폼 선택은 필수입니다")
+        ContentType secondContentType
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignCreateResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignCreateResponse.java
@@ -1,8 +1,8 @@
 package com.lokoko.domain.campaign.api.dto.response;
 
 import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
-import com.lokoko.global.common.enums.Language;
 
 import java.time.Instant;
 import java.util.List;
@@ -10,7 +10,7 @@ import java.util.List;
 public record CampaignCreateResponse(
         Long campaignId,
         String campaignTitle,
-        Language language,
+        CampaignLanguage language,
         CampaignType campaignType,
         List<CampaignImageResponse> topImages,
         List<CampaignImageResponse> bottomImages,

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignDetailResponse.java
@@ -3,8 +3,8 @@ package com.lokoko.domain.campaign.api.dto.response;
 import com.lokoko.domain.brand.domain.entity.Brand;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignDetailPageStatus;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
-import com.lokoko.global.common.enums.Language;
 
 import java.time.Instant;
 import java.util.List;
@@ -16,7 +16,7 @@ public record CampaignDetailResponse(
         String title,
         String brandImageUrl,
         String brandName,
-        Language language,
+        CampaignLanguage language,
         Instant applyStartDate,
         Instant applyDeadline,
         Instant creatorAnnouncementDate,

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignListResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignListResponse.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.campaign.api.dto.response;
+
+import com.lokoko.global.common.response.PageableResponse;
+
+import java.util.List;
+
+public record MainPageCampaignListResponse(
+        List<MainPageCampaignResponse> campaigns,
+        PageableResponse pageInfo
+) {
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignListResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignListResponse.java
@@ -1,11 +1,16 @@
 package com.lokoko.domain.campaign.api.dto.response;
 
 import com.lokoko.global.common.response.PageableResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record MainPageCampaignListResponse(
+        @Schema(requiredMode = REQUIRED, description = "메인 페이지 캠페인 목록")
         List<MainPageCampaignResponse> campaigns,
+        @Schema(requiredMode = REQUIRED, description = "페이지 정보")
         PageableResponse pageInfo
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignResponse.java
@@ -1,6 +1,5 @@
 package com.lokoko.domain.campaign.api.dto.response;
 
-import com.lokoko.domain.campaign.domain.entity.enums.CampaignChipStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
 
@@ -17,6 +16,6 @@ public record MainPageCampaignResponse(
         Integer applicantNumber,
         Integer recruitmentNumber,
         Instant endTime,
-        CampaignChipStatus chipStatus
+        String chipStatus
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignResponse.java
@@ -1,5 +1,6 @@
 package com.lokoko.domain.campaign.api.dto.response;
 
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignChipStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
 
@@ -15,7 +16,7 @@ public record MainPageCampaignResponse(
         String campaignName,
         Integer applicantNumber,
         Integer recruitmentNumber,
-        Instant openTime,
-        Instant endTime
+        Instant endTime,
+        CampaignChipStatus chipStatus
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignResponse.java
@@ -2,20 +2,33 @@ package com.lokoko.domain.campaign.api.dto.response;
 
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 
 import java.time.Instant;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record MainPageCampaignResponse(
+        @Schema(requiredMode = REQUIRED, description = "캠페인 ID", example = "1")
         Long campaignId,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 타입", example = "GIVEAWAY")
         CampaignType campaignType,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 언어", example = "ENG")
         CampaignLanguage language,
+        @Schema(requiredMode = REQUIRED, description = "브랜드명", example = "Anua")
         String brandName,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 이미지 URL", example = "https://example.com/image.jpg")
         String campaignImageUrl,
+        @Schema(requiredMode = REQUIRED, description = "캠페인명", example = "Anua campaign")
         String campaignName,
+        @Schema(requiredMode = REQUIRED, description = "지원자 수", example = "10")
         Integer applicantNumber,
+        @Schema(requiredMode = REQUIRED, description = "모집 인원", example = "10")
         Integer recruitmentNumber,
+        @Schema(requiredMode = REQUIRED, description = "모집 마감 시간", example = "2024-12-31T23:59:59Z")
         Instant endTime,
+        @Schema(requiredMode = REQUIRED, description = "칩 상태", example = "default / disabled")
         String chipStatus
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageCampaignResponse.java
@@ -1,0 +1,21 @@
+package com.lokoko.domain.campaign.api.dto.response;
+
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+
+
+import java.time.Instant;
+
+public record MainPageCampaignResponse(
+        Long campaignId,
+        CampaignType campaignType,
+        CampaignLanguage language,
+        String brandName,
+        String campaignImageUrl,
+        String campaignName,
+        Integer applicantNumber,
+        Integer recruitmentNumber,
+        Instant openTime,
+        Instant endTime
+) {
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignListResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignListResponse.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.campaign.api.dto.response;
+
+import com.lokoko.global.common.response.PageableResponse;
+
+import java.util.List;
+
+public record MainPageUpcomingCampaignListResponse(
+        List<MainPageUpcomingCampaignResponse> campaigns,
+        PageableResponse pageInfo
+) {
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignListResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignListResponse.java
@@ -1,11 +1,16 @@
 package com.lokoko.domain.campaign.api.dto.response;
 
 import com.lokoko.global.common.response.PageableResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record MainPageUpcomingCampaignListResponse(
+        @Schema(requiredMode = REQUIRED, description = "메인 페이지 오픈 예정 캠페인 목록")
         List<MainPageUpcomingCampaignResponse> campaigns,
+        @Schema(requiredMode = REQUIRED, description = "페이지 정보")
         PageableResponse pageInfo
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignListResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignListResponse.java
@@ -1,6 +1,5 @@
 package com.lokoko.domain.campaign.api.dto.response;
 
-import com.lokoko.global.common.response.PageableResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -9,8 +8,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 public record MainPageUpcomingCampaignListResponse(
         @Schema(requiredMode = REQUIRED, description = "메인 페이지 오픈 예정 캠페인 목록")
-        List<MainPageUpcomingCampaignResponse> campaigns,
-        @Schema(requiredMode = REQUIRED, description = "페이지 정보")
-        PageableResponse pageInfo
+        List<MainPageUpcomingCampaignResponse> campaigns
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignResponse.java
@@ -1,0 +1,21 @@
+package com.lokoko.domain.campaign.api.dto.response;
+
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignChipStatus;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+
+import java.time.Instant;
+
+public record MainPageUpcomingCampaignResponse(
+        Long campaignId,
+        CampaignType campaignType,
+        CampaignLanguage language,
+        String brandName,
+        String campaignImageUrl,
+        String campaignName,
+        Integer applicantNumber,
+        Integer recruitmentNumber,
+        Instant startTime,
+        CampaignChipStatus chipStatus
+) {
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignResponse.java
@@ -1,6 +1,5 @@
 package com.lokoko.domain.campaign.api.dto.response;
 
-import com.lokoko.domain.campaign.domain.entity.enums.CampaignChipStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
 
@@ -16,6 +15,6 @@ public record MainPageUpcomingCampaignResponse(
         Integer applicantNumber,
         Integer recruitmentNumber,
         Instant startTime,
-        CampaignChipStatus chipStatus
+        String chipStatus
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/MainPageUpcomingCampaignResponse.java
@@ -2,19 +2,32 @@ package com.lokoko.domain.campaign.api.dto.response;
 
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record MainPageUpcomingCampaignResponse(
+        @Schema(requiredMode = REQUIRED, description = "캠페인 ID", example = "1")
         Long campaignId,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 타입", example = "GIVEAWAY")
         CampaignType campaignType,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 언어", example = "ENG")
         CampaignLanguage language,
+        @Schema(requiredMode = REQUIRED, description = "브랜드명", example = "Anua")
         String brandName,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 이미지 URL", example = "https://example.com/image.jpg")
         String campaignImageUrl,
+        @Schema(requiredMode = REQUIRED, description = "캠페인명", example = "Anua campaign")
         String campaignName,
+        @Schema(requiredMode = REQUIRED, description = "지원자 수", example = "10")
         Integer applicantNumber,
+        @Schema(requiredMode = REQUIRED, description = "모집 인원", example = "10")
         Integer recruitmentNumber,
+        @Schema(requiredMode = REQUIRED, description = "시작 시간", example = "2024-12-31T10:00:00Z")
         Instant startTime,
+        @Schema(requiredMode = REQUIRED, description = "칩 상태", example = "disabled")
         String chipStatus
 ) {
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/message/ResponseMessage.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
     CAMPAIGN_DETAIL_GET_SUCCESS("캠페인 상세조회에 성공했습니다"),
-    CAMPAIGN_MEDIA_PRESIGNED_URL_SUCCESS("캠페인 사진의 Presigned Url이 성공적으로 발급되었습니다.");
+    CAMPAIGN_MEDIA_PRESIGNED_URL_SUCCESS("캠페인 사진의 Presigned Url이 성공적으로 발급되었습니다."),
+    MAIN_PAGE_CAMPAIGNS_GET_SUCCESS("메인페이지에서 캠페인 리스트 조회에 성공했습니다");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/message/ResponseMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum ResponseMessage {
     CAMPAIGN_DETAIL_GET_SUCCESS("캠페인 상세조회에 성공했습니다"),
     CAMPAIGN_MEDIA_PRESIGNED_URL_SUCCESS("캠페인 사진의 Presigned Url이 성공적으로 발급되었습니다."),
-    MAIN_PAGE_CAMPAIGNS_GET_SUCCESS("메인페이지에서 캠페인 리스트 조회에 성공했습니다");
+    MAIN_PAGE_CAMPAIGNS_GET_SUCCESS("메인페이지에서 캠페인 리스트 조회에 성공했습니다"),
+    MAIN_PAGE_UPCOMING_CAMPAIGNS_GET_SUCCESS("메인페이지에서 Opening Soon 캠페인 리스트 조회에 성공했습니다");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.campaign.application.service;
 import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
 import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
+import com.lokoko.domain.campaign.api.dto.response.MainPageUpcomingCampaignListResponse;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignDetailPageStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
@@ -63,6 +64,10 @@ public class CampaignGetService {
 
     public MainPageCampaignListResponse getCampaignsInMainPage(Long userId, LanguageFilter lang, CampaignProductTypeFilter category, int page, int size) {
         return campaignRepository.findCampaignsInMainPage(userId, lang, category, PageRequest.of(page, size));
+    }
+
+    public MainPageUpcomingCampaignListResponse getUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category, int page, int size) {
+        return campaignRepository.findUpcomingCampaignsInMainPage(lang, category, PageRequest.of(page, size));
     }
 
 

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -2,8 +2,11 @@ package com.lokoko.domain.campaign.application.service;
 
 import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
+import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignDetailPageStatus;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
+import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
 import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
 import com.lokoko.domain.campaign.exception.CampaignNotFoundException;
 import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
@@ -13,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Hibernate;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,5 +60,10 @@ public class CampaignGetService {
         Hibernate.initialize(campaign.getDeliverableRequirements());
         Hibernate.initialize(campaign.getEligibilityRequirements());
     }
+
+    public MainPageCampaignListResponse getCampaignsInMainPage(Long userId, LanguageFilter lang, CampaignProductTypeFilter category, int page, int size) {
+        return campaignRepository.findCampaignsInMainPage(userId, lang, category, PageRequest.of(page, size));
+    }
+
 
 }

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -66,8 +66,8 @@ public class CampaignGetService {
         return campaignRepository.findCampaignsInMainPage(userId, lang, category, PageRequest.of(page, size));
     }
 
-    public MainPageUpcomingCampaignListResponse getUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category, int page, int size) {
-        return campaignRepository.findUpcomingCampaignsInMainPage(lang, category, PageRequest.of(page, size));
+    public MainPageUpcomingCampaignListResponse getUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category) {
+        return campaignRepository.findUpcomingCampaignsInMainPage(lang, category);
     }
 
 

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -7,6 +7,7 @@ import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
 import com.lokoko.domain.campaign.exception.DraftNotFilledException;
+import com.lokoko.domain.socialclip.domain.entity.enums.ContentType;
 import com.lokoko.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -87,6 +88,8 @@ public class Campaign extends BaseEntity {
 
     private int approvedNumber; // 승인 인원
 
+
+
     /**
      * 크리에이터 참여 보상 목록
      */
@@ -123,6 +126,15 @@ public class Campaign extends BaseEntity {
 
     @Column
     private Instant publishedAt;
+
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    private ContentType firstContentPlatform;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    private ContentType secondContentPlatform;
 
     /**
      * 캠페인 지원자 수 증가 메소드
@@ -222,7 +234,9 @@ public class Campaign extends BaseEntity {
                 this.reviewSubmissionDeadline == null,
                 this.recruitmentNumber == null,
                 this.participationRewards == null || this.participationRewards.isEmpty(),
-                this.deliverableRequirements == null || this.deliverableRequirements.isEmpty()
+                this.deliverableRequirements == null || this.deliverableRequirements.isEmpty(),
+                this.firstContentPlatform == null,
+                this.secondContentPlatform == null
         ).anyMatch(condition -> condition);
     }
 
@@ -243,6 +257,8 @@ public class Campaign extends BaseEntity {
                 .participationRewards(request.participationRewards())
                 .deliverableRequirements(request.deliverableRequirements())
                 .eligibilityRequirements(request.eligibilityRequirements())
+                .firstContentPlatform(request.firstContentType())
+                .secondContentPlatform(request.secondContentType())
                 .build();
     }
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -2,12 +2,12 @@ package com.lokoko.domain.campaign.domain.entity;
 
 import com.lokoko.domain.brand.domain.entity.Brand;
 import com.lokoko.domain.campaign.api.dto.request.CampaignCreateRequest;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
 import com.lokoko.domain.campaign.exception.DraftNotFilledException;
 import com.lokoko.global.common.entity.BaseEntity;
-import com.lokoko.global.common.enums.Language;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -43,7 +43,7 @@ public class Campaign extends BaseEntity {
      */
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
-    private Language language;
+    private CampaignLanguage language;
 
     /**
      * 캠페인 종류

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignChipStatus.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignChipStatus.java
@@ -1,0 +1,17 @@
+package com.lokoko.domain.campaign.domain.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CampaignChipStatus {
+
+    DEFAULT("default"),
+    DISABLED("disabled"),
+    APPROVED("approved"),
+    DECLINED("declined"),
+    PROGRESS("progress");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignLanguage.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignLanguage.java
@@ -1,0 +1,14 @@
+package com.lokoko.domain.campaign.domain.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CampaignLanguage {
+
+    ENG("Eng"),
+    ESN("Esn");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignProductType.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignProductType.java
@@ -1,8 +1,15 @@
 package com.lokoko.domain.campaign.domain.entity.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum CampaignProductType {
-    SKINCARE,
-    SUNCARE,
-    FACE_MAKEUP,
-    LIP_MAKEUP
+
+    SKINCARE("Skincare"),
+    SUNCARE("Suncare"),
+    MAKEUP("Makeup");
+
+    private final String displayName;
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignProductTypeFilter.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignProductTypeFilter.java
@@ -1,0 +1,18 @@
+package com.lokoko.domain.campaign.domain.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CampaignProductTypeFilter {
+
+    ALL("All"),
+    SKINCARE("Skincare"),
+    SUNCARE("Suncare"),
+    MAKEUP("Makeup");
+
+    private final String displayName;
+
+
+}

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/LanguageFilter.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/LanguageFilter.java
@@ -1,0 +1,14 @@
+package com.lokoko.domain.campaign.domain.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LanguageFilter {
+    ENG("Eng"),
+    ESN("Esn"),
+    ALL("All");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CampaignRepository extends JpaRepository<Campaign, Long> {
+public interface CampaignRepository extends JpaRepository<Campaign, Long> , CampaignRepositoryCustom {
 
     /**
      * Campaign 과 brand 를 fetch join

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
@@ -12,5 +12,5 @@ public interface CampaignRepositoryCustom {
 
     MainPageCampaignListResponse findCampaignsInMainPage(Long userId, LanguageFilter lang, CampaignProductTypeFilter category, Pageable pageable);
 
-    MainPageUpcomingCampaignListResponse findUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category, PageRequest of);
+    MainPageUpcomingCampaignListResponse findUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category);
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.campaign.domain.repository;
+
+import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
+import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
+import org.springframework.data.domain.Pageable;
+
+public interface CampaignRepositoryCustom {
+
+    MainPageCampaignListResponse findCampaignsInMainPage(Long userId, LanguageFilter lang, CampaignProductTypeFilter category, Pageable pageable);
+}

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
@@ -1,11 +1,16 @@
 package com.lokoko.domain.campaign.domain.repository;
 
 import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
+import com.lokoko.domain.campaign.api.dto.response.MainPageUpcomingCampaignListResponse;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
 import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 public interface CampaignRepositoryCustom {
 
+
     MainPageCampaignListResponse findCampaignsInMainPage(Long userId, LanguageFilter lang, CampaignProductTypeFilter category, Pageable pageable);
+
+    MainPageUpcomingCampaignListResponse findUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category, PageRequest of);
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -41,7 +41,7 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
 
 
     @Override
-    public MainPageUpcomingCampaignListResponse findUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category, PageRequest pageable) {
+    public MainPageUpcomingCampaignListResponse findUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category) {
 
         BooleanExpression langCondition = buildLanguageCondition(lang);
         BooleanExpression categoryCondition = buildCategoryCondition(category);
@@ -71,8 +71,7 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
                         .and(campaignImage.imageType.eq((TOP))))
                 .where(campaign.campaignStatus.eq(CampaignStatus.OPEN_RESERVED).and(languageAndCategoryCondition))
                 .orderBy(campaign.applyStartDate.asc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(6)
                 .fetch();
 
         return new MainPageUpcomingCampaignListResponse(upcomingCampaigns);

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -73,23 +73,7 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-
-        Long totalCount = queryFactory
-                .select(campaign.count())
-                .from(campaign)
-                .where(campaign.campaignStatus.eq(CampaignStatus.OPEN_RESERVED).and(languageAndCategoryCondition))
-                .fetchOne();
-
-        boolean isLast = (pageable.getOffset() + pageable.getPageSize()) >= totalCount;
-
-        PageableResponse pageInfo = new PageableResponse(
-                pageable.getPageNumber(),
-                pageable.getPageSize(),
-                upcomingCampaigns.size(),
-                isLast);
-
-
-        return new MainPageUpcomingCampaignListResponse(upcomingCampaigns, pageInfo);
+        return new MainPageUpcomingCampaignListResponse(upcomingCampaigns);
 
     }
 

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -1,0 +1,204 @@
+package com.lokoko.domain.campaign.domain.repository;
+
+import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
+import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignResponse;
+import com.lokoko.domain.campaign.domain.entity.QCampaign;
+import com.lokoko.domain.campaign.domain.entity.enums.*;
+import com.lokoko.domain.image.domain.entity.QCampaignImage;
+import com.lokoko.domain.user.domain.entity.User;
+import com.lokoko.domain.user.domain.entity.enums.Role;
+import com.lokoko.domain.user.domain.repository.UserRepository;
+import com.lokoko.global.common.response.PageableResponse;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.AbstractMap;
+import java.util.List;
+
+import static com.lokoko.domain.image.domain.entity.enums.ImageType.TOP;
+
+@Repository
+@RequiredArgsConstructor
+public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QCampaign campaign = QCampaign.campaign;
+    private final QCampaignImage campaignImage = QCampaignImage.campaignImage;
+
+    private final UserRepository userRepository;
+
+
+    /**
+     * 실시간 상태 계산 메서드
+     */
+    private CampaignStatus calculateRealTimeStatus(CampaignStatus dbStatus, Instant applyStartDate,
+                                                   Instant applyDeadline, Instant creatorAnnouncementDate,
+                                                   Instant reviewSubmissionDeadline, Instant now) {
+        if (dbStatus == CampaignStatus.DRAFT) {
+            return CampaignStatus.DRAFT;
+        }
+        if (dbStatus == CampaignStatus.WAITING_APPROVAL) {
+            return CampaignStatus.WAITING_APPROVAL;
+        }
+        if (now.isBefore(applyStartDate)) {
+            return CampaignStatus.OPEN_RESERVED;
+        }
+        if (now.isBefore(applyDeadline)) {
+            return CampaignStatus.RECRUITING;
+        }
+        if (now.isBefore(creatorAnnouncementDate)) {
+            return CampaignStatus.RECRUITMENT_CLOSED;
+        }
+        if (now.isBefore(reviewSubmissionDeadline)) {
+            return CampaignStatus.IN_REVIEW;
+        }
+
+        return CampaignStatus.COMPLETED;
+    }
+
+    @Override
+    public MainPageCampaignListResponse findCampaignsInMainPage(Long userId, LanguageFilter lang, CampaignProductTypeFilter category, Pageable pageable) {
+
+        User user = null;
+        if (userId != null) {
+            user = userRepository.findById(userId).orElse(null);
+        }
+
+        BooleanExpression langCondition = buildLanguageCondition(lang);
+        BooleanExpression categoryCondition = buildCategoryCondition(category);
+        BooleanExpression visibilityCondition = buildVisibilityCondition(user);
+
+        BooleanExpression condition = combineConditions(
+                langCondition,
+                categoryCondition,
+                visibilityCondition
+        );
+
+        List<Tuple> results = queryFactory
+                .select(
+                        campaign.id,
+                        campaign.campaignType,
+                        campaign.language,
+                        campaign.brand.brandName,
+                        campaignImage.mediaFile.fileUrl,
+                        campaign.title,
+                        campaign.applicantNumber,
+                        campaign.recruitmentNumber,
+                        campaign.applyStartDate,
+                        campaign.applyDeadline,
+                        campaign.creatorAnnouncementDate,
+                        campaign.reviewSubmissionDeadline,
+                        campaign.campaignStatus
+                )
+                .from(campaign)
+                .leftJoin(campaignImage).on(campaignImage.campaign.eq(campaign)
+                        .and(campaignImage.displayOrder.eq(1))
+                        .and(campaignImage.imageType.eq((TOP))))
+                .where(condition)
+                .orderBy(campaign.applyDeadline.asc()) // 마감기한 얼마 남지 않은 순
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Instant now = Instant.now();
+
+        List<MainPageCampaignResponse> campaignList = results.stream()
+                .map(tuple -> {
+                    CampaignStatus dbStatus = tuple.get(campaign.campaignStatus);
+                    CampaignStatus calculatedStatus = calculateRealTimeStatus(
+                            dbStatus,
+                            tuple.get(campaign.applyStartDate),
+                            tuple.get(campaign.applyDeadline),
+                            tuple.get(campaign.creatorAnnouncementDate),
+                            tuple.get(campaign.reviewSubmissionDeadline),
+                            now
+                    );
+
+                    return new AbstractMap.SimpleEntry<>(tuple, calculatedStatus);
+                })
+                // DRAFT와 WAITING_APPROVAL 는 제외한다.
+                .filter(entry -> {
+                    CampaignStatus status = entry.getValue();
+                    return status != CampaignStatus.DRAFT && status != CampaignStatus.WAITING_APPROVAL;
+                })
+                .map(entry -> {
+                    Tuple tuple = entry.getKey();
+                    return new MainPageCampaignResponse(
+                            tuple.get(campaign.id),
+                            tuple.get(campaign.campaignType),
+                            tuple.get(campaign.language),
+                            tuple.get(campaign.brand.brandName),
+                            tuple.get(campaignImage.mediaFile.fileUrl),
+                            tuple.get(campaign.title),
+                            tuple.get(campaign.applicantNumber),
+                            tuple.get(campaign.recruitmentNumber),
+                            tuple.get(campaign.applyStartDate),
+                            tuple.get(campaign.reviewSubmissionDeadline)
+                    );
+                })
+                .toList();
+
+        Long totalCount = queryFactory
+                .select(campaign.count())
+                .from(campaign)
+                .where(condition)
+                .fetchOne();
+
+        boolean isLast = (pageable.getOffset() + pageable.getPageSize()) >= totalCount;
+
+        PageableResponse pageInfo = new PageableResponse(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                campaignList.size(),
+                isLast);
+
+        return new MainPageCampaignListResponse(campaignList, pageInfo);
+    }
+
+    private BooleanExpression buildLanguageCondition(LanguageFilter lang) {
+        if (lang == null || lang == LanguageFilter.ALL) {
+            return null; // 모든 언어 포함
+        }
+        CampaignLanguage campaignLanguage = CampaignLanguage.valueOf(lang.name());
+        return campaign.language.eq(campaignLanguage);
+    }
+
+    private BooleanExpression buildCategoryCondition(CampaignProductTypeFilter category) {
+        if (category == null || category == CampaignProductTypeFilter.ALL) {
+            return null; // 모든 카테고리 포함
+        }
+        CampaignProductType campaignProductType = CampaignProductType.valueOf(category.name());
+        return campaign.campaignProductType.eq(campaignProductType);
+    }
+
+    private BooleanExpression buildVisibilityCondition(User user) {
+        // 브랜드 사용자는 모든 캠페인을 볼 수 있다
+        if (user != null && user.getRole() == Role.BRAND) {
+            return null;
+        }
+
+        // 크리에이터 또는 비로그인 사용자는 캠페인 종료 후 30일까지만 볼 수 있으므로
+        Instant thirtyDaysAgo = Instant.now().minus(30, ChronoUnit.DAYS);
+
+        // reviewSubmissionDeadline이 null이거나, 종료 후 30일이 지나지 않은 캠페인
+        return campaign.reviewSubmissionDeadline.isNull()
+                .or(campaign.reviewSubmissionDeadline.after(thirtyDaysAgo));
+    }
+
+    private BooleanExpression combineConditions(BooleanExpression... expressions) {
+        BooleanExpression result = null;
+        for (BooleanExpression expression : expressions) {
+            if (expression != null) {
+                result = (result == null) ? expression : result.and(expression);
+            }
+        }
+        return result;
+    }
+
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #223 

## 작업 내용 💻

코드를 읽기 전에 커밋 메시지 자세히 보기를 쭉 한번 보시고 리뷰를 하시는 것을 추천드립니다.

- [ 메인페이지 캠페인 리스트 조회 API 를 구현하였습니다.] 
- [ 메인페이지 Opening Soon 캠페인 리스트 조회 API  를 구현하였습니다. ] 

## 스크린샷 📷

- 메인페이지 캠페인 리스트 조회 성공 
<img width="512" height="415" alt="image" src="https://github.com/user-attachments/assets/d328bd30-7e7b-4925-b9e9-b918f334eda5" />

- 메인페이지 Opening Soon 캠페인 리스트 조회 성공
<img width="576" height="349" alt="image" src="https://github.com/user-attachments/assets/9b56090d-a599-4621-b780-d6f6cf4e0930" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 메인 페이지 캠페인 목록 및 Opening Soon 캠페인 조회 API 추가(언어·카테고리 필터, 페이지네이션, 사용자 컨텍스트 지원)
  - 메인 페이지 응답 포맷 및 캠페인 카드 DTO 추가(MainPageCampaign*, MainPageUpcomingCampaign*)

- **Refactor**
  - 캠페인 언어 타입 Language → CampaignLanguage 변경
  - 캠페인 상품 타입에 표시명 추가 및 필터(enum) 정비
  - 캠페인 엔티티에 콘텐츠 플랫폼(first/second) 필드 추가 및 관련 요청/응답 타입 반영
  - 캠페인 상태 표시(chip) 타입 추가

- **Chores**
  - 응답 메시지 문구 추가 및 리포지토리에 커스텀 쿼리 지원 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->