### PR TITLE
[CHORE] #243 : 틱톡 PermitUrl 변경

### DIFF
--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -57,11 +57,8 @@ public class PermitUrlConfig {
      */
     public String[] getCreatorUrl() {
         return new String[]{
-                "/api/auth/tiktok/connect",
-                "/api/auth/tiktok/callback",
-                "/api/auth/tiktok/status",
-                "/api/auth/tiktok/sync",
-                "/api/auth/tiktok/disconnect"
+                "/api/auth/sns/tiktok/connect",
+                "/api/auth/sns/tiktok/callback",
         };
     }
 


### PR DESCRIPTION
## Related issue 🛠

- closed #242 

## 작업 내용 💻

크리에이터 URL 에 아래 두 엔드포인트를 추가합니다.
"/api/auth/sns/tiktok/connect",
 "/api/auth/sns/tiktok/callback",

## 스크린샷 📷


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 크리에이터용 TikTok 연동 경로를 SNS 네임스페이스로 통합했습니다: /api/auth/sns/tiktok/{connect,callback}.
  - 기존 /api/auth/tiktok/... 경로는 더 이상 허용되지 않습니다. 저장된 링크, 자동화, 스크립트를 새 경로로 업데이트하세요.
  - 인증 및 콜백 흐름은 동일하게 동작하며, 모바일·웹 모두 적용됩니다.
  - 기능 변화는 없고, 허용되는 접근 URL 범위가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->