### PR TITLE
[REFACTOR] #268 캠페인 상세조회 API 고도화 

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignDetailResponse.java
@@ -40,18 +40,26 @@ public record CampaignDetailResponse(
         List<CampaignImageResponse> thumbnailImages,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "하단 이미지 목록 리스트")
         List<CampaignImageResponse> detailImages,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "캠페인 상태" , example = "Coming Soon, Apply Now!, Completed ....")
-        String campaignStatusCode,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "사용자가 보는 현재 캠페인 상태")
+        String userSpecificCampaignStatus,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "캠페인이 PRO 크리에이터 대상 캠페인인지 여부  ", example = "true")
+        boolean isProCampaign,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "현재 상세페이지를 조회하고 있는 사용자의 권한 정보" , example = "CUSTOMER , BRAND, CREATOR, ADMIN, null(비로그인 사용자")
-        String currentUserRole
+        String currentUserRole,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "현재 사용자가 크리에이터라면, 크리에이터의 등급 정보" , example = "NOT_APPROVED, PRO, NORMAL")
+        String creatorRoleInfo
 ) {
 
     public static CampaignDetailResponse of(Campaign campaign, List<CampaignImageResponse> thumbnailImages,
                                             List<CampaignImageResponse> detailImages,
                                             CampaignDetailPageStatus campaignStatusCode,
-                                            String currentUserRole) {
+                                            String currentUserRole, String creatorRoleInfo) {
 
         Brand brand = campaign.getBrand();
+
+        boolean isProCampaign = campaign.getCampaignType() == CampaignType.CONTENTS
+                || campaign.getCampaignType() == CampaignType.EXCLUSIVE;
+
         return new CampaignDetailResponse(
                 campaign.getId(),
                 campaign.getCampaignType(),
@@ -68,7 +76,9 @@ public record CampaignDetailResponse(
                 thumbnailImages,
                 detailImages,
                 campaignStatusCode.getCode(),
-                currentUserRole
+                isProCampaign,
+                currentUserRole,
+                creatorRoleInfo
         );
     }
 }

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -13,15 +13,19 @@ import com.lokoko.domain.campaign.domain.entity.enums.*;
 import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
 import com.lokoko.domain.campaign.exception.CampaignNotFoundException;
 import com.lokoko.domain.campaign.exception.NotCampaignOwnershipException;
+import com.lokoko.domain.creator.domain.entity.Creator;
+import com.lokoko.domain.creator.domain.entity.enums.CreatorStatus;
 import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
 import com.lokoko.domain.creatorCampaign.domain.repository.CreatorCampaignRepository;
 import com.lokoko.domain.image.domain.repository.CampaignImageRepository;
 import com.lokoko.domain.user.domain.entity.User;
 import com.lokoko.domain.user.domain.repository.UserRepository;
 import com.lokoko.domain.user.exception.UserNotFoundException;
+
 import java.util.List;
 import java.util.Optional;
 
+import com.lokoko.domain.user.domain.entity.enums.Role;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Hibernate;
 import org.springframework.data.domain.PageRequest;
@@ -53,11 +57,26 @@ public class CampaignGetService {
         CampaignDetailPageStatus detailPageStatus = determineDetailPageStatus(userId, campaign);
 
         String currentUserRole = null; // 비로그인 유저
-        if (userId != null){
+        String creatorRoleInfo = null;
+
+        if (userId != null) {
             User currentUser = userRepository.findById(userId).get();
             currentUserRole = currentUser.getRole().name();
+            // user 타입 확인
+            if (currentUserRole.equals(Role.CREATOR.name())) {
+
+                Creator currentCreator = currentUser.getCreator();
+                if (currentCreator.getCreatorStatus() == CreatorStatus.NOT_APPROVED){
+                    creatorRoleInfo = CreatorStatus.NOT_APPROVED.name();
+                }
+                if (currentCreator.getCreatorType() != null){
+                    creatorRoleInfo = currentCreator.getCreatorType().name();
+                }
+            }
         }
-        return CampaignDetailResponse.of(campaign, topImages, bottomImages, detailPageStatus, currentUserRole);
+
+        return CampaignDetailResponse.of(campaign, topImages, bottomImages,
+                detailPageStatus, currentUserRole, creatorRoleInfo);
     }
 
     private Campaign findCampaignAndInitializeCollection(Long campaignId) {

--- a/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
+++ b/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
@@ -94,10 +94,9 @@ public class Creator {
     @Column
     private CreatorStatus creatorStatus = CreatorStatus.NOT_APPROVED;
 
-    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column
-    private CreatorType creatorType = CreatorType.NORMAL;
+    private CreatorType creatorType;
 
     @Column
     private String tikTokUserId;

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -20,7 +20,7 @@ public class PermitUrlConfig {
                 "/api/reviews/details/video",
                 "/api/reviews/{productId}/{userId}",
                 "/api/products/details/{productId}/youtube",
-                "api/campaigns/upcoming"
+                "/api/campaigns/upcoming"
         };
     }
 
@@ -62,7 +62,9 @@ public class PermitUrlConfig {
         return new String[]{
                 "/api/customer/profile/image",
                 "/api/customer/profile",
-                "/api/customer/sns-status"
+                "/api/customer/sns-status",
+                "/api/auth/sns/tiktok/connect",
+                "/api/auth/sns/tiktok/callback"
         };
     }
 


### PR DESCRIPTION
## Related issue 🛠

- closed #267 

## 작업 내용 💻

크리에이터 엔티티에서, creatorType enum 의 기본 값 초기화를 제거합니다.
자세한 내용은 커밋 메시지를 참고 부탁드리겠습니다. 

캠페인 상세조회 api 의 응답 dto 에
1. 현재 상세조회 페이지를 조회하고 있는 사용자의 역할 정보를 추가하였습니다.
2. 만약 현재 사용자가 크리에이터라면, 크리에이터의 등급이 무엇인지도 반환하도록 하였습니다. (NOT_APPROVED, PRO, NORMAL)
3. 조회하는 캠페인이, PRO 대상 캠페인지 여부도 반환합니다.


## 스크린샷 📷

<img width="275" height="58" alt="image" src="https://github.com/user-attachments/assets/6e27879d-2305-4e35-a436-46806b309e4e" />

추가된 필드는 위 사진과 같습니다. 

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

