### PR TITLE
[REFACTOR] #257  DateTimeExpression 대신 Instant 사용하도록 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -300,13 +300,13 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
     }
 
     private StringExpression createChipStatusExpression() {
-        DateTimeExpression<Instant> now = DateTimeExpression.currentTimestamp(Instant.class);
+        Instant now = Instant.now();
 
         return new CaseBuilder()
-                .when(now.after(campaign.applyStartDate)
-                        .and(now.before(campaign.applyDeadline)))
+                .when(campaign.applyStartDate.loe(now)
+                        .and(campaign.applyDeadline.gt(now)))
                 .then(CampaignChipStatus.DEFAULT.getDisplayName())
-                .when(now.after(campaign.applyDeadline))
+                .when(campaign.applyDeadline.loe(now))
                 .then(CampaignChipStatus.DISABLED.getDisplayName())
                 .otherwise(Expressions.nullExpression(String.class));
     }


### PR DESCRIPTION
## Related issue 🛠

- closed #256 

## 작업 내용 💻

메인페이지 캠페인 리스트 조회할 때, DateTimeExpression 을 사용하지 않고 Instant 를 사용하도록 수정하였습니다.

## 스크린샷 📷



## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 캠페인 신청 시작/마감 시점에 상태 배지가 간헐적으로 잘못 표기되던 문제를 수정했습니다.
  * 현재 시각을 기준으로 상태 계산을 정교화하여 경계 시점(시작 직전/직후, 마감 직전/직후)에서도 일관되게 표시됩니다.
  * 타이밍 처리에서 드물게 발생하던 지연·오차를 해소해 상태 표시의 신뢰성과 예측 가능성을 개선했습니다.
  * 사용자 조치 없이 즉시 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->