### PR TITLE
[REFACTOR] #296 : CampaignReview 에 유니크 제약 조건 추가

### DIFF
--- a/src/main/java/com/lokoko/domain/campaignReview/domain/entity/CampaignReview.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/domain/entity/CampaignReview.java
@@ -19,13 +19,20 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "campaign_reviews")
+@Table(name = "campaign_reviews",
+       uniqueConstraints = {
+           @UniqueConstraint(
+               name = "uq_campaign_review_campaign_round_content",
+               columnNames = {"creator_campaign_id", "review_round", "content_type"}
+           )
+       })
 @NoArgsConstructor
 public class CampaignReview extends BaseEntity {
 


### PR DESCRIPTION
## Related issue 🛠

- closed #295 

## 작업 내용 💻

유니크 제약 조건을 추가해야합니다.
어 ? 저번에 제거하지 않았나 생각하실 수도 있는데요.

저번에 제거한 제약 조건은 (creator_campaign_id , review_round) 유니크 제약조건입니다.
(creator_campaign_id, review_round, content_type) 에 대해서는 유일성이 보장되어야 합니다.

이유 : 크리에이터가 캠페인에 참여했는데, 동일한 컨텐츠 타입에 대해 1차 리뷰를 두 번 올릴 수 는 없겠죠.
즉, creator_campaign_id : 1 , FIRST, INSTA_REELS
creator_campiagn_id : 1 , FIRST , INSTA_REELS

두 row 가 존재하면 안되겠죠.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 동일 캠페인·리뷰 라운드·콘텐츠 유형 조합에 대한 중복 리뷰 생성이 방지되어 데이터 중복 문제를 해소합니다. 중복 시 저장이 차단되고 오류가 표시됩니다.

- 기타(품질/안정성)
  - 데이터 무결성 강화로 리뷰 관리의 일관성과 운영 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->