### PR TITLE
[REFACTOR] #263  Customer 와 Creator 의 SNS 연동 확인 로직을 통일

### DIFF
--- a/src/main/java/com/lokoko/domain/creator/application/mapper/CreatorMapper.java
+++ b/src/main/java/com/lokoko/domain/creator/application/mapper/CreatorMapper.java
@@ -71,8 +71,8 @@ public class CreatorMapper {
 
     public CreatorSnsConnectedResponse toSnsStateResponse(Creator creator) {
         return new CreatorSnsConnectedResponse(
-                creator.getInstaLink() != null,
-                creator.getTiktokLink() != null
+                creator.getInstagramUserId() != null,
+                creator.getTikTokUserId() != null
         );
     }
 

--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
@@ -137,8 +137,8 @@ public class CreatorUsecase {
             }
         }
 
-        boolean hasInstagram = creator.getInstaLink() != null && !creator.getInstaLink().isBlank();
-        boolean hasTiktok = creator.getTiktokLink() != null && !creator.getTiktokLink().isBlank();
+        boolean hasInstagram = creator.getInstagramUserId() != null && !creator.getInstagramUserId().isBlank();
+        boolean hasTiktok = creator.getTikTokUserId() != null && !creator.getTikTokUserId().isBlank();
 
         if (!hasInstagram && !hasTiktok) {
             throw new SnsNotConnectedException();

--- a/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
+++ b/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
@@ -89,12 +89,6 @@ public class Creator {
     @Column
     private ContentLanguage contentLanguage = ContentLanguage.ENGLISH;
 
-    @Column
-    private String instaLink;
-
-    @Column
-    private String tiktokLink;
-
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column
@@ -107,6 +101,9 @@ public class Creator {
 
     @Column
     private String tikTokUserId;
+
+    @Column
+    private String instagramUserId;
 
     //최종 전화번호
     public String getCreatorPhoneNumber() {

--- a/src/main/java/com/lokoko/global/auth/service/AuthService.java
+++ b/src/main/java/com/lokoko/global/auth/service/AuthService.java
@@ -303,8 +303,8 @@ public class AuthService {
         boolean hasBasicInfo = creator.getCreatorName() != null;
 
         // 2단계: SNS 연동 확인 (최소 하나 이상)
-        boolean hasSnsConnected = (creator.getInstaLink() != null) ||
-                (creator.getTiktokLink() != null);
+        boolean hasSnsConnected = (creator.getInstagramUserId() != null) ||
+                (creator.getTikTokUserId() != null);
 
         // 둘 다 충족해야 완료
         return hasBasicInfo && hasSnsConnected;
@@ -315,8 +315,8 @@ public class AuthService {
         Creator creator = user.getCreator();
 
         boolean hasBasicInfo = creator.getCreatorName() != null;
-        boolean hasSnsConnected = (creator.getInstaLink() != null) ||
-                (creator.getTiktokLink() != null);
+        boolean hasSnsConnected = (creator.getInstagramUserId() != null) ||
+                (creator.getTikTokUserId() != null);
 
         if (!hasBasicInfo) {
             return OauthLoginStatus.INFO_REQUIRED;
@@ -412,7 +412,7 @@ public class AuthService {
                 }
 
                 // 1개 이상의 SNS가 연동되지 않은 상태 (SNS_REQUIRED)
-                if (creator.getInstaLink() == null && creator.getTiktokLink() == null) {
+                if (creator.getInstagramUserId() == null && creator.getTikTokUserId() == null) {
                     throw new UserNotCompletedSignUpException();
                 }
 


### PR DESCRIPTION
## Related issue 🛠

- closed #262 

## 작업 내용 💻

기존에 Customer 의 SNS 연동여부는 customer.getTiktokUserid(), customer.getInstagramUserId()  으로 확인하는 반면,
Creator 의 SNS 연동여부는 creator.getTiktokLink, creator.getInstaLink 를 통해 진행하고 있었습니다.

Creator, Customer 의 틱톡/ 인스타 필드를 tikTokUserId, instagramUserId 로 통일해주었습니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 없음
- 버그 수정
  - SNS 연결 상태 판단 로직을 개선해 크리에이터 회원가입 완료 조건과 로그인 상태 표시의 정확도가 높아졌습니다.
  - SNS 미연결 시 일관된 안내/예외 처리가 적용되어 흐름 중단이나 오동작 사례를 줄였습니다.
- 리팩터링
  - SNS 연동 여부 판별 기준을 정비해 계정 식별 기반으로 통일했습니다. 이를 통해 회원가입 완료 체크, 로그인 후 상태 결정, 사용자 이름 조회 등 관련 흐름의 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->