### PR TITLE
[FIX] #250 : 틱톡 redirect uri 를 직접 api 응답에 반환하도록 수정

### DIFF
--- a/src/main/java/com/lokoko/global/auth/controller/SnsConnectionController.java
+++ b/src/main/java/com/lokoko/global/auth/controller/SnsConnectionController.java
@@ -31,12 +31,10 @@ public class SnsConnectionController {
 
     @Operation(summary = "TikTok 계정 연결", description = "Creator가 TikTok 계정 연결 / TikTok OAuth 인증 페이지로 리다이렉트")
     @GetMapping("/tiktok/connect")
-    public void connectTikTok(
-            @Parameter(hidden = true) @CurrentUser Long userId,
-            HttpServletResponse response) throws IOException {
-
+    public ApiResponse<String> connectTikTok(
+            @Parameter(hidden = true) @CurrentUser Long userId){
         String authUrl = tikTokConnectionService.generateConnectionUrl(userId);
-        response.sendRedirect(authUrl);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.TIKTOK_REDIRECT_URI_GET_SUCCESS.getMessage(), authUrl);
     }
 
     @Operation(summary = "TikTok OAuth 콜백", description = "TikTok OAuth 인증 후 콜백을 처리 및 계정 연결 완료")

--- a/src/main/java/com/lokoko/global/auth/controller/enums/ResponseMessage.java
+++ b/src/main/java/com/lokoko/global/auth/controller/enums/ResponseMessage.java
@@ -12,7 +12,7 @@ public enum ResponseMessage {
     REFRESH_TOKEN_REISSUE("리프레시 토큰 재발급에 성공했습니다."),
     ROLE_ASSIGNED_SUCCESS("역할 설정이 완료되었습니다."),
     TIKTOK_CONNECT_SUCCESS("틱톡 계정 연결에 성공했습니다."),
-
+    TIKTOK_REDIRECT_URI_GET_SUCCESS("틱톡 redirect uri 반환에 성공했습니다"),
     GET_LOGIN_USER_ID_SUCCESS("로그인한 유저의 ID를 성공적으로 불러왔습니다.");
 
     private final String message;


### PR DESCRIPTION
## Related issue 🛠

- closed #249 

## 작업 내용 💻

서버에서 리다이렉트 시키지 않고, redirect uri 를 직접 반환합니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 틱톡 연결 API가 리디렉트 대신 인증 URL을 포함한 표준 응답을 반환합니다. 클라이언트에서 해당 URL로 이동해 연결을 진행할 수 있습니다.
- 개선/리팩터
  - 소셜 연결 흐름의 응답 형식을 표준화하여 일관된 상태/메시지/데이터 구조로 제공됩니다.
- 스타일/문구
  - 틱톡 인증 URL 반환 성공에 대한 사용자 메시지를 추가해 응답 가독성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->