### PR TITLE
[Feat] #229 브랜드 마이페이지 캠페인 리스트 조회 & 브랜드 프로필 및 통계 정보 조회 & 임시저장 캠페인 조회 API 구현 

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -14,7 +14,7 @@ import com.lokoko.domain.campaign.api.dto.request.CampaignPublishRequest;
 import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
 import com.lokoko.domain.campaign.application.service.CampaignGetService;
 import com.lokoko.domain.campaign.application.service.CampaignService;
-import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatusFilter;
 import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -128,7 +128,7 @@ public class BrandController {
     @GetMapping("/my/campaigns")
     public ApiResponse<BrandMyCampaignListResponse> getBrandMyCampaigns(
             @Parameter(hidden = true) @CurrentUser Long brandId,
-            @RequestParam(required = false) CampaignStatus status,
+            @RequestParam CampaignStatusFilter status,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "6") int size
     ) {

--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -5,6 +5,7 @@ import com.lokoko.domain.brand.api.dto.request.BrandMyPageUpdateRequest;
 import com.lokoko.domain.brand.api.dto.request.BrandProfileImageRequest;
 import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignListResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandMyPageResponse;
+import com.lokoko.domain.brand.api.dto.response.BrandProfileAndStatisticsResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandProfileImageResponse;
 import com.lokoko.domain.brand.api.message.ResponseMessage;
 import com.lokoko.domain.brand.application.BrandService;
@@ -135,6 +136,15 @@ public class BrandController {
         BrandMyCampaignListResponse response = campaignGetService.getBrandMyCampaigns(brandId, status, page, size);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_MY_PAGE_CAMPAIGNS_GET_SUCCESS.getMessage(), response);
     }
+
+    @Operation(summary = "브랜드 마이페이지에서 프로필(브랜드 이미지, 이름, 이메일) 및 통계 정보(진행 중인 캠페인, 종료 캠페인)조회")
+    @GetMapping("/my/profile/stats")
+    public ApiResponse<BrandProfileAndStatisticsResponse> getBrandProfileAndStatistics(@Parameter(hidden = true) @CurrentUser Long brandId) {
+
+        BrandProfileAndStatisticsResponse response = brandService.getBrandProfileAndStatistics(brandId);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_PROFILE_AND_STATISTICS_GET_SUCCESS.getMessage(), response);
+    }
+
 
 
 

--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -11,7 +11,7 @@ import com.lokoko.domain.brand.api.message.ResponseMessage;
 import com.lokoko.domain.brand.application.BrandService;
 import com.lokoko.domain.campaign.api.dto.request.CampaignDraftRequest;
 import com.lokoko.domain.campaign.api.dto.request.CampaignPublishRequest;
-import com.lokoko.domain.campaign.api.dto.response.CampaignCreateResponse;
+import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
 import com.lokoko.domain.campaign.application.service.CampaignGetService;
 import com.lokoko.domain.campaign.application.service.CampaignService;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
@@ -48,11 +48,11 @@ public class BrandController {
     @Operation(summary = "캠페인 생성 - 임시저장",
             description = "브랜드 마이페이지에서 브랜드가 캠패인을 임시저장 상태로 생성하는 API 입니다.")
     @PostMapping("/my/campaigns/drafts")
-    public ApiResponse<CampaignCreateResponse> createDraftCampaign(
+    public ApiResponse<CampaignBasicResponse> createDraftCampaign(
             @Parameter(hidden = true) @CurrentUser Long brandId,
             @Valid @RequestBody CampaignDraftRequest draftRequest) {
 
-        CampaignCreateResponse response = campaignService.createCampaignDraft(brandId, draftRequest);
+        CampaignBasicResponse response = campaignService.createCampaignDraft(brandId, draftRequest);
         return ApiResponse.success(HttpStatus.OK,
                 ResponseMessage.CAMPAIGN_DRAFT_SUCCESS.getMessage(), response);
     }
@@ -60,11 +60,11 @@ public class BrandController {
     @Operation(summary = "캠페인 생성 - 발행",
             description = "브랜드 마이페이지에서 브랜드가 캠페인을 발행 상태로 생성하는 API 입니다.")
     @PostMapping("/my/campaigns/publish")
-    public ApiResponse<CampaignCreateResponse> createAndPublishCampaign(
+    public ApiResponse<CampaignBasicResponse> createAndPublishCampaign(
             @Parameter(hidden = true) @CurrentUser Long brandId,
             @Valid @RequestBody CampaignPublishRequest publishRequest) {
 
-        CampaignCreateResponse response = campaignService.createAndPublishCampaign(brandId, publishRequest);
+        CampaignBasicResponse response = campaignService.createAndPublishCampaign(brandId, publishRequest);
         return ApiResponse.success(HttpStatus.OK,
                 ResponseMessage.CAMPAIGN_PUBLISH_SUCCESS.getMessage(), response);
     }
@@ -72,12 +72,12 @@ public class BrandController {
     @Operation(summary = "캠페인 수정 - 임시저장",
             description = "브랜드 마이페이지에서 브랜드가 기존에 존재하는 캠페인에 대한 임시저장을 수행하는 API 입니다.")
     @PutMapping("/my/campaigns/{campaignId}/draft")
-    public ApiResponse<CampaignCreateResponse> updateCampaignDraft(
+    public ApiResponse<CampaignBasicResponse> updateCampaignDraft(
             @Parameter(hidden = true) @CurrentUser Long brandId,
             @PathVariable Long campaignId,
             @Valid @RequestBody CampaignDraftRequest draftRequest) {
 
-        CampaignCreateResponse response = campaignService.updateCampaignToDraft(brandId, campaignId, draftRequest);
+        CampaignBasicResponse response = campaignService.updateCampaignToDraft(brandId, campaignId, draftRequest);
         return ApiResponse.success(HttpStatus.OK,
                 ResponseMessage.CAMPAIGN_UPDATE_SUCCESS.getMessage(), response);
     }
@@ -85,12 +85,12 @@ public class BrandController {
     @Operation(summary = "캠페인 수정 - 발행",
             description = "브랜드 마이페이지에서 브랜드가 기존에 존재하는 캠페인에 대한 발행을 수행하는 API 입니다.")
     @PatchMapping("/my/campaigns/{campaignId}/publish")
-    public ApiResponse<CampaignCreateResponse> publishCampaign(
+    public ApiResponse<CampaignBasicResponse> publishCampaign(
             @Parameter(hidden = true) @CurrentUser Long brandId,
             @PathVariable Long campaignId,
             @Valid @RequestBody CampaignPublishRequest publishRequest) {
 
-        CampaignCreateResponse response = campaignService.updateAndPublishCampaign(brandId, campaignId, publishRequest);
+        CampaignBasicResponse response = campaignService.updateAndPublishCampaign(brandId, campaignId, publishRequest);
         return ApiResponse.success(HttpStatus.OK,
                 ResponseMessage.CAMPAIGN_PUBLISH_SUCCESS.getMessage(), response);
     }
@@ -145,8 +145,13 @@ public class BrandController {
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_PROFILE_AND_STATISTICS_GET_SUCCESS.getMessage(), response);
     }
 
+    @Operation(summary = "브랜드 마이페이지에서 임시저장한 캠페인 조회")
+    @GetMapping("/my/campaigns/drafts/{campaignId}")
+    public ApiResponse<CampaignBasicResponse> getDraftCampaign(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @PathVariable Long campaignId){
 
-
-
-
+        CampaignBasicResponse response = campaignGetService.getDraftCampaign(brandId, campaignId);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.DRAFT_CAMPAIGN_GET_SUCCESS.getMessage(), response);
+    }
 }

--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.brand.api;
 import com.lokoko.domain.brand.api.dto.request.BrandInfoUpdateRequest;
 import com.lokoko.domain.brand.api.dto.request.BrandMyPageUpdateRequest;
 import com.lokoko.domain.brand.api.dto.request.BrandProfileImageRequest;
+import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignListResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandMyPageResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandProfileImageResponse;
 import com.lokoko.domain.brand.api.message.ResponseMessage;
@@ -10,7 +11,9 @@ import com.lokoko.domain.brand.application.BrandService;
 import com.lokoko.domain.campaign.api.dto.request.CampaignDraftRequest;
 import com.lokoko.domain.campaign.api.dto.request.CampaignPublishRequest;
 import com.lokoko.domain.campaign.api.dto.response.CampaignCreateResponse;
+import com.lokoko.domain.campaign.application.service.CampaignGetService;
 import com.lokoko.domain.campaign.application.service.CampaignService;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,14 +22,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "BRAND")
 @RestController
@@ -36,6 +32,7 @@ public class BrandController {
 
     private final BrandService brandService;
     private final CampaignService campaignService;
+    private final CampaignGetService campaignGetService;
 
     @PatchMapping("/register/info")
     @Operation(summary = "회원가입시 브랜드 추가 정보를 입력하는 API 입니다.")
@@ -125,4 +122,21 @@ public class BrandController {
         brandService.updateBrandMyPage(brandId, request);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_UPDATE_MYPAGE_INFO_SUCCESS.getMessage());
     }
+
+    @Operation(summary = "브랜드 마이페이지에서 캠페인 리스트 조회.")
+    @GetMapping("/my/campaigns")
+    public ApiResponse<BrandMyCampaignListResponse> getBrandMyCampaigns(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @RequestParam(required = false) CampaignStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "6") int size
+    ) {
+
+        BrandMyCampaignListResponse response = campaignGetService.getBrandMyCampaigns(brandId, status, page, size);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_MY_PAGE_CAMPAIGNS_GET_SUCCESS.getMessage(), response);
+    }
+
+
+
+
 }

--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyCampaignListResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyCampaignListResponse.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.brand.api.dto.response;
+
+import com.lokoko.global.common.response.PageableResponse;
+
+import java.util.List;
+
+public record BrandMyCampaignListResponse(
+        List<BrandMyCampaignResponse> campaigns,
+        PageableResponse pageInfo
+) {
+}

--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyCampaignListResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyCampaignListResponse.java
@@ -1,11 +1,16 @@
 package com.lokoko.domain.brand.api.dto.response;
 
 import com.lokoko.global.common.response.PageableResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 public record BrandMyCampaignListResponse(
+        @Schema(requiredMode = REQUIRED, description = "브랜드 마이페이지 캠페인 리스트")
         List<BrandMyCampaignResponse> campaigns,
+        @Schema(requiredMode = REQUIRED, description = "페이징 정보")
         PageableResponse pageInfo
 ) {
 }

--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyCampaignResponse.java
@@ -1,16 +1,25 @@
 package com.lokoko.domain.brand.api.dto.response;
 
-import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record BrandMyCampaignResponse(
+        @Schema(requiredMode = REQUIRED, description = "캠페인 id", example = "1")
         Long id,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 대표 이미지 url")
         String campaignImageUrl,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 제목", example = "1")
         String title,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 마감기간", example = "2025-09-17T07:32:08.995Z")
         Instant applyDeadline,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 지원자 수", example = "1")
         Integer applicantNumber,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 모집인원 수", example = "10")
         Integer recruitmentNumber,
+        @Schema(requiredMode = REQUIRED, description = "캠페인 상태", example = "DRAFT")
         String campaignStatus
 ) {
 }

--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyCampaignResponse.java
@@ -1,0 +1,16 @@
+package com.lokoko.domain.brand.api.dto.response;
+
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
+
+import java.time.Instant;
+
+public record BrandMyCampaignResponse(
+        Long id,
+        String campaignImageUrl,
+        String title,
+        Instant applyDeadline,
+        Integer applicantNumber,
+        Integer recruitmentNumber,
+        String campaignStatus
+) {
+}

--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandProfileAndStatisticsResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandProfileAndStatisticsResponse.java
@@ -1,17 +1,27 @@
 package com.lokoko.domain.brand.api.dto.response;
 
 import com.lokoko.domain.brand.domain.entity.Brand;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 public record BrandProfileAndStatisticsResponse(
 
+        @Schema(requiredMode = REQUIRED, description = "브랜드 id", example = "1")
         Long brandId,
+        @Schema(requiredMode = REQUIRED, description = "브랜드 이름", example = "I WANT REST")
         String brandName,
+        @Schema(requiredMode = REQUIRED, description = "브랜드 이메일", example = "hello@gamil.com")
         String email,
+        @Schema(requiredMode = REQUIRED, description = "브랜드 프로필 이미지 url")
         String profileImageUrl,
+        @Schema(requiredMode = REQUIRED, description = "브랜드가 개설한 캠페인의 통계 정보")
         Statistics statistics
 ) {
     public record Statistics(
+            @Schema(requiredMode = REQUIRED, description = "진행 중인 캠페인 수" , example = "1")
             Integer ongoingCampaigns,
+            @Schema(requiredMode = REQUIRED, description = "종료 된 캠페인 수", example = "1")
             Integer completedCampaigns
     ){
         public static Statistics of(Integer ongoingCampaigns, Integer completedCampaigns) {

--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandProfileAndStatisticsResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandProfileAndStatisticsResponse.java
@@ -1,0 +1,32 @@
+package com.lokoko.domain.brand.api.dto.response;
+
+import com.lokoko.domain.brand.domain.entity.Brand;
+
+public record BrandProfileAndStatisticsResponse(
+
+        Long brandId,
+        String brandName,
+        String email,
+        String profileImageUrl,
+        Statistics statistics
+) {
+    public record Statistics(
+            Integer ongoingCampaigns,
+            Integer completedCampaigns
+    ){
+        public static Statistics of(Integer ongoingCampaigns, Integer completedCampaigns) {
+            return new Statistics(ongoingCampaigns, completedCampaigns);
+        }
+    }
+
+    public static BrandProfileAndStatisticsResponse of(Brand brand, Integer ongoingNumber, Integer completedNumber) {
+        return new BrandProfileAndStatisticsResponse(
+                brand.getId(),
+                brand.getBrandName(),
+                brand.getUser().getEmail(),
+                brand.getUser().getProfileImageUrl(),
+                Statistics.of(ongoingNumber, completedNumber)
+        );
+    }
+}
+

--- a/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
@@ -15,7 +15,9 @@ public enum ResponseMessage {
 
     BRAND_PROFILE_IMAGE_PRESIGNED_URL_SUCCESS("브랜드 프로필 이미지 presigend url이 성공적으로 발급되었습니다."),
     BRAND_MYPAGE_INFO_SUCCESS("브랜드 마이페이지 정보를 성공적으로 불러왔습니다."),
-    BRAND_UPDATE_MYPAGE_INFO_SUCCESS("브랜드 마이페이지 정보를 성공적으로 수정했습니다.");
+    BRAND_UPDATE_MYPAGE_INFO_SUCCESS("브랜드 마이페이지 정보를 성공적으로 수정했습니다."),
+
+    BRAND_MY_PAGE_CAMPAIGNS_GET_SUCCESS("브랜드 마이페이지 캠페인 리스트 조회에 성공했습니다");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
@@ -17,7 +17,8 @@ public enum ResponseMessage {
     BRAND_MYPAGE_INFO_SUCCESS("브랜드 마이페이지 정보를 성공적으로 불러왔습니다."),
     BRAND_UPDATE_MYPAGE_INFO_SUCCESS("브랜드 마이페이지 정보를 성공적으로 수정했습니다."),
 
-    BRAND_MY_PAGE_CAMPAIGNS_GET_SUCCESS("브랜드 마이페이지 캠페인 리스트 조회에 성공했습니다");
+    BRAND_MY_PAGE_CAMPAIGNS_GET_SUCCESS("브랜드 마이페이지 캠페인 리스트 조회에 성공했습니다"),
+    BRAND_PROFILE_AND_STATISTICS_GET_SUCCESS("브랜드 마이페이지 프로필 및 통계 정보 조회에 성공했습니다");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
@@ -18,7 +18,8 @@ public enum ResponseMessage {
     BRAND_UPDATE_MYPAGE_INFO_SUCCESS("브랜드 마이페이지 정보를 성공적으로 수정했습니다."),
 
     BRAND_MY_PAGE_CAMPAIGNS_GET_SUCCESS("브랜드 마이페이지 캠페인 리스트 조회에 성공했습니다"),
-    BRAND_PROFILE_AND_STATISTICS_GET_SUCCESS("브랜드 마이페이지 프로필 및 통계 정보 조회에 성공했습니다");
+    BRAND_PROFILE_AND_STATISTICS_GET_SUCCESS("브랜드 마이페이지 프로필 및 통계 정보 조회에 성공했습니다"),
+    DRAFT_CAMPAIGN_GET_SUCCESS("임시저장 상태의 캠페인 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/brand/application/BrandService.java
+++ b/src/main/java/com/lokoko/domain/brand/application/BrandService.java
@@ -4,13 +4,14 @@ import com.lokoko.domain.brand.api.dto.request.BrandInfoUpdateRequest;
 import com.lokoko.domain.brand.api.dto.request.BrandMyPageUpdateRequest;
 import com.lokoko.domain.brand.api.dto.request.BrandProfileImageRequest;
 import com.lokoko.domain.brand.api.dto.response.BrandMyPageResponse;
+import com.lokoko.domain.brand.api.dto.response.BrandProfileAndStatisticsResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandProfileImageResponse;
 import com.lokoko.domain.brand.domain.entity.Brand;
 import com.lokoko.domain.brand.domain.repository.BrandRepository;
 import com.lokoko.domain.brand.exception.BrandNotFoundException;
+import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
 import com.lokoko.domain.productReview.exception.ErrorMessage;
 import com.lokoko.domain.productReview.exception.InvalidMediaTypeException;
-import com.lokoko.domain.user.domain.repository.UserRepository;
 import com.lokoko.global.common.entity.MediaFile;
 import com.lokoko.global.common.service.S3Service;
 import com.lokoko.global.utils.S3UrlParser;
@@ -18,12 +19,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BrandService {
 
-    private final UserRepository userRepository;
+    private final CampaignRepository campaignRepository;
     private final BrandRepository brandRepository;
     private final S3Service s3Service;
 
@@ -88,5 +91,15 @@ public class BrandService {
         }
     }
 
+    public BrandProfileAndStatisticsResponse getBrandProfileAndStatistics(Long brandId) {
 
+        Brand brand = brandRepository.findById(brandId)
+                .orElseThrow(BrandNotFoundException::new);
+
+        Instant now = Instant.now();
+        Integer ongoingCampaigns = campaignRepository.countOngoingCampaignsById(brandId, now);
+        Integer completedCampaigns = campaignRepository.countCompletedCampaignsById(brandId, now);
+
+        return BrandProfileAndStatisticsResponse.of(brand, ongoingCampaigns, completedCampaigns);
+    }
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
@@ -5,27 +5,63 @@ import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
 import com.lokoko.domain.socialclip.domain.entity.enums.ContentType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record CampaignBasicResponse(
+        @Schema(requiredMode = REQUIRED, description = "캠페인 id", example = "1")
         Long campaignId,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 제목", example = "나는야 캠페인")
         String campaignTitle,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 진행 언어", example = "ENG")
         CampaignLanguage language,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 종류", example = "GIVEAWAY")
         CampaignType campaignType,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 상품 카테고리", example = "SKINCARE")
         CampaignProductType campaignProductType,
+
+        @Schema(requiredMode = REQUIRED, description = "상단 이미지 리스트")
         List<CampaignImageResponse> topImages,
+
+        @Schema(requiredMode = REQUIRED, description = "하단 이미지 리스트")
         List<CampaignImageResponse> bottomImages,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 지원 시작 일시", example = "2025-09-17T시7:32:08.995Z")
         Instant applyStartDate,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 지원 마감 일", example = "2025-09-17T시7:32:08.995Z")
         Instant applyDeadline,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 발표 일시", example = "2025-09-17T07:32:08.995Z")
         Instant creatorAnnouncementDate,
+
+        @Schema(requiredMode = REQUIRED, description = "리뷰 제출 마감일", example = "2025-09-17T07:32:08.995Z")
         Instant reviewSubmissionDeadline,
+
+        @Schema(requiredMode = REQUIRED, description = "모집 인원 수 ", example = "20")
         int recruitmentNumber,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 참여 보상 리스트")
         List<String> participationRewards,
+
+        @Schema(requiredMode = REQUIRED, description = "컨텐츠 제출 요구사항 리스트")
         List<String> deliverableRequirements,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 자격 요건 리스트")
         List<String> eligibilityRequirements,
+
+        @Schema(requiredMode = REQUIRED, description = "첫 번째 제출 컨텐츠", example = "INSTA_REELS")
         ContentType firstContentType,
+
+        @Schema(requiredMode = REQUIRED, description = "두 번째 제출 컨텐츠", example = "TIKTOK_VIDEO")
         ContentType secondContentType
 ) {
     public static CampaignBasicResponse of(Campaign campaign, List<CampaignImageResponse> topImages,

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
@@ -7,7 +7,7 @@ import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
 import java.time.Instant;
 import java.util.List;
 
-public record CampaignCreateResponse(
+public record CampaignBasicResponse(
         Long campaignId,
         String campaignTitle,
         CampaignLanguage language,
@@ -23,9 +23,9 @@ public record CampaignCreateResponse(
         List<String> deliverableRequirements,
         List<String> eligibilityRequirements
 ) {
-    public static CampaignCreateResponse of(Campaign campaign, List<CampaignImageResponse> topImages,
-                                            List<CampaignImageResponse> bottomImages) {
-        return new CampaignCreateResponse(
+    public static CampaignBasicResponse of(Campaign campaign, List<CampaignImageResponse> topImages,
+                                           List<CampaignImageResponse> bottomImages) {
+        return new CampaignBasicResponse(
                 campaign.getId(),
                 campaign.getTitle(),
                 campaign.getLanguage(),

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
@@ -2,7 +2,9 @@ package com.lokoko.domain.campaign.api.dto.response;
 
 import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.domain.socialclip.domain.entity.enums.ContentType;
 
 import java.time.Instant;
 import java.util.List;
@@ -12,6 +14,7 @@ public record CampaignBasicResponse(
         String campaignTitle,
         CampaignLanguage language,
         CampaignType campaignType,
+        CampaignProductType campaignProductType,
         List<CampaignImageResponse> topImages,
         List<CampaignImageResponse> bottomImages,
         Instant applyStartDate,
@@ -21,7 +24,9 @@ public record CampaignBasicResponse(
         int recruitmentNumber,
         List<String> participationRewards,
         List<String> deliverableRequirements,
-        List<String> eligibilityRequirements
+        List<String> eligibilityRequirements,
+        ContentType firstContentType,
+        ContentType secondContentType
 ) {
     public static CampaignBasicResponse of(Campaign campaign, List<CampaignImageResponse> topImages,
                                            List<CampaignImageResponse> bottomImages) {
@@ -30,6 +35,7 @@ public record CampaignBasicResponse(
                 campaign.getTitle(),
                 campaign.getLanguage(),
                 campaign.getCampaignType(),
+                campaign.getCampaignProductType(),
                 topImages,
                 bottomImages,
                 campaign.getApplyStartDate(),
@@ -39,7 +45,9 @@ public record CampaignBasicResponse(
                 campaign.getRecruitmentNumber(),
                 campaign.getParticipationRewards(),
                 campaign.getDeliverableRequirements(),
-                campaign.getEligibilityRequirements()
+                campaign.getEligibilityRequirements(),
+                campaign.getFirstContentPlatform(),
+                campaign.getSecondContentPlatform()
 
         );
     }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignImageResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignImageResponse.java
@@ -1,10 +1,16 @@
 package com.lokoko.domain.campaign.api.dto.response;
 
 import com.lokoko.domain.image.domain.entity.CampaignImage;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 public record CampaignImageResponse(
+        @Schema(requiredMode = REQUIRED, description = "이미지 id", example = "1")
         Long id,
+        @Schema(requiredMode = REQUIRED, description = "이미지 url")
         String url,
+        @Schema(requiredMode = REQUIRED, description = "이미지 표시 순서", example = "1")
         int displayOrder
 ) {
     public static CampaignImageResponse from(CampaignImage image) {

--- a/src/main/java/com/lokoko/domain/campaign/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/message/ResponseMessage.java
@@ -11,5 +11,6 @@ public enum ResponseMessage {
     MAIN_PAGE_CAMPAIGNS_GET_SUCCESS("메인페이지에서 캠페인 리스트 조회에 성공했습니다"),
     MAIN_PAGE_UPCOMING_CAMPAIGNS_GET_SUCCESS("메인페이지에서 Opening Soon 캠페인 리스트 조회에 성공했습니다");
 
+
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -1,10 +1,8 @@
 package com.lokoko.domain.campaign.application.service;
 
 import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignListResponse;
-import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
-import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
-import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
-import com.lokoko.domain.campaign.api.dto.response.MainPageUpcomingCampaignListResponse;
+import com.lokoko.domain.brand.domain.repository.BrandRepository;
+import com.lokoko.domain.campaign.api.dto.response.*;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignDetailPageStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
@@ -12,6 +10,7 @@ import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
 import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
 import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
 import com.lokoko.domain.campaign.exception.CampaignNotFoundException;
+import com.lokoko.domain.campaign.exception.NotCampaignOwnershipException;
 import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
 import com.lokoko.domain.creatorCampaign.domain.repository.CreatorCampaignRepository;
 import com.lokoko.domain.image.domain.repository.CampaignImageRepository;
@@ -79,5 +78,22 @@ public class CampaignGetService {
         return campaignRepository.findBrandMyCampaigns(brandId, status, PageRequest.of(page, size));
     }
 
+    /**
+     * 브랜드 마이페이지 임시저장 캠페인 조회
+     */
+    public CampaignBasicResponse getDraftCampaign(Long brandId, Long campaignId) {
 
+        Campaign draftCampaign = campaignRepository.findDraftCampaignById(campaignId, CampaignStatus.DRAFT)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        if (!draftCampaign.getBrand().getId().equals(brandId)){
+            throw new NotCampaignOwnershipException();
+        }
+        initializeElementCollections(draftCampaign);
+
+        List<CampaignImageResponse> topImages = campaignImageRepository.findTopImagesByCampaignId(campaignId);
+        List<CampaignImageResponse> bottomImages = campaignImageRepository.findBottomImagesByCampaignId(campaignId);
+
+        return CampaignBasicResponse.of(draftCampaign, topImages, bottomImages);
+    }
 }

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -1,13 +1,9 @@
 package com.lokoko.domain.campaign.application.service;
 
 import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignListResponse;
-import com.lokoko.domain.brand.domain.repository.BrandRepository;
 import com.lokoko.domain.campaign.api.dto.response.*;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
-import com.lokoko.domain.campaign.domain.entity.enums.CampaignDetailPageStatus;
-import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
-import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
-import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
+import com.lokoko.domain.campaign.domain.entity.enums.*;
 import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
 import com.lokoko.domain.campaign.exception.CampaignNotFoundException;
 import com.lokoko.domain.campaign.exception.NotCampaignOwnershipException;
@@ -74,7 +70,7 @@ public class CampaignGetService {
     /**
      * 브랜드 마이페이지 캠페인 리스트 조회
      **/
-    public BrandMyCampaignListResponse getBrandMyCampaigns(Long brandId, CampaignStatus status, int page, int size) {
+    public BrandMyCampaignListResponse getBrandMyCampaigns(Long brandId, CampaignStatusFilter status, int page, int size) {
         return campaignRepository.findBrandMyCampaigns(brandId, status, PageRequest.of(page, size));
     }
 

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -1,11 +1,13 @@
 package com.lokoko.domain.campaign.application.service;
 
+import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignListResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
 import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
 import com.lokoko.domain.campaign.api.dto.response.MainPageUpcomingCampaignListResponse;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignDetailPageStatus;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
 import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
 import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
@@ -68,6 +70,13 @@ public class CampaignGetService {
 
     public MainPageUpcomingCampaignListResponse getUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category) {
         return campaignRepository.findUpcomingCampaignsInMainPage(lang, category);
+    }
+
+    /**
+     * 브랜드 마이페이지 캠페인 리스트 조회
+     **/
+    public BrandMyCampaignListResponse getBrandMyCampaigns(Long brandId, CampaignStatus status, int page, int size) {
+        return campaignRepository.findBrandMyCampaigns(brandId, status, PageRequest.of(page, size));
     }
 
 

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignService.java
@@ -9,7 +9,7 @@ import com.lokoko.domain.campaign.api.dto.request.CampaignCreateRequest;
 import com.lokoko.domain.campaign.api.dto.request.CampaignDraftRequest;
 import com.lokoko.domain.campaign.api.dto.request.CampaignMediaRequest;
 import com.lokoko.domain.campaign.api.dto.request.CampaignPublishRequest;
-import com.lokoko.domain.campaign.api.dto.response.CampaignCreateResponse;
+import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignMediaResponse;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
@@ -65,34 +65,34 @@ public class CampaignService {
     }
 
     @Transactional
-    public CampaignCreateResponse createCampaignDraft(Long brandId, CampaignDraftRequest draftRequest) {
+    public CampaignBasicResponse createCampaignDraft(Long brandId, CampaignDraftRequest draftRequest) {
         CampaignCreateRequest createRequest = CampaignCreateRequest.convertDraftToCreateRequest(draftRequest);
         return createCampaignWithAction(brandId, ActionType.SAVE_DRAFT, createRequest);
     }
 
     @Transactional
-    public CampaignCreateResponse createAndPublishCampaign(Long brandId, CampaignPublishRequest publishRequest) {
+    public CampaignBasicResponse createAndPublishCampaign(Long brandId, CampaignPublishRequest publishRequest) {
         CampaignCreateRequest createRequest = CampaignCreateRequest.convertPublishToCreateRequest(publishRequest);
         return createCampaignWithAction(brandId, ActionType.PUBLISH, createRequest);
     }
 
     @Transactional
-    public CampaignCreateResponse updateCampaignToDraft(Long brandId, Long campaignId,
-                                                        CampaignDraftRequest draftRequest) {
+    public CampaignBasicResponse updateCampaignToDraft(Long brandId, Long campaignId,
+                                                       CampaignDraftRequest draftRequest) {
         CampaignCreateRequest updateRequest = CampaignCreateRequest.convertDraftToCreateRequest(draftRequest);
         return updateCampaign(brandId, campaignId, ActionType.SAVE_DRAFT, updateRequest);
     }
 
     @Transactional
-    public CampaignCreateResponse updateAndPublishCampaign(Long brandId, Long campaignId,
-                                                           CampaignPublishRequest publishRequest) {
+    public CampaignBasicResponse updateAndPublishCampaign(Long brandId, Long campaignId,
+                                                          CampaignPublishRequest publishRequest) {
         CampaignCreateRequest updateRequest = CampaignCreateRequest.convertPublishToCreateRequest(publishRequest);
         return updateCampaign(brandId, campaignId, ActionType.PUBLISH, updateRequest);
     }
 
     @Transactional
-    public CampaignCreateResponse createCampaignWithAction(Long brandId, ActionType actionType,
-                                                           CampaignCreateRequest createRequest) {
+    public CampaignBasicResponse createCampaignWithAction(Long brandId, ActionType actionType,
+                                                          CampaignCreateRequest createRequest) {
         Brand brand = brandRepository.findById(brandId)
                 .orElseThrow(BrandNotFoundException::new);
 
@@ -124,7 +124,7 @@ public class CampaignService {
         return campaignImageRepository.saveAll(toSaveImages);
     }
 
-    private CampaignCreateResponse buildCampaignCreateResponse(
+    private CampaignBasicResponse buildCampaignCreateResponse(
             Campaign campaign, List<CampaignImage> savedImages) {
 
         List<CampaignImageResponse> topImages = savedImages.stream()
@@ -139,13 +139,13 @@ public class CampaignService {
                 .map(CampaignImageResponse::from)
                 .toList();
 
-        return CampaignCreateResponse.of(campaign, topImages, bottomImages);
+        return CampaignBasicResponse.of(campaign, topImages, bottomImages);
 
     }
 
     @Transactional
-    public CampaignCreateResponse updateCampaign(Long brandId, Long campaignId, ActionType actionType,
-                                                 CampaignCreateRequest updateRequest) {
+    public CampaignBasicResponse updateCampaign(Long brandId, Long campaignId, ActionType actionType,
+                                                CampaignCreateRequest updateRequest) {
 
         Brand brand = brandRepository.findById(brandId)
                 .orElseThrow(BrandNotFoundException::new);

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -36,14 +36,12 @@ public class Campaign extends BaseEntity {
     @JoinColumn(name = "brand_id")
     private Brand brand;
 
-    @Column(nullable = false)
     private String title;
 
     /**
      * 캠페인 진행언어
      */
     @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
     private CampaignLanguage language;
 
     /**
@@ -51,7 +49,6 @@ public class Campaign extends BaseEntity {
      * ex. GIVEAWAY / CONTENTS / EXCLUSIVE
      */
     @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
     private CampaignType campaignType;
 
     /**
@@ -66,29 +63,21 @@ public class Campaign extends BaseEntity {
      * 캠페인을 진행할 상품의 카테고리
      */
     @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
     private CampaignProductType campaignProductType;
 
-
-    @Column(nullable = false)
     private Instant applyStartDate;
 
-    @Column(nullable = false)
     private Instant applyDeadline;
 
-    @Column(nullable = false)
     private Instant creatorAnnouncementDate;
 
-    @Column(nullable = false)
     private Instant reviewSubmissionDeadline;
 
     private Integer recruitmentNumber; // 모집 인원
 
-    private int applicantNumber; // 지원 인원
+    private Integer applicantNumber; // 지원 인원
 
-    private int approvedNumber; // 승인 인원
-
-
+    private Integer approvedNumber; // 승인 인원
 
     /**
      * 크리에이터 참여 보상 목록
@@ -127,13 +116,10 @@ public class Campaign extends BaseEntity {
     @Column
     private Instant publishedAt;
 
-
     @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
     private ContentType firstContentPlatform;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
     private ContentType secondContentPlatform;
 
     /**

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -186,6 +186,12 @@ public class Campaign extends BaseEntity {
             this.eligibilityRequirements.clear();
             this.eligibilityRequirements.addAll(request.eligibilityRequirements());
         }
+        if (request.firstContentType() != null) {
+            this.firstContentPlatform = request.firstContentType();
+        }
+        if (request.secondContentType() != null) {
+            this.secondContentPlatform = request.secondContentType();
+        }
     }
 
 

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignStatusFilter.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/enums/CampaignStatusFilter.java
@@ -1,0 +1,17 @@
+package com.lokoko.domain.campaign.domain.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CampaignStatusFilter {
+    ALL("모두"),
+    DRAFT("임시 저장"),
+    WAITING_APPROVAL("대기 중"),
+    OPEN_RESERVED("오픈 예정"),
+    ACTIVE("진행 중"),
+    COMPLETED("종료");
+
+    private final String displayName;
+}

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
@@ -4,6 +4,8 @@ import com.lokoko.domain.campaign.domain.entity.Campaign;
 
 import java.time.Instant;
 import java.util.Optional;
+
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,6 +21,10 @@ public interface CampaignRepository extends JpaRepository<Campaign, Long> , Camp
     @EntityGraph(attributePaths = {"brand"})
     @Query("SELECT c FROM Campaign c WHERE c.id = :id")
     Optional<Campaign> findCampaignWithBrandById(Long id);
+
+    @EntityGraph(attributePaths = {"brand"})
+    @Query("SELECT c FROM Campaign c WHERE c.id = :id AND c.campaignStatus = :status")
+    Optional<Campaign> findDraftCampaignById(Long id, @Param("status") CampaignStatus status);
 
     @Query("SELECT count(c) FROM Campaign c " +
             "WHERE c.brand.id = :brandId " +

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
@@ -1,10 +1,13 @@
 package com.lokoko.domain.campaign.domain.repository;
 
 import com.lokoko.domain.campaign.domain.entity.Campaign;
+
+import java.time.Instant;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,4 +19,19 @@ public interface CampaignRepository extends JpaRepository<Campaign, Long> , Camp
     @EntityGraph(attributePaths = {"brand"})
     @Query("SELECT c FROM Campaign c WHERE c.id = :id")
     Optional<Campaign> findCampaignWithBrandById(Long id);
+
+    @Query("SELECT count(c) FROM Campaign c " +
+            "WHERE c.brand.id = :brandId " +
+            "AND c.campaignStatus NOT IN ('DRAFT', 'WAITING_APPROVAL') " +
+            "AND c.applyStartDate <= :now " +
+            "AND c.reviewSubmissionDeadline > :now")
+    Integer countOngoingCampaignsById(@Param("brandId") Long brandId, @Param("now") Instant now);
+
+
+    @Query("SELECT count(c) FROM Campaign c " +
+            "WHERE c.brand.id = :brandId " +
+            "AND c.campaignStatus NOT IN ('DRAFT', 'WAITING_APPROVAL') " +
+            "AND c.reviewSubmissionDeadline <= :now")
+    Integer countCompletedCampaignsById(@Param("brandId") Long brandId, @Param("now") Instant now);
+
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
@@ -4,7 +4,7 @@ import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignListResponse;
 import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
 import com.lokoko.domain.campaign.api.dto.response.MainPageUpcomingCampaignListResponse;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
-import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatusFilter;
 import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
 import org.springframework.data.domain.Pageable;
 
@@ -15,5 +15,5 @@ public interface CampaignRepositoryCustom {
 
     MainPageUpcomingCampaignListResponse findUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category);
 
-    BrandMyCampaignListResponse findBrandMyCampaigns(Long brandId, CampaignStatus status, Pageable pageable);
+    BrandMyCampaignListResponse findBrandMyCampaigns(Long brandId, CampaignStatusFilter status, Pageable pageable);
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
@@ -6,7 +6,6 @@ import com.lokoko.domain.campaign.api.dto.response.MainPageUpcomingCampaignListR
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 public interface CampaignRepositoryCustom {

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
@@ -1,8 +1,10 @@
 package com.lokoko.domain.campaign.domain.repository;
 
+import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignListResponse;
 import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
 import com.lokoko.domain.campaign.api.dto.response.MainPageUpcomingCampaignListResponse;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.LanguageFilter;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -13,4 +15,6 @@ public interface CampaignRepositoryCustom {
     MainPageCampaignListResponse findCampaignsInMainPage(Long userId, LanguageFilter lang, CampaignProductTypeFilter category, Pageable pageable);
 
     MainPageUpcomingCampaignListResponse findUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category);
+
+    BrandMyCampaignListResponse findBrandMyCampaigns(Long brandId, CampaignStatus status, Pageable pageable);
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -62,7 +62,6 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
         BooleanExpression condition = campaign.brand.id.eq(brandId);
 
         if (filterStatus != null && !"ALL".equals(filterStatus.name())) {
-            // ACTIVE 이면 RECRUITING, RECRUITMENT_CLOSED, IN_REVIEW를 모두 포함시켜야겠지.
             if ("ACTIVE".equals(filterStatus.name())) {
                 condition = condition.and(
                     statusCase.eq(CampaignStatus.RECRUITING.name())


### PR DESCRIPTION
## Related issue 🛠

- closed #228 

## 작업 내용 💻

🟩  브랜드 마이페이지에서 임시저장 캠페인을  조회하는 API 를 구현하였습니다.

<img width="272" height="757" alt="image" src="https://github.com/user-attachments/assets/42c69952-03f6-457b-b3e0-62e6d38ae4c4" />
브랜드 마이페이지에서 브랜드가 임시저장 상태인 캠페인에 대해 편집하기 버튼을 누르면, 해당 뷰로 이동을 해야합니다.
임시저장 된 필드를 보여줘야 하기 때문에 GET API 가 필요합니다.

--------

🟩  브랜드 마이페이지에서 브랜드 프로필 및 통계 정보 조회를 조회하는 API 를 구현하였습니다.
<img width="785" height="162" alt="image" src="https://github.com/user-attachments/assets/4c06e02a-37bd-4a0a-a1fe-c2e560616043" />

브랜드 프로필 이미지, 이름, 이메일이 필요합니다.
또한, 진행중인 캠페인과 종료된 캠페인 수도 조회해야합니다.

이 정보를 한 번에 조회하는 API 를 구현하였습니다.

----

🟩 브랜드 마이페이지에서 캠페인 리스트를 조회하는 API 를 구현하였습니다.

<img width="683" height="441" alt="image" src="https://github.com/user-attachments/assets/5ce960f4-b811-4f7f-b61b-44d684229cbb" />

코드에는 필터랑, 페이지네이션까지 구현되어 있는데요. 뷰에는 필터랑 페이지네이션이 포함되어 있지 않습니다.
해당 부분은 이번 회의에서 확인 완료했고, 디자인 팀이 누락한 것이었기 때문에 걱정 안 하셔도 됩니다. 

------

## 스크린샷 📷

1. 브랜드 마이페이지 캠페인 리스트 조회 성공
<img width="1015" height="400" alt="image" src="https://github.com/user-attachments/assets/46ba5768-acab-4795-b64c-bcab8f8bd813" />

2. 브랜드 마이페이지 브랜드 프로필 및 통계 정보 조회 성공
<img width="761" height="255" alt="image" src="https://github.com/user-attachments/assets/4ac48b5d-fac8-419f-b04e-eb45a5255b79" />

3. 임시저장 캠페인 조회 성공
<img width="448" height="411" alt="image" src="https://github.com/user-attachments/assets/0beca87b-992f-4308-b023-33a48c54736f" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 브랜드 마이페이지 캠페인 목록 조회(상태 필터, 페이징)
  * 브랜드 프로필 및 통계(진행/완료 캠페인 수) 조회
  * 임시저장 캠페인 단건 조회
  * 메인페이지 캠페인 및 오픈 예정 리스트 조회

* **Changes**
  * 캠페인 응답 형식 통일(CampaignBasicResponse 채택)
  * 브랜드용 목록/프로필 DTO 및 상태 필터 추가
  * 관련 성공 메시지 항목 추가 및 응답 구조 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->