### PR TITLE
[REFACTOR]  #290 : 캠페인 대표 이미지 조회 코드 추가

### DIFF
--- a/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorMyCampaignResponse.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorMyCampaignResponse.java
@@ -19,6 +19,10 @@ public record CreatorMyCampaignResponse(
         @Schema(description = "캠페인 이름")
         String title,
 
+        @Schema(description = "캠페인 대표 이미지 URL", example = "https://example.com/campaign-image.jpg")
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        String campaignImageUrl,
+
         @Schema(description = "리뷰 제출 데드라인")
         Instant reviewSubmissionDeadline,
 
@@ -37,6 +41,7 @@ public record CreatorMyCampaignResponse(
     public static CreatorMyCampaignResponse of(
             Long campaignId,
             String title,
+            String campaignImageUrl,
             Instant reviewSubmissionDeadline,
             ParticipationStatus participationStatus,
             List<CampaignStatusMapper.ReviewInfo> reviews,
@@ -48,6 +53,7 @@ public record CreatorMyCampaignResponse(
         return CreatorMyCampaignResponse.builder()
                 .campaignId(campaignId)
                 .title(title)
+                .campaignImageUrl(campaignImageUrl)
                 .reviewSubmissionDeadline(reviewSubmissionDeadline)
                 .nextAction(nextAction)
                 .participationStatus(participationStatus) // 호환성을 위해 유지
@@ -60,12 +66,14 @@ public record CreatorMyCampaignResponse(
     public static CreatorMyCampaignResponse ofSimple(
             Long campaignId,
             String title,
+            String campaignImageUrl,
             Instant reviewSubmissionDeadline,
             ParticipationStatus participationStatus) {
 
         return CreatorMyCampaignResponse.builder()
                 .campaignId(campaignId)
                 .title(title)
+                .campaignImageUrl(campaignImageUrl)
                 .reviewSubmissionDeadline(reviewSubmissionDeadline)
                 .nextAction(NextAction.BRAND_APPROVAL_WAITING)  // PENDING 상태의 액션
                 .participationStatus(participationStatus)

--- a/src/main/java/com/lokoko/domain/creatorCampaign/application/mapper/CreatorCampaignMapper.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/application/mapper/CreatorCampaignMapper.java
@@ -10,6 +10,7 @@ import com.lokoko.domain.creator.domain.entity.Creator;
 import com.lokoko.domain.creator.util.CampaignStatusMapper;
 import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
 import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
+import com.lokoko.domain.media.image.domain.repository.CampaignImageRepository;
 import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
 import com.lokoko.global.common.response.PageableResponse;
 import java.time.Instant;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component;
 public class CreatorCampaignMapper {
 
     private final CampaignReviewRepository campaignReviewRepository;
+    private final CampaignImageRepository campaignImageRepository;
 
     public CreatorCampaign toCampaignParticipation(Creator creator, Campaign campaign, Instant now) {
         return CreatorCampaign.builder()
@@ -46,6 +48,13 @@ public class CreatorCampaignMapper {
             requiredContentTypes.add(campaign.getSecondContentPlatform());
         }
 
+        // 캠페인 대표 이미지 조회 (썸네일 타입의 첫 번째 이미지)
+        String campaignImageUrl = campaignImageRepository.findThumbnailImagesByCampaignId(campaign.getId())
+                .stream()
+                .findFirst()
+                .map(com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse::url)
+                .orElse(null);
+
         // 실제 리뷰 정보 조회
         List<CampaignReview> campaignReviews = campaignReviewRepository.findAllByCreatorCampaignIdOrderByIdAsc(participation.getId());
 
@@ -66,6 +75,7 @@ public class CreatorCampaignMapper {
         return CreatorMyCampaignResponse.of(
                 campaign.getId(),
                 campaign.getTitle(),
+                campaignImageUrl,
                 campaign.getReviewSubmissionDeadline(),
                 participation.getStatus(),
                 reviewInfos, // 실제 리뷰 정보
@@ -91,9 +101,17 @@ public class CreatorCampaignMapper {
             requiredContentTypes.add(campaign.getSecondContentPlatform());
         }
 
+        // 캠페인 대표 이미지 조회 (썸네일 타입의 첫 번째 이미지)
+        String campaignImageUrl = campaignImageRepository.findThumbnailImagesByCampaignId(campaign.getId())
+                .stream()
+                .findFirst()
+                .map(com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse::url)
+                .orElse(null);
+
         return CreatorMyCampaignResponse.of(
                 campaign.getId(),
                 campaign.getTitle(),
+                campaignImageUrl,
                 campaign.getReviewSubmissionDeadline(),
                 participation.getStatus(),
                 reviews,


### PR DESCRIPTION
현재 N+1 발생하므로 추후 리팩토링 해야합니다.

## Related issue #289 

- closed #289 

## 작업 내용 💻

크리에이터 마이페이지 - 캠페인 리스트 조회에서, 캠페인 대표 이미지가 같이 반환되도록 합니다. 

## 스크린샷 📷

<img width="1053" height="118" alt="image" src="https://github.com/user-attachments/assets/36614ac2-016e-4a93-8447-1fce0cf60eea" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 내 캠페인/캠페인 목록에 캠페인 대표 이미지(썸네일)가 표시됩니다.
  - 캠페인 요약 응답에 이미지 URL이 포함되어, 앱과 연동 서비스에서 이미지를 쉽게 노출할 수 있습니다.
  - 리뷰 포함/미포함 목록 모두에서 이미지가 함께 제공됩니다.
  - 이미지가 없더라도 해당 필드는 항상 제공되어 응답 구조가 일관됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->