### PR TITLE
[FEAT] #255  어드민용 캠페인 발행 API 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -219,4 +219,20 @@ public class BrandController {
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.CAMPAIGN_APPLICANTS_GET_SUCCESS.getMessage(), response);
     }
 
+
+    /**
+     * 어드민용 캠페인 발행 API 추후 삭제 예정
+     */
+    @Operation(summary = "캠페인 생성 - 발행",
+            description = "브랜드 마이페이지에서 브랜드가 캠페인을 발행 상태로 생성하는 API 입니다.")
+    @PostMapping("/my/campaigns/publish/admin")
+    public ApiResponse<CampaignBasicResponse> createAndPublishCampaignForAdmin(
+            @Parameter(hidden = true) @CurrentUser Long adminId,
+            @Valid @RequestBody CampaignPublishRequest publishRequest) {
+
+        CampaignBasicResponse response = campaignService.createAndPublishCampaignForAdmin(adminId, publishRequest);
+        return ApiResponse.success(HttpStatus.OK,
+                ResponseMessage.CAMPAIGN_PUBLISH_SUCCESS.getMessage(), response);
+    }
+
 }

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignPublishRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/CampaignPublishRequest.java
@@ -4,63 +4,81 @@ import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
 import com.lokoko.domain.socialclip.domain.entity.enums.ContentType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
 import java.time.Instant;
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 public record CampaignPublishRequest(
+        @Schema(requiredMode = REQUIRED, description = "캠페인 제목", example = "로코코 신제품")
         @NotBlank(message = "캠페인 제목은 필수입니다")
         String campaignTitle,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 언어 설정", example = "EN 또는 ES")
         @NotNull(message = "언어 설정은 필수입니다")
         CampaignLanguage language,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 타입", example = "GIVEAWAY 또는 CONTENTS 또는 EXCLUSIVE")
         @NotNull(message = "캠페인 타입은 필수입니다")
         CampaignType campaignType,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 상품 타입", example = "SKINCARE 또는 SUNCARE 또는 MAKEUP")
         @NotNull(message = "캠페인 상품 타입은 필수입니다")
         CampaignProductType campaignProductType,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "썸네일 이미지 목록 (최소 1개, 최대 5개)")
         @NotEmpty(message = "상단 이미지는 최소 1개 이상 필요합니다")
         @Size(max = 5, message = "상단 이미지는 최대 5개까지 가능합니다")
         List<CampaignImageRequest> thumbnailImages,
-        
+
+        @Schema(requiredMode = NOT_REQUIRED, description = "상세 이미지 목록 (최대 15개)")
         @Size(max = 15, message = "하단 이미지는 최대 15개까지 가능합니다")
         List<CampaignImageRequest> detailImages,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "신청 시작일", example = "2024-12-01T00:00:00Z")
         @NotNull(message = "신청 시작일은 필수입니다")
         @Future(message = "신청 시작일은 미래 날짜여야 합니다")
         Instant applyStartDate,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "신청 마감일", example = "2024-12-15T23:59:59Z")
         @NotNull(message = "신청 마감일은 필수입니다")
         @Future(message = "신청 마감일은 미래 날짜여야 합니다")
         Instant applyDeadline,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 발표일", example = "2024-12-20T00:00:00Z")
         @NotNull(message = "크리에이터 발표일은 필수입니다")
         @Future(message = "크리에이터 발표일은 미래 날짜여야 합니다")
         Instant creatorAnnouncementDate,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "리뷰 제출 마감일", example = "2025-01-15T23:59:59Z")
         @NotNull(message = "리뷰 제출 마감일은 필수입니다")
         @Future(message = "리뷰 제출 마감일은 미래 날짜여야 합니다")
         Instant reviewSubmissionDeadline,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "모집 인원 수", example = "10")
         @NotNull(message = "모집 인원은 필수입니다")
         @Min(value = 1, message = "모집 인원은 최소 1명 이상이어야 합니다")
         Integer recruitmentNumber,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "참여 혜택 목록", example = "[\"신제품 무료 제공\", \"배송비 무료\"]")
         @NotEmpty(message = "참여 혜택은 최소 1개 이상 필요합니다")
         List<@NotBlank(message = "참여 혜택 항목은 공백일 수 없습니다") String> participationRewards,
-        
+
+        @Schema(requiredMode = REQUIRED, description = "컨텐츠 요구사항 목록", example = "[\"인스타그램 피드 포스팅\", \"스토리 업로드\"]")
         @NotEmpty(message = "컨텐츠 요구사항은 최소 1개 이상 필요합니다")
         List<@NotBlank(message = "컨텐츠 요구사항 항목은 공백일 수 없습니다") String> deliverableRequirements,
-        
-        // 선택사항
+
+        @Schema(requiredMode = NOT_REQUIRED, description = "참여 자격 요건 목록", example = "[\"팔로워 1000명 이상\", \"뷰티 관심분야\"]")
         List<String> eligibilityRequirements,
 
+        @Schema(requiredMode = REQUIRED, description = "첫 번째 컨텐츠 플랫폼", example = "INSTAGRAM_REELS 또는 INSTAGRAM_POST 또는 TIKTOK_VIDEO")
         @NotNull(message = "컨텐츠 플랫폼 선택은 필수입니다")
         ContentType firstContentType,
 
+        @Schema(requiredMode = REQUIRED, description = "두 번째 컨텐츠 플랫폼", example = "INSTAGRAM_REELS 또는 INSTAGRAM_POST 또는 TIKTOK_VIDEO")
         @NotNull(message = "컨텐츠 플랫폼 선택은 필수입니다")
         ContentType secondContentType
 ) {

--- a/src/main/java/com/lokoko/domain/image/domain/entity/CampaignImage.java
+++ b/src/main/java/com/lokoko/domain/image/domain/entity/CampaignImage.java
@@ -4,7 +4,6 @@ import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.image.domain.entity.enums.ImageType;
 import com.lokoko.global.common.entity.BaseEntity;
 import com.lokoko.global.common.entity.MediaFile;
-import com.lokoko.global.utils.S3UrlParser;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -37,8 +36,7 @@ public class CampaignImage extends BaseEntity {
     @Column(nullable = false)
     private ImageType imageType;
 
-    public static CampaignImage createCampaignImage(String imageUrl, int displayOrder, ImageType imageType, Campaign campaign) {
-        MediaFile mediaFile = S3UrlParser.parsePresignedUrl(imageUrl);
+    public static CampaignImage createCampaignImage(MediaFile mediaFile, int displayOrder, ImageType imageType, Campaign campaign) {
         return CampaignImage.builder()
                 .mediaFile(mediaFile)
                 .campaign(campaign)


### PR DESCRIPTION
## Related issue 🛠

- closed #254 

## 작업 내용 💻

기획 측의 캠페인 더미데이터 삽입을 위해 어드민용 캠페인 발행 API 를 구현합니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 관리자용 캠페인 즉시 생성·발행 API 엔드포인트 추가.
  - 캠페인 발행 요청에 콘텐츠 유형(firstContentType, secondContentType) 필수 입력 추가.

- Documentation
  - 요청 스키마에 필수/선택 항목을 Swagger로 명시: 제목, 언어, 캠페인/상품 유형, 썸네일, 모집·발표·제출 일정, 모집 인원, 리워드, 산출물 요구사항 등은 필수. 상세이미지는 선택, 자격요건(eligibilityRequirements)은 선택으로 표기.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->