### PR TITLE
[REFACTOR] #259 OPEN_RESERVED 상태를 실시간으로 계산하도록 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -194,16 +194,17 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
             user = userRepository.findById(userId).orElse(null);
         }
 
+        Instant now = Instant.now();
+
         BooleanExpression langCondition = buildLanguageCondition(lang);
         BooleanExpression categoryCondition = buildCategoryCondition(category);
         BooleanExpression visibilityCondition = buildVisibilityCondition(user);
 
-        // DRAFT, WAITING_APPROVAL, OPEN_RESERVED 상태 제외
+        // DRAFT, WAITING_APPROVAL만 제외하고, 실시간으로 아직 시작되지 않은 캠페인도 제외
         BooleanExpression statusCondition = campaign.campaignStatus.notIn(
                 CampaignStatus.DRAFT,
-                CampaignStatus.WAITING_APPROVAL,
-                CampaignStatus.OPEN_RESERVED
-        );
+                CampaignStatus.WAITING_APPROVAL
+        ).and(campaign.applyStartDate.loe(now)); // 모집 시작일이 현재 시간보다 이전이어야 함
 
         BooleanExpression condition = combineConditions(
                 langCondition,


### PR DESCRIPTION
## Related issue 🛠

- closed #258 

## 작업 내용 💻

기존에는, DB 의 상태가 OPEN_RESERVED 이면 검색 결과에서 제외되는 로직이었습니다.
하지만, 만약 모집 시작 시간이 되었음에도 불구하고 db 의 상태가 여전히 OPEN_RESERVED 상태라면, 
검색 결과에 포함되어야 하는 요소임에도 불구하고 포함되지 않게 됩니다.
그래서 OPEN_RESERVED 상태를 실시간으로 계산하는 로직으로 수정했습니다.


## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 메인 페이지에서 신청 시작 이전인 캠페인을 더 이상 노출하지 않습니다. 현재 시각 기준으로 신청 시작일이 지난 캠페인만 표시됩니다.
  - 초안 및 승인대기 상태는 계속 제외됩니다.
  - 기존에 제외되던 예약 오픈 캠페인도 신청 시작 시 자동으로 노출됩니다.
  - 실시간 시간 비교 적용으로 캠페인 노출 상태가 지연 없이 최신으로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->