### PR TITLE
[REFACTOR] #276 : SocialClip 엔티티의 필드 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/media/socialclip/domain/SocialClip.java
+++ b/src/main/java/com/lokoko/domain/media/socialclip/domain/SocialClip.java
@@ -25,7 +25,7 @@ public class SocialClip extends BaseEntity {
     @Column(name = "social_clip_id")
     private Long id;
 
-    @ManyToOne(fetch = LAZY)
+    @OneToOne(fetch = LAZY)
     @JoinColumn(name = "campaign_review_id")
     private CampaignReview campaignReview;
 
@@ -38,8 +38,4 @@ public class SocialClip extends BaseEntity {
     Long shares;
 
     private Instant uploadedAt;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private ContentType contentType;
 }

--- a/src/main/java/com/lokoko/domain/media/socialclip/domain/SocialClip.java
+++ b/src/main/java/com/lokoko/domain/media/socialclip/domain/SocialClip.java
@@ -1,19 +1,18 @@
 package com.lokoko.domain.media.socialclip.domain;
 
+import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
 import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
 import com.lokoko.global.common.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+
+import java.time.Instant;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import static jakarta.persistence.FetchType.*;
 
 @Getter
 @Entity
@@ -26,20 +25,19 @@ public class SocialClip extends BaseEntity {
     @Column(name = "social_clip_id")
     private Long id;
 
-    @Column(nullable = false)
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "campaign_review_id")
+    private CampaignReview campaignReview;
+
     Long plays;
 
-    @Column(nullable = false)
     Long likes;
 
-    @Column(nullable = false)
     Long comments;
 
-    @Column(nullable = false)
     Long shares;
 
-    @Column(nullable = false)
-    private LocalDateTime uploadedAt;
+    private Instant uploadedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)


### PR DESCRIPTION
## Related issue 🛠

- closed #275 

## 작업 내용 💻

-[ uploadedAt 필드의 타입을 LocalDateTime -> Instant 로 변경하여 시간을 UTC 로 관리]
-[ 크리에이터의 CampaignReview 에 대해 , 한가지 SocialClip 이 존재할 수 있기 때문에 \@OneToOne 으로 CampaignReview 외래키를 매핑합니다. ]
-[ 크리에이터가 2차 리뷰 업로드를 완료하지 않은 경우라면, 아직 SocialClip 의 조회수 / 좋아요수 / 댓글수 / 공유수가 설정되지 않은 상태여야합니다. null 허용으로 ddl 을 변경합니다.] 

--> 이에 따라, dev 및 prod 의 SocialClip 테이블의  필드 타입 변경과 , null 허용 마이그레이션을 진행해주어야 합니다. 

## 스크린샷 📷


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 소셜 클립을 캠페인 리뷰와 연동할 수 있습니다. 관련 리뷰로 빠르게 이동하고 캠페인별 콘텐츠 맥락을 쉽게 확인할 수 있습니다.
* 리팩터링
  * 업로드 시각의 저장 정밀도가 개선되어 표시·정렬의 일관성과 정확성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->