### PR TITLE
[REFACTOR] #294 브랜드 마이페이지 - 지원자 확인뷰에 상태별 필터링 추가 / 페이징 정보에 전체 페이지 개수 반환하도록 수정 

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -1,10 +1,6 @@
 package com.lokoko.domain.brand.api;
 
-import com.lokoko.domain.brand.api.dto.request.BrandInfoUpdateRequest;
-import com.lokoko.domain.brand.api.dto.request.BrandMyPageUpdateRequest;
-import com.lokoko.domain.brand.api.dto.request.BrandNoteRevisionRequest;
-import com.lokoko.domain.brand.api.dto.request.BrandProfileImageRequest;
-import com.lokoko.domain.brand.api.dto.request.CreatorApproveRequest;
+import com.lokoko.domain.brand.api.dto.request.*;
 import com.lokoko.domain.brand.api.dto.response.BrandDashboardCampaignListResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandIssuedCampaignResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignInfoListResponse;
@@ -259,11 +255,12 @@ public class BrandController {
     public ApiResponse<CampaignApplicantListResponse> getCampaignApplicants(
             @Parameter(hidden = true) @CurrentUser Long brandId,
             @PathVariable Long campaignId,
+            @RequestParam(required = false) ApplicantStatus status,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
         CampaignApplicantListResponse response = campaignGetService.getCampaignApplicants(brandId, campaignId, page,
-                size);
+                size , status);
 
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.CAMPAIGN_APPLICANTS_GET_SUCCESS.getMessage(),
                 response);

--- a/src/main/java/com/lokoko/domain/brand/api/dto/request/ApplicantStatus.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/request/ApplicantStatus.java
@@ -1,0 +1,7 @@
+package com.lokoko.domain.brand.api.dto.request;
+
+public enum ApplicantStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -1,11 +1,11 @@
 package com.lokoko.domain.campaign.application.service;
 
+import com.lokoko.domain.brand.api.dto.request.ApplicantStatus;
 import com.lokoko.domain.brand.api.dto.response.BrandDashboardCampaignListResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignInfoListResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignListResponse;
 import com.lokoko.domain.brand.api.dto.response.CampaignApplicantListResponse;
 import com.lokoko.domain.brand.domain.entity.Brand;
-import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
@@ -39,9 +39,6 @@ import org.hibernate.Hibernate;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -169,8 +166,8 @@ public class CampaignGetService {
         return campaignRepository.findSimpleCampaignInfoByBrandId(brandId);
     }
 
-    public CampaignApplicantListResponse getCampaignApplicants(Long brandId, Long campaignId, int page, int size) {
-        return creatorCampaignRepository.findCampaignApplicants(brandId, campaignId, PageRequest.of(page, size));
+    public CampaignApplicantListResponse getCampaignApplicants(Long brandId, Long campaignId, int page, int size, ApplicantStatus status) {
+        return creatorCampaignRepository.findCampaignApplicants(brandId, campaignId, PageRequest.of(page, size), status);
     }
 
     public int countOngoingCampaigns(Long brandId, Instant now) {

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -157,11 +157,12 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
         long total = totalCount != null ? totalCount : 0L;
         boolean isLast = (pageable.getOffset() + pageable.getPageSize()) >= total;
 
-        PageableResponse pageInfo = new PageableResponse(
+        PageableResponse pageInfo = PageableResponse.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize(),
                 campaigns.size(),
-                isLast
+                isLast,
+                total
         );
 
         return new BrandMyCampaignListResponse(campaigns, pageInfo);
@@ -271,11 +272,12 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
         long total = totalCount != null ? totalCount : 0L;
         boolean isLast = (pageable.getOffset() + pageable.getPageSize()) >= total;
 
-        PageableResponse pageInfo = new PageableResponse(
+        PageableResponse pageInfo = PageableResponse.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize(),
                 campaignList.size(),
-                isLast);
+                isLast,
+                total);
 
         return new MainPageCampaignListResponse(campaignList, pageInfo);
     }
@@ -415,11 +417,12 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
         long total = totalCount != null ? totalCount : 0L;
         boolean isLast = (pageable.getOffset() + pageable.getPageSize()) >= total;
 
-        PageableResponse pageInfo = new PageableResponse(
+        PageableResponse pageInfo = PageableResponse.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize(),
                 campaigns.size(),
-                isLast
+                isLast,
+                total
         );
 
         return new BrandDashboardCampaignListResponse(campaigns, pageInfo);

--- a/src/main/java/com/lokoko/domain/creator/api/CreatorController.java
+++ b/src/main/java/com/lokoko/domain/creator/api/CreatorController.java
@@ -51,7 +51,7 @@ public class CreatorController {
     @GetMapping("/profile/campaigns")
     public ApiResponse<CreatorMyCampaignListResponse> getMyCampaigns(@Parameter(hidden = true) @CurrentUser Long userId,
                                                                      @RequestParam(defaultValue = "0") int page,
-                                                                     @RequestParam(defaultValue = "20") int size
+                                                                     @RequestParam(defaultValue = "12") int size
     ) {
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.MY_CAMPAIGN_FETCH_SUCCESS.getMessage(),
                 creatorUsecase.getMyCampaigns(userId, page, size));

--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorUsecase.java
@@ -63,11 +63,13 @@ public class CreatorUsecase {
         Slice<CreatorCampaign> slice =
                 creatorCampaignGetService.findMyCampaigns(creator.getId(), page, size);
 
+        Long totalElements = creatorCampaignGetService.countMyCampaigns(creator.getId());
+
         List<CreatorMyCampaignResponse> campaigns = slice.getContent().stream()
                 .map(creatorCampaignMapper::toMyCampaignResponse)
                 .toList();
 
-        return creatorCampaignMapper.toMyCampaignListResponse(creator, campaigns, slice);
+        return creatorCampaignMapper.toMyCampaignListResponse(creator, campaigns, slice, totalElements);
     }
 
     @Transactional

--- a/src/main/java/com/lokoko/domain/creatorCampaign/application/mapper/CreatorCampaignMapper.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/application/mapper/CreatorCampaignMapper.java
@@ -128,6 +128,24 @@ public class CreatorCampaignMapper {
                 .build();
     }
 
+    /**
+     * totalPages 정보를 포함한 CreatorMyCampaignListResponse 생성
+     */
+    public CreatorMyCampaignListResponse toMyCampaignListResponse(Creator creator, List<CreatorMyCampaignResponse> campaigns,
+                                                                  Slice<?> slice, long totalElements) {
+        return CreatorMyCampaignListResponse.builder()
+                .basicInfo(toBasicInfo(creator))
+                .campaigns(campaigns)
+                .pageInfo(PageableResponse.of(
+                        slice.getNumber(),
+                        slice.getSize(),
+                        slice.getNumberOfElements(),
+                        slice.isLast(),
+                        totalElements
+                ))
+                .build();
+    }
+
     private CreatorBasicInfo toBasicInfo(Creator creator) {
         return CreatorBasicInfo.builder()
                 .creatorId(creator.getId())

--- a/src/main/java/com/lokoko/domain/creatorCampaign/application/service/CreatorCampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/application/service/CreatorCampaignGetService.java
@@ -60,6 +60,15 @@ public class CreatorCampaignGetService {
     }
 
     /**
+     * 특정 크리에이터가 참여한 캠페인 총 개수 조회
+     * @param creatorId 조회할 크리에이터의 고유 ID
+     * @return 크리에이터가 참여한 캠페인 총 개수
+     */
+    public Long countMyCampaigns(Long creatorId) {
+        return creatorCampaignRepository.countByCreatorId(creatorId);
+    }
+
+    /**
      * 크리에이터가 현재 리뷰 작성이 가능한 캠페인 참여 이력들을 조회하는 메서드
      *
      * 리뷰 작성 가능 조건:

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepository.java
@@ -57,6 +57,13 @@ public interface CreatorCampaignRepository extends JpaRepository<CreatorCampaign
             """)
     Slice<CreatorCampaign> findSliceWithCampaignByCreator(Long creatorId, Pageable pageable);
 
+    @Query("""
+                select count(cc)
+                from CreatorCampaign cc
+                where cc.creator.id = :creatorId
+            """)
+    Long countByCreatorId(Long creatorId);
+
     @Modifying(clearAutomatically = true)
     @Query("UPDATE CreatorCampaign cc SET cc.status = 'APPROVED' WHERE cc.id IN :applicationIds")
     int bulkApproveApplicationStatus(List<Long> applicationIds);

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryCustom.java
@@ -1,9 +1,10 @@
 package com.lokoko.domain.creatorCampaign.domain.repository;
 
+import com.lokoko.domain.brand.api.dto.request.ApplicantStatus;
 import com.lokoko.domain.brand.api.dto.response.CampaignApplicantListResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface CreatorCampaignRepositoryCustom {
 
-    CampaignApplicantListResponse findCampaignApplicants(Long brandId, Long campaignId, Pageable pageable);
+    CampaignApplicantListResponse findCampaignApplicants(Long brandId, Long campaignId, Pageable pageable, ApplicantStatus status);
 }

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.lokoko.domain.creatorCampaign.domain.repository;
 
+import com.lokoko.domain.brand.api.dto.request.ApplicantStatus;
 import com.lokoko.domain.brand.api.dto.response.CampaignApplicantListResponse;
 import com.lokoko.domain.brand.api.dto.response.CampaignApplicantResponse;
 import com.lokoko.domain.creator.domain.entity.QCreator;
@@ -9,6 +10,7 @@ import com.lokoko.domain.creatorSocialStats.domain.entity.QCreatorSocialStats;
 import com.lokoko.domain.user.domain.entity.QUser;
 import com.lokoko.global.common.response.PageableResponse;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.JPAExpressions;
@@ -32,7 +34,7 @@ public class CreatorCampaignRepositoryImpl implements CreatorCampaignRepositoryC
 
 
     @Override
-    public CampaignApplicantListResponse findCampaignApplicants(Long brandId, Long campaignId, Pageable pageable) {
+    public CampaignApplicantListResponse findCampaignApplicants(Long brandId, Long campaignId, Pageable pageable, ApplicantStatus status) {
 
         StringExpression simpleStatus = new CaseBuilder()
                 .when(creatorCampaign.status.eq(ParticipationStatus.PENDING))
@@ -42,6 +44,9 @@ public class CreatorCampaignRepositoryImpl implements CreatorCampaignRepositoryC
                 .when(creatorCampaign.status.in(ParticipationStatus.getActiveStatuses()))
                     .then("APPROVED")
                 .otherwise("PENDING");
+
+        // status 파라미터에 따른 필터링 조건 생성
+        BooleanExpression statusCondition = createStatusCondition(status);
 
         List<CampaignApplicantResponse> applicants = queryFactory
                 .select(Projections.constructor(CampaignApplicantResponse.class,
@@ -69,7 +74,8 @@ public class CreatorCampaignRepositoryImpl implements CreatorCampaignRepositoryC
                 .innerJoin(creatorSocialStats).on(creatorSocialStats.creator.id.eq(creator.id))
                 .where(
                         creatorCampaign.campaign.id.eq(campaignId),
-                        creatorCampaign.campaign.brand.id.eq(brandId)
+                        creatorCampaign.campaign.brand.id.eq(brandId),
+                        statusCondition  // status 필터링 조건 추가
                 )
                 .orderBy(creatorCampaign.appliedAt.desc())
                 .offset(pageable.getOffset())
@@ -82,7 +88,8 @@ public class CreatorCampaignRepositoryImpl implements CreatorCampaignRepositoryC
                 .from(creatorCampaign)
                 .where(
                         creatorCampaign.campaign.id.eq(campaignId),
-                        creatorCampaign.campaign.brand.id.eq(brandId)
+                        creatorCampaign.campaign.brand.id.eq(brandId),
+                        statusCondition  // count 쿼리에도 동일한 필터링 적용
                 )
                 .fetchOne();
 
@@ -97,5 +104,21 @@ public class CreatorCampaignRepositoryImpl implements CreatorCampaignRepositoryC
         );
 
         return new CampaignApplicantListResponse(applicants, pageInfo);
+    }
+
+    /**
+     * ApplicantStatus에 따른 필터링 조건 생성
+     * @param status null이면 필터링 없음, PENDING/APPROVED/REJECTED에 따라 다른 ParticipationStatus 필터링
+     */
+    private BooleanExpression createStatusCondition(ApplicantStatus status) {
+        if (status == null) {
+            return null; // 필터링 없음
+        }
+
+        return switch (status) {
+            case PENDING -> creatorCampaign.status.eq(ParticipationStatus.PENDING);
+            case REJECTED -> creatorCampaign.status.eq(ParticipationStatus.REJECTED);
+            case APPROVED -> creatorCampaign.status.in(ParticipationStatus.getActiveStatuses()); // APPROVED, ACTIVE, COMPLETED
+        };
     }
 }

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
@@ -96,11 +96,12 @@ public class CreatorCampaignRepositoryImpl implements CreatorCampaignRepositoryC
         long total = totalCount != null ? totalCount : 0L;
         boolean isLast = (pageable.getOffset() + pageable.getPageSize()) >= total;
 
-        PageableResponse pageInfo = new PageableResponse(
+        PageableResponse pageInfo = PageableResponse.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize(),
                 applicants.size(),
-                isLast
+                isLast,
+                total
         );
 
         return new CampaignApplicantListResponse(applicants, pageInfo);

--- a/src/main/java/com/lokoko/global/common/response/PageableResponse.java
+++ b/src/main/java/com/lokoko/global/common/response/PageableResponse.java
@@ -15,7 +15,9 @@ public record PageableResponse(
         @Schema(requiredMode = REQUIRED)
         Integer numberOfElements,
         @Schema(requiredMode = REQUIRED)
-        Boolean isLast
+        Boolean isLast,
+        @Schema(description = "전체 페이지 개수")
+        Integer totalPages
 ) {
     public static PageableResponse of(Slice<?> slice) {
         return PageableResponse.builder()
@@ -23,6 +25,21 @@ public record PageableResponse(
                 .pageSize(slice.getSize())
                 .numberOfElements(slice.getNumberOfElements())
                 .isLast(slice.isLast())
+                .totalPages(null)
+                .build();
+    }
+
+    /**
+     * 전체 페이지 정보와 함께 PageableResponse 생성
+     */
+    public static PageableResponse of(int pageNumber, int pageSize, int numberOfElements, boolean isLast, long totalElements) {
+        int totalPages = (int) Math.ceil((double) totalElements / pageSize);
+        return PageableResponse.builder()
+                .pageNumber(pageNumber)
+                .pageSize(pageSize)
+                .numberOfElements(numberOfElements)
+                .isLast(isLast)
+                .totalPages(totalPages)
                 .build();
     }
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #293 

## 작업 내용 💻

브랜드 마이페이지 - 지원자 확인뷰에 상태별 필터링 하여 조회할 수 있도록 수정합니다. 
페이징 정보에 전체 페이지 개수 반환하도록 수정합니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

