### PR TITLE
[HOTFIX] #274 브랜드 전화번호 글자수 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/dto/request/BrandInfoUpdateRequest.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/request/BrandInfoUpdateRequest.java
@@ -19,7 +19,7 @@ public record BrandInfoUpdateRequest(
         String managerPosition,
 
         @NotBlank(message = "담당자 연락처는 필수입니다")
-        @Size(max = 11, message = "담당자 연락처는 최대 10자까지 가능합니다")
+        @Size(max = 11, message = "담당자 연락처는 최대 11자까지 가능합니다")
         @Pattern(regexp = "^[0-9]+$", message = "연락처는 숫자만 입력 가능합니다")
         String phoneNumber,
 

--- a/src/main/java/com/lokoko/domain/brand/api/dto/request/BrandMyPageUpdateRequest.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/request/BrandMyPageUpdateRequest.java
@@ -14,7 +14,7 @@ public record BrandMyPageUpdateRequest(
         @Size(max = 10, message = "담당자명은 최대 10자까지 가능합니다")
         String managerName,
 
-        @Size(max = 11, message = "담당자 연락처는 최대 10자까지 가능합니다")
+        @Size(max = 11, message = "담당자 연락처는 최대 11자까지 가능합니다")
         @Pattern(regexp = "^[0-9]+$", message = "연락처는 숫자만 입력 가능합니다")
         String phoneNumber,
 


### PR DESCRIPTION
## Related issue 🛠

- closed #273 

## 작업 내용 💻
- [ ] 브랜드 전화번호 글자수 수정했습니다.
- [ ] 

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **뉴 기능**
  * 연락처 입력 허용 범위 확대: 브랜드 정보 수정 및 마이페이지에서 담당자/브랜드 연락처를 최대 11자리까지 입력 가능. 기존 숫자-only 검증과 형식 제약은 유지되어, 국내 휴대전화(예: 010 포함) 입력 불편이 해소됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->