### PR TITLE
[Refactor] #283 크리에이터 마이페이지- 내가 참여한/참여중인 캠페인 조회 API 의 응답 구조 수정 

### DIFF
--- a/src/main/java/com/lokoko/domain/creator/api/CreatorController.java
+++ b/src/main/java/com/lokoko/domain/creator/api/CreatorController.java
@@ -47,7 +47,7 @@ public class CreatorController {
                 creatorUsecase.getMyProfile(userId));
     }
 
-    @Operation(summary = "크리에이터 마이페이지 내가 참여중/참여한 캠페인 목록 조회 [무한 스크롤]")
+    @Operation(summary = "크리에이터 마이페이지 내가 참여중/참여한 캠페인 목록 조회 [페이지네이션]")
     @GetMapping("/profile/campaigns")
     public ApiResponse<CreatorMyCampaignListResponse> getMyCampaigns(@Parameter(hidden = true) @CurrentUser Long userId,
                                                                      @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorBasicInfo.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorBasicInfo.java
@@ -30,6 +30,13 @@ public record CreatorBasicInfo(
         Gender gender,
 
         @Schema(requiredMode = REQUIRED, description = "생년월일(YYYY-MM-DD)", example = "1999-10-19")
-        String birthDate
+        String birthDate,
+
+        @Schema(requiredMode = REQUIRED, description = "이메일", example = "chanel@gmail.com")
+        String email,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 레벨", example = "PRO / NORMAL")
+        String creatorLevel
+
 ) {
 }

--- a/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorMyCampaignListResponse.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorMyCampaignListResponse.java
@@ -12,6 +12,9 @@ import lombok.Builder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CreatorMyCampaignListResponse(
 
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 기본 정보")
+        CreatorBasicInfo basicInfo,
+
         @Schema(requiredMode = REQUIRED)
         List<CreatorMyCampaignResponse> campaigns,
 

--- a/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorMyCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorMyCampaignResponse.java
@@ -1,10 +1,7 @@
 package com.lokoko.domain.creator.api.dto.response;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
-import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import lombok.Builder;
@@ -12,9 +9,6 @@ import lombok.Builder;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CreatorMyCampaignResponse(
-
-        @Schema(requiredMode = REQUIRED, description = "크리에이터 기본 정보")
-        CreatorBasicInfo basicInfo,
 
         @Schema(description = "캠페인 ID")
         Long campaignId,
@@ -24,9 +18,6 @@ public record CreatorMyCampaignResponse(
 
         @Schema(description = "리뷰 제출 데드라인")
         Instant reviewSubmissionDeadline,
-
-        @Schema(description = "소셜 클립 콘텐츠 종류", example = "INSTA_REELS")
-        ContentType contentType,
 
         @Schema(description = "참여 상태", example = "APPROVED_ADDRESS_CONFIRMED")
         ParticipationStatus participationStatus

--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
@@ -64,10 +64,10 @@ public class CreatorUsecase {
                 creatorCampaignGetService.findMyCampaigns(creator.getId(), page, size);
 
         List<CreatorMyCampaignResponse> campaigns = slice.getContent().stream()
-                .map(creatorCampaign -> creatorCampaignMapper.toMyCampaignResponse(creator, creatorCampaign))
+                .map(creatorCampaignMapper::toMyCampaignResponse)
                 .toList();
 
-        return creatorCampaignMapper.toMyCampaignListResponse(campaigns, slice);
+        return creatorCampaignMapper.toMyCampaignListResponse(creator, campaigns, slice);
     }
 
     @Transactional

--- a/src/main/java/com/lokoko/domain/creatorCampaign/application/mapper/CreatorCampaignMapper.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/application/mapper/CreatorCampaignMapper.java
@@ -26,22 +26,21 @@ public class CreatorCampaignMapper {
                 .build();
     }
 
-    public CreatorMyCampaignResponse toMyCampaignResponse(Creator creator, CreatorCampaign participation) {
+    public CreatorMyCampaignResponse toMyCampaignResponse(CreatorCampaign participation) {
         Campaign c = participation.getCampaign();
 
         return CreatorMyCampaignResponse.builder()
-                .basicInfo(toBasicInfo(creator))
                 .campaignId(c.getId())
                 .title(c.getTitle())
                 .reviewSubmissionDeadline(c.getReviewSubmissionDeadline())
-                .contentType(c.getFirstContentPlatform())
                 .participationStatus(participation.getStatus())
                 .build();
     }
 
-    public CreatorMyCampaignListResponse toMyCampaignListResponse(List<CreatorMyCampaignResponse> campaigns,
+    public CreatorMyCampaignListResponse toMyCampaignListResponse(Creator creator, List<CreatorMyCampaignResponse> campaigns,
                                                                   Slice<?> slice) {
         return CreatorMyCampaignListResponse.builder()
+                .basicInfo(toBasicInfo(creator))
                 .campaigns(campaigns)
                 .pageInfo(PageableResponse.of(slice))
                 .build();
@@ -53,6 +52,8 @@ public class CreatorCampaignMapper {
                 .creatorName(creator.getCreatorName())
                 .firstName(creator.getFirstName())
                 .lastName(creator.getLastName())
+                .email(creator.getUser() != null ? creator.getUser().getEmail() : null)
+                .creatorLevel(creator.getCreatorType().name())
                 .build();
     }
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #282 

## 작업 내용 💻

기존 응답 구조의 문제점

<img width="648" height="796" alt="image" src="https://github.com/user-attachments/assets/cb9896e9-b3bf-42d0-990b-cb24970ac693" />

위 이미지를 보면, 크리에이터의 이메일과 PRO(등급) 이 표시되어야 하지만, 기존 dto 에는 해당필드가 존재하지 않았습니다.

또한, 크리에이터의 정보가 캠페인 id 한개마다 포함되고 있어서, 불필요한 중복을 야기했습니다.

이를 수정하여서 크리에이터 정보는 캠페인 리스트를 조회할때 딱 한번만 표시되도록 수정하였습니다.



- [크리에이터 마이페이지- 내가 참여한/참여중인 캠페인 조회 API 의 응답 구조를 수정하였습니다. ] 
- [스웨거에 표시되는 api 이름을 무한 스크롤 -> 페이지네이션으로 수정하였습니다. ] 

## 스크린샷 📷

<img width="789" height="420" alt="image" src="https://github.com/user-attachments/assets/760655d2-c019-41c2-bbc7-a536d94c7831" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 내 캠페인 목록 응답에 크리에이터 기본 정보가 포함됩니다(이메일, 레벨 등 확장).
- 리팩터링
  - 개별 캠페인 항목에서 크리에이터 기본 정보와 콘텐츠 유형 필드가 제거되었습니다. 대신 목록 응답에 크리에이터 기본 정보가 제공됩니다. API 응답 필드 사용을 조정해 주세요.
- 문서
  - 내 캠페인 조회의 설명을 무한 스크롤에서 페이지네이션으로 수정해 실제 사용 방식을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->