### PR TITLE
Feat #247 크리에이터 프로필 사진 presign url 발급 api

### DIFF
--- a/src/main/java/com/lokoko/domain/creator/api/CreatorController.java
+++ b/src/main/java/com/lokoko/domain/creator/api/CreatorController.java
@@ -2,10 +2,12 @@ package com.lokoko.domain.creator.api;
 
 import com.lokoko.domain.creator.api.dto.request.CreatorInfoUpdateRequest;
 import com.lokoko.domain.creator.api.dto.request.CreatorMyPageUpdateRequest;
+import com.lokoko.domain.creator.api.dto.request.CreatorProfileImageRequest;
 import com.lokoko.domain.creator.api.dto.response.CreatorAddressInfo;
 import com.lokoko.domain.creator.api.dto.response.CreatorInfoResponse;
 import com.lokoko.domain.creator.api.dto.response.CreatorMyCampaignListResponse;
 import com.lokoko.domain.creator.api.dto.response.CreatorMyPageResponse;
+import com.lokoko.domain.creator.api.dto.response.CreatorProfileImageResponse;
 import com.lokoko.domain.creator.api.dto.response.CreatorRegisterCompleteResponse;
 import com.lokoko.domain.creator.api.dto.response.CreatorSnsConnectedResponse;
 import com.lokoko.domain.creator.api.message.ResponseMessage;
@@ -62,12 +64,26 @@ public class CreatorController {
                 creatorUsecase.updateMyProfile(userId, request));
     }
 
+    @PostMapping("/profile/image")
+    @Operation(summary = "크리에이터 프로필 이미지 presignedUrl 발급")
+    public ApiResponse<CreatorProfileImageResponse> createProfileImagePresignedUrl(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @Valid @RequestBody CreatorProfileImageRequest request) {
+
+        CreatorProfileImageResponse response = creatorUsecase.createPresignedUrlForProfile(userId, request);
+
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.PROFILE_IMAGE_PRESIGNED_URL_SUCCESS.getMessage(),
+                response);
+    }
+
+
     @Operation(summary = "크리에이터 주소 정보 조회")
     @GetMapping("/profile/address")
     public ApiResponse<CreatorAddressInfo> getCreatorAddress(
             @Parameter(hidden = true) @CurrentUser Long userId
     ) {
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.PROFILE_FETCH_ADDRESS_SUCCESS.getMessage(), creatorUsecase.getMyAddress(userId)
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.PROFILE_FETCH_ADDRESS_SUCCESS.getMessage(),
+                creatorUsecase.getMyAddress(userId)
         );
     }
 

--- a/src/main/java/com/lokoko/domain/creator/api/dto/request/CreatorMyPageUpdateRequest.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/request/CreatorMyPageUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.lokoko.domain.creator.api.dto.request;
 
 import com.lokoko.domain.creator.domain.entity.enums.ContentLanguage;
+import com.lokoko.domain.creator.domain.entity.enums.Gender;
 import com.lokoko.domain.creator.domain.entity.enums.SkinTone;
 import com.lokoko.domain.creator.domain.entity.enums.SkinType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,6 +26,13 @@ public record CreatorMyPageUpdateRequest(
 
         @Schema(description = "성", example = "Anderson")
         String lastName,
+
+        @Schema(description = "생년월일(YYYY-MM-DD)", example = "2001-10-19")
+        @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$")
+        String birthDate,
+
+        @Schema(description = "성별", example = "FEMALE")
+        Gender gender,
 
         @Schema(description = "국가번호 (선택, 최대 5자)", example = "+1")
         @Size(max = 5)

--- a/src/main/java/com/lokoko/domain/creator/api/dto/request/CreatorProfileImageRequest.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/request/CreatorProfileImageRequest.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.creator.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreatorProfileImageRequest(
+        
+        @NotNull
+        String mediaType
+) {
+}

--- a/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorBasicInfo.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorBasicInfo.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.creator.api.dto.response;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.lokoko.domain.creator.domain.entity.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -23,6 +24,12 @@ public record CreatorBasicInfo(
         String firstName,
 
         @Schema(requiredMode = REQUIRED, description = "성", example = "Anderson")
-        String lastName
+        String lastName,
+
+        @Schema(requiredMode = REQUIRED, description = "성별", example = "FEMALE")
+        Gender gender,
+
+        @Schema(requiredMode = REQUIRED, description = "생년월일(YYYY-MM-DD)", example = "1999-10-19")
+        String birthDate
 ) {
 }

--- a/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorProfileImageResponse.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorProfileImageResponse.java
@@ -1,0 +1,12 @@
+package com.lokoko.domain.creator.api.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreatorProfileImageResponse(
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 프로필 이미지 URL")
+        String profileImageUrl
+) {
+}

--- a/src/main/java/com/lokoko/domain/creator/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/creator/api/message/ResponseMessage.java
@@ -15,11 +15,12 @@ public enum ResponseMessage {
     CREATOR_LOGIN_SUCCESS("크리에이터 최종 회원가입이 성공했습니다"),
 
     // 마이페이지 관련
-    PROFILE_FETCH_SUCCESS("크리에이터 마이페이지 조회 성공"),
-    PROFILE_UPDATE_SUCCESS("크리에이터 마이페이지 수정 성공"),
-    ADDRESS_CONFIRM_SUCCESS("배송지 확정 성공"),
-    MY_CAMPAIGN_FETCH_SUCCESS("참여 캠페인 조회 성공"),
-    PROFILE_FETCH_ADDRESS_SUCCESS("크리에이터 배송지 조회 성공");
+    PROFILE_FETCH_SUCCESS("크리에이터 마이페이지 조회를 성공했습니다."),
+    PROFILE_UPDATE_SUCCESS("크리에이터 마이페이지 수정을 성공했습니다."),
+    PROFILE_IMAGE_PRESIGNED_URL_SUCCESS("크리에이터 프로필 이미지 presignedUrl 발급을 성공했습니다."),
+    ADDRESS_CONFIRM_SUCCESS("배송지 확정에 성공했습니다."),
+    MY_CAMPAIGN_FETCH_SUCCESS("참여 캠페인 조회에 성공했습니다."),
+    PROFILE_FETCH_ADDRESS_SUCCESS("크리에이터 배송지 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/creator/application/mapper/CreatorMapper.java
+++ b/src/main/java/com/lokoko/domain/creator/application/mapper/CreatorMapper.java
@@ -21,6 +21,8 @@ public class CreatorMapper {
                         .creatorName(creator.getCreatorName())
                         .firstName(creator.getFirstName())
                         .lastName(creator.getLastName())
+                        .gender(creator.getGender())
+                        .birthDate(creator.getBirthDate())
                         .build())
                 .creatorContactInfo(CreatorContactInfo.builder()
                         .email(creator.getUser().getEmail())

--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorUpdateService.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorUpdateService.java
@@ -42,6 +42,13 @@ public class CreatorUpdateService {
             creator.changeLastName(request.lastName());
         }
 
+        if (request.birthDate() != null) {
+            creator.changeBirthDate(request.birthDate());
+        }
+        if (request.gender() != null) {
+            creator.changeGender(request.gender());
+        }
+
         if (request.countryCode() != null) {
             creator.changeCountryCode(request.countryCode());
         }

--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
@@ -3,11 +3,13 @@ package com.lokoko.domain.creator.application.service;
 import com.lokoko.domain.campaignReview.application.service.CampaignReviewGetService;
 import com.lokoko.domain.creator.api.dto.request.CreatorInfoUpdateRequest;
 import com.lokoko.domain.creator.api.dto.request.CreatorMyPageUpdateRequest;
+import com.lokoko.domain.creator.api.dto.request.CreatorProfileImageRequest;
 import com.lokoko.domain.creator.api.dto.response.CreatorAddressInfo;
 import com.lokoko.domain.creator.api.dto.response.CreatorInfoResponse;
 import com.lokoko.domain.creator.api.dto.response.CreatorMyCampaignListResponse;
 import com.lokoko.domain.creator.api.dto.response.CreatorMyCampaignResponse;
 import com.lokoko.domain.creator.api.dto.response.CreatorMyPageResponse;
+import com.lokoko.domain.creator.api.dto.response.CreatorProfileImageResponse;
 import com.lokoko.domain.creator.api.dto.response.CreatorRegisterCompleteResponse;
 import com.lokoko.domain.creator.api.dto.response.CreatorSnsConnectedResponse;
 import com.lokoko.domain.creator.application.mapper.CreatorMapper;
@@ -75,6 +77,14 @@ public class CreatorUsecase {
         Creator updated = creatorUpdateService.updateProfile(creator, request);
 
         return creatorMapper.toMyPageResponse(updated);
+    }
+
+    @Transactional
+    public CreatorProfileImageResponse createPresignedUrlForProfile(Long userId,
+                                                                    CreatorProfileImageRequest request) {
+        Creator creator = creatorGetService.findByUserId(userId);
+
+        return creatorUpdateService.createPresignedUrlForProfile(creator.getId(), request);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Related issue 🛠

- closed #246 

## 작업 내용 💻

- [x] 크리에이터 프로필 사진 Presign URL 발급 API
- [x] 마이페이지 조회 API에서 자잘한 반환 필드 수정

## 스크린샷 📷

- x

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- Presign URL은 기존에 구현되어있던 형식이랑 최대한 비슷하게 구현했습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 크리에이터 프로필 이미지 업로드용 사전 서명 URL 발급 API(POST /profile/image) 추가.
  - 마이페이지 기본 정보 응답에 성별, 생년월일(YYYY-MM-DD) 필드가 포함됩니다.
  - 마이페이지 수정 요청에서 성별, 생년월일 입력을 지원합니다.
  - 프로필 이미지 업로드 미디어 타입에 대한 유효성 검증을 추가했습니다.

- 스타일
  - 마이페이지, 배송지, 참여 캠페인 등 여러 응답 메시지 문구를 더 자연스럽게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->