### PR TITLE
[REFACTOR] #278 :  CampaignApplicantResponse 응답 구조 변경

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/CampaignApplicantResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/CampaignApplicantResponse.java
@@ -9,23 +9,32 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 public record CampaignApplicantResponse(
         @Schema(requiredMode = REQUIRED, description = "크리에이터 참여 정보 id", example = "1")
         Long creatorCampaignId,
-        @Schema(requiredMode = REQUIRED, description = "크리에이터 id", example = "1")
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 id", example = "3845")
         Long creatorId,
-        @Schema(requiredMode = REQUIRED, description = "크리에이터 프로필 이미지")
-        String creatorProfileImageUrl,
-        @Schema(requiredMode = REQUIRED, description = "크리에이터 풀네임", example = "PARK JAMES")
-        String creatorFullName,
-        @Schema(requiredMode = REQUIRED, description = "크리에이터 닉네임", example = "@rookie21")
-        String creatorNickName,
-        @Schema(requiredMode = REQUIRED, description = "인스타그램 팔로워 수", example = "111111111")
-        Integer instagramFollower,
-        @Schema(requiredMode = REQUIRED, description = "틱톡 팔로워 수", example = "2222222")
-        Integer tiktokFollower,
-        @Schema(requiredMode = REQUIRED, description = "크리에이터가 참여한 총 캠페인 수", example = "5")
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 기본 정보")
+        CreatorInfo creator,
+        @Schema(requiredMode = REQUIRED, description = "팔로워 수 정보")
+        FollowerCount followerCount,
+        @Schema(requiredMode = REQUIRED, description = "크리에이터가 참여한 총 캠페인 수", example = "10")
         Integer participationCount,
-        @Schema(requiredMode = REQUIRED, description = "크리에이터가 캠페인에 지원한 날짜", example = "2025-09-16T00:21:04Z")
+        @Schema(requiredMode = REQUIRED, description = "크리에이터가 캠페인에 지원한 날짜", example = "2025-09-27T12:45:01.455391")
         Instant appliedDate,
-        @Schema(requiredMode = REQUIRED, description = "승인 상태", example = "PENDING/APPROVED/REJECTED")
+        @Schema(requiredMode = REQUIRED, description = "승인 상태", example = "PENDING")
         String approveStatus
 ) {
+    public record CreatorInfo(
+            @Schema(requiredMode = REQUIRED, description = "크리에이터 풀네임", example = "James Rodriguez")
+            String creatorFullName,
+            @Schema(requiredMode = REQUIRED, description = "크리에이터 닉네임", example = "echandler")
+            String creatorNickName,
+            @Schema(requiredMode = REQUIRED, description = "크리에이터 프로필 이미지")
+            String creatorProfileImageUrl
+    ) {}
+
+    public record FollowerCount(
+            @Schema(requiredMode = REQUIRED, description = "인스타그램 팔로워 수", example = "3859")
+            Integer instagramFollower,
+            @Schema(requiredMode = REQUIRED, description = "틱톡 팔로워 수", example = "110089")
+            Integer tiktokFollower
+    ) {}
 }

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
@@ -47,11 +47,15 @@ public class CreatorCampaignRepositoryImpl implements CreatorCampaignRepositoryC
                 .select(Projections.constructor(CampaignApplicantResponse.class,
                         creatorCampaign.id,
                         creator.id,
-                        user.profileImageUrl,
-                        user.name,
-                        creator.creatorName,
-                        creatorSocialStats.instagramFollower,
-                        creatorSocialStats.tiktokFollower,
+                        Projections.constructor(CampaignApplicantResponse.CreatorInfo.class,
+                                user.name,
+                                creator.creatorName,
+                                user.profileImageUrl
+                        ),
+                        Projections.constructor(CampaignApplicantResponse.FollowerCount.class,
+                                creatorSocialStats.instagramFollower,
+                                creatorSocialStats.tiktokFollower
+                        ),
                         JPAExpressions
                                 .select(subCreatorCampaign.count().intValue())
                                 .from(subCreatorCampaign)


### PR DESCRIPTION
## Related issue 🛠

- closed #277 

## 작업 내용 💻

CampaignApplicantResponse 응답 구조를 변경합니다.

## 스크린샷 📷

<img width="574" height="279" alt="image" src="https://github.com/user-attachments/assets/ac56d56c-f5e7-4613-943a-e8287db7d2a7" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 캠페인 지원자 API 응답 구조를 개선해 크리에이터 정보와 팔로워 수를 각각 묶어 제공합니다. 기존 정보의 의미는 유지하면서 응답의 가독성과 확장성을 높였습니다.
- Bug Fixes
  - 참여 횟수 집계에 크리에이터 범위 필터를 명확히 적용하여 특정 상황에서 발생하던 잘못된 카운트를 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->