### PR TITLE
[CHORE] #253 : PermitUrlConfig 업데이트

### DIFF
--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -19,7 +19,8 @@ public class PermitUrlConfig {
                 "/api/reviews/video",
                 "/api/reviews/details/video",
                 "/api/reviews/{productId}/{userId}",
-                "/api/products/details/{productId}/youtube"
+                "/api/products/details/{productId}/youtube",
+                "api/campaigns/upcoming"
         };
     }
 
@@ -36,6 +37,8 @@ public class PermitUrlConfig {
                 "/api/products/categories/new",
                 "/api/products/categories/popular",
                 "/api/products/details/{productId}",
+                "/api/campaigns/{campaignId}",
+                "/api/campaigns"
         };
     }
 
@@ -53,17 +56,62 @@ public class PermitUrlConfig {
     }
 
     /**
-     * 4) Creator 전용 - Creator 권한 필요
+     * 4) Customer 전용 - Customer 권한 필요
+     *
+     */
+    public String[] getCustomerUrl() {
+        return new String[]{
+                "/api/customer/profile/image",
+                "/api/customer/profile",
+                "/api/customer/sns-status"
+        };
+    }
+
+    /**
+     * 5) Creator 전용 - Creator 권한 필요
      */
     public String[] getCreatorUrl() {
         return new String[]{
                 "/api/auth/sns/tiktok/connect",
                 "/api/auth/sns/tiktok/callback",
+                "/api/campaigns/media",
+                "/api/creator/register/info",
+                "/api/creator/register/sns-status",
+                "/api/creator/register/complete",
+                "/api/creator/profile",
+                "/api/creator/profile/{campaignId}/address",
+                "/api/creator/profile/address",
+                "/api/creator-campaign/{campaignId}/participate",
+                "/api/campaignReviews/{campaignId}/first",
+                "/api/campaignReviews/{campaignId}/second",
+                "/api/campaignReviews/my/participation",
         };
     }
 
     /**
-     * 5) 관리자 전용 (Admin) - ROLE_ADMIN
+     * 6) 브랜드 전용 (Brand) - Brand 권한 필요
+     */
+    public String[] getBrandUrl(){
+        return new String[]{
+                "/api/brands/my/campaigns/{campaigned}/applicants",
+                "/api/brands/my/campaigns/infos",
+                "/api/brands/my/campaigns/{campaignId}/applicants/approve",
+                "/api/brands/my/profile/stats",
+                "/api/brands/my/campaigns",
+                "/api/brands/my/reviews/{campaignReviewId}/revision-request",
+                "/api/brands/my/campaigns/drafts/{campaignId}",
+                "/api/brands/my/campaigns/{campaignId}/publish",
+                "/api/brands/my/campaigns/{campaignId}/draft",
+                "/api/brands/my/campaigns/drafts",
+                "/api/brands/my/campaigns/publish",
+                "/api/brands/register/info",
+                "/api/brands/profile/image",
+                "/api/brands/profile",
+        };
+    }
+
+    /**
+     * 7) 관리자 전용 (Admin) - ROLE_ADMIN
      */
     public String[] getAdminUrl() {
         return new String[]{

--- a/src/main/java/com/lokoko/global/config/SecurityConfig.java
+++ b/src/main/java/com/lokoko/global/config/SecurityConfig.java
@@ -48,7 +48,9 @@ public class SecurityConfig {
                 .requestMatchers(permitUrlConfig.getPublicUrl()).permitAll()
                 .requestMatchers(permitUrlConfig.getOptionalUrl()).permitAll()
                 .requestMatchers(permitUrlConfig.getUserUrl()).hasAnyRole(CUSTOMER.name(), CREATOR.name(), BRAND.name(), ADMIN.name())
+                .requestMatchers(permitUrlConfig.getCustomerUrl()).hasAnyRole(CUSTOMER.name(), ADMIN.name())
                 .requestMatchers(permitUrlConfig.getCreatorUrl()).hasAnyRole(CREATOR.name(), ADMIN.name())
+                .requestMatchers(permitUrlConfig.getBrandUrl()).hasAnyRole(BRAND.name(), ADMIN.name())
                 .requestMatchers(permitUrlConfig.getAdminUrl()).hasRole(ADMIN.name())
                 .anyRequest().authenticated());
 


### PR DESCRIPTION
## Related issue 🛠

- closed #252 

## 작업 내용 💻

- PermitUrlConfig 를 일괄 업데이트 해주었습니다.
노션에도, 추가한 엔드포인트에 대해서는 "URL O" 라는 표시를 해두었습니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 역할 기반 접근 제어를 강화했습니다. 고객 전용 엔드포인트는 고객/관리자만, 브랜드 전용 엔드포인트는 브랜드/관리자만 접근할 수 있습니다. 고객은 프로필 및 SNS 상태 관련 기능을, 브랜드는 캠페인 관리·승인·프로필·통계 등 기능을 해당 권한으로 이용합니다. 권한이 없는 경우 일관된 접근 거부 응답을 받을 수 있어 보안성과 예측 가능성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->