### PR TITLE
[FEAT] #298 : 크리에이터 최종 제출 리뷰 조회 API 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignStatusManager.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignStatusManager.java
@@ -105,8 +105,8 @@ public class CampaignStatusManager {
             // 우선순위 3: 캠페인 전체 상태 고려
             return switch (campaignStatus) {
                 case COMPLETED -> CampaignDetailPageStatus.CLOSED;
-                case RECRUITING ,IN_REVIEW, RECRUITMENT_CLOSED -> CampaignDetailPageStatus.ACTIVE;
-                default -> CampaignDetailPageStatus.APPLIED;
+                case IN_REVIEW, RECRUITMENT_CLOSED -> CampaignDetailPageStatus.ACTIVE;
+                default -> CampaignDetailPageStatus.APPLIED; // RECRUITING 및 기타 상태
             };
         }
     }

--- a/src/main/java/com/lokoko/domain/campaignReview/api/CampaignReviewController.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/api/CampaignReviewController.java
@@ -4,9 +4,9 @@ import com.lokoko.domain.campaign.api.dto.response.CampaignParticipatedResponse;
 import com.lokoko.domain.campaignReview.api.dto.request.FirstReviewUploadRequest;
 import com.lokoko.domain.campaignReview.api.dto.request.SecondReviewUploadRequest;
 import com.lokoko.domain.campaignReview.api.dto.response.ReviewUploadResponse;
+import com.lokoko.domain.campaignReview.api.dto.response.CompletedReviewResponse;
 import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
 import com.lokoko.domain.campaignReview.api.message.ResponseMessage;
-import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
 import com.lokoko.domain.campaignReview.application.usecase.CampaignReviewUsecase;
 import com.lokoko.domain.media.api.dto.request.MediaPresignedUrlRequest;
 import com.lokoko.domain.media.api.dto.response.MediaPresignedUrlResponse;
@@ -84,6 +84,18 @@ public class CampaignReviewController {
         MediaPresignedUrlResponse response = campaignReviewUsecase.createMediaPresignedUrl(userId, request);
 
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_MEDIA_PRESIGNED_URL_SUCCESS.getMessage(),
+                response);
+    }
+
+    @Operation(summary = "완료된 캠페인 리뷰 결과 조회 (2차 리뷰)")
+    @GetMapping("/{campaignId}/results")
+    public ApiResponse<CompletedReviewResponse> getCompletedReviews(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @PathVariable Long campaignId
+    ) {
+        CompletedReviewResponse response = campaignReviewUsecase.getCompletedReviews(userId, campaignId);
+
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.COMPLETED_REVIEW_FETCH_SUCCESS.getMessage(),
                 response);
     }
 

--- a/src/main/java/com/lokoko/domain/campaignReview/api/dto/response/CompletedReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/api/dto/response/CompletedReviewResponse.java
@@ -1,0 +1,42 @@
+package com.lokoko.domain.campaignReview.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.List;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CompletedReviewResponse(
+        @Schema(description = "참여한 캠페인 ID", example = "61")
+        Long campaignId,
+
+        @Schema(description = "완료된 리뷰 컨텐츠 목록")
+        List<CompletedReviewContent> reviewContents
+) {
+
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record CompletedReviewContent(
+            @Schema(description = "컨텐츠 타입", example = "INSTA_REELS")
+            ContentType contentType,
+
+            @Schema(description = "최종 제출한 캡션과 해시태그", example = "수정해서 제출합니다 ㅎ")
+            String captionWithHashtags,
+
+            @Schema(description = "최종 제출한 미디어 URL 목록")
+            List<String> mediaUrls,
+
+            @Schema(description = "최종 제출한 포스트 URL", example = "https://instagram.com/p/...")
+            String postUrl,
+
+            @Schema(description = "1차 리뷰에 대한 브랜드 노트", example = "흠 이건 좀 수정하셔야 될 것 같은데요?")
+            String brandNote,
+
+            @Schema(description = "브랜드 노트 작성 시간", example = "2025-09-29T07:33:53Z")
+            Instant revisionRequestedAt
+    ) {}
+}

--- a/src/main/java/com/lokoko/domain/campaignReview/api/dto/response/CompletedReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/api/dto/response/CompletedReviewResponse.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-
-import java.time.Instant;
 import java.util.List;
 
 @Builder
@@ -13,6 +11,9 @@ import java.util.List;
 public record CompletedReviewResponse(
         @Schema(description = "참여한 캠페인 ID", example = "61")
         Long campaignId,
+
+        @Schema(description = "캠페인 이름", example = "신상품 홍보 캠페인")
+        String campaignName,
 
         @Schema(description = "완료된 리뷰 컨텐츠 목록")
         List<CompletedReviewContent> reviewContents
@@ -34,9 +35,6 @@ public record CompletedReviewResponse(
             String postUrl,
 
             @Schema(description = "1차 리뷰에 대한 브랜드 노트", example = "흠 이건 좀 수정하셔야 될 것 같은데요?")
-            String brandNote,
-
-            @Schema(description = "브랜드 노트 작성 시간", example = "2025-09-29T07:33:53Z")
-            Instant revisionRequestedAt
+            String brandNote
     ) {}
 }

--- a/src/main/java/com/lokoko/domain/campaignReview/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/api/message/ResponseMessage.java
@@ -10,7 +10,8 @@ public enum ResponseMessage {
     SECOND_REVIEW_SUCCESS("두번째 캠페인 리뷰 작성에 성공했습니다."),
     REVIEW_ABLE_ITEM_FETCH_SUCCESS("리뷰 가능 캠페인 단건 조회에 성공했습니다."),
     REVIEW_ABLE_LIST_FETCH_SUCCESS("리뷰 가능 캠페인 리스트 조회에 성공했습니다."),
-    REVIEW_MEDIA_PRESIGNED_URL_SUCCESS("리뷰 미디어 presignedUrl 발급에 성공했습니다.");
+    REVIEW_MEDIA_PRESIGNED_URL_SUCCESS("리뷰 미디어 presignedUrl 발급에 성공했습니다."),
+    COMPLETED_REVIEW_FETCH_SUCCESS("완료된 캠페인 리뷰 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
@@ -8,6 +8,7 @@ import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaignReview.api.dto.request.FirstReviewUploadRequest;
 import com.lokoko.domain.campaignReview.api.dto.request.SecondReviewUploadRequest;
 import com.lokoko.domain.campaignReview.api.dto.response.ReviewUploadResponse;
+import com.lokoko.domain.campaignReview.api.dto.response.CompletedReviewResponse;
 import com.lokoko.domain.campaignReview.application.mapper.CampaignReviewMapper;
 import com.lokoko.domain.campaignReview.application.service.CampaignReviewGetService;
 import com.lokoko.domain.campaignReview.application.service.CampaignReviewSaveService;
@@ -17,7 +18,6 @@ import com.lokoko.domain.campaignReview.application.service.CreatorCampaignUpdat
 import com.lokoko.domain.campaignReview.application.utils.CampaignReviewValidationUtil;
 import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
 import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
-import com.lokoko.domain.campaignReview.exception.CampaignReviewNotFoundException;
 import com.lokoko.domain.creatorCampaign.exception.CampaignReviewAbleNotFoundException;
 import com.lokoko.domain.creator.application.service.CreatorGetService;
 import com.lokoko.domain.creator.domain.entity.Creator;
@@ -365,6 +365,52 @@ public class CampaignReviewUsecase {
     }
 
     /**
+     * 완료된 2차 리뷰의 컨텐츠를 생성하는 메서드
+     */
+    private List<CompletedReviewResponse.CompletedReviewContent> createCompletedReviewContents(CreatorCampaign creatorCampaign) {
+        // 실제 업로드된 2차 리뷰의 컨텐츠 타입들
+        List<ContentType> existingSecondTypes = campaignReviewGetService
+                .findContentTypesByRound(creatorCampaign.getId(), ReviewRound.SECOND);
+
+        return existingSecondTypes.stream()
+                .map(contentType -> {
+                    // 2차 리뷰 정보 조회
+                    Optional<CampaignReview> secondReview = campaignReviewGetService
+                            .findByContentType(creatorCampaign.getId(), ReviewRound.SECOND, contentType);
+
+                    if (secondReview.isPresent()) {
+                        CampaignReview review = secondReview.get();
+                        String captionWithHashtags = review.getCaptionWithHashtags();
+                        List<String> mediaUrls = campaignReviewGetService.getOrderedMediaUrls(review);
+                        String postUrl = review.getPostUrl();
+
+                        // 1차 리뷰에서 브랜드 노트 가져오기
+                        String brandNote = null;
+                        Instant revisionRequestedAt = null;
+                        Optional<CampaignReview> firstReview = campaignReviewGetService
+                                .findByContentType(creatorCampaign.getId(), ReviewRound.FIRST, contentType);
+
+                        if (firstReview.isPresent()) {
+                            brandNote = firstReview.get().getBrandNote();
+                            revisionRequestedAt = firstReview.get().getRevisionRequestedAt();
+                        }
+
+                        return CompletedReviewResponse.CompletedReviewContent.builder()
+                                .contentType(contentType)
+                                .captionWithHashtags(captionWithHashtags)
+                                .mediaUrls(mediaUrls)
+                                .postUrl(postUrl)
+                                .brandNote(brandNote)
+                                .revisionRequestedAt(revisionRequestedAt)
+                                .build();
+                    }
+                    return null;
+                })
+                .filter(content -> content != null)
+                .toList();
+    }
+
+    /**
      * 조회 시점에 브랜드 노트가 있는 모든 1차 리뷰의 noteViewed를 true로 업데이트
      */
     private void markBrandNotesAsViewed(CreatorCampaign creatorCampaign) {
@@ -386,5 +432,35 @@ public class CampaignReviewUsecase {
         List<String> urls = campaignReviewUpdateService.createPresignedUrlForReview(creator.getId(), request);
 
         return campaignReviewMapper.toMediaPresignedUrlResponse(urls);
+    }
+
+    /**
+     * 완료된 캠페인의 최종 리뷰 결과 조회 (2차 리뷰)
+     */
+    @Transactional(readOnly = true)
+    public CompletedReviewResponse getCompletedReviews(Long userId, Long campaignId) {
+        Creator creator = creatorGetService.findByUserId(userId);
+        CreatorCampaign creatorCampaign =
+                creatorCampaignGetService.getByCampaignAndCreatorId(
+                        campaignGetService.findByCampaignId(campaignId), creator.getId());
+
+        // COMPLETED 상태만 허용
+        if (creatorCampaign.getStatus() != ParticipationStatus.COMPLETED) {
+            throw new CampaignReviewAbleNotFoundException();
+        }
+
+        // 실제 2차 리뷰 존재 여부 확인
+        List<ContentType> secondReviewTypes = campaignReviewGetService
+                .findContentTypesByRound(creatorCampaign.getId(), ReviewRound.SECOND);
+
+        // 완료된 2차 리뷰 조회
+        List<CompletedReviewResponse.CompletedReviewContent> reviewContents =
+                createCompletedReviewContents(creatorCampaign);
+
+
+        return CompletedReviewResponse.builder()
+                .campaignId(campaignId)
+                .reviewContents(reviewContents)
+                .build();
     }
 }

--- a/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
@@ -386,13 +386,11 @@ public class CampaignReviewUsecase {
 
                         // 1차 리뷰에서 브랜드 노트 가져오기
                         String brandNote = null;
-                        Instant revisionRequestedAt = null;
                         Optional<CampaignReview> firstReview = campaignReviewGetService
                                 .findByContentType(creatorCampaign.getId(), ReviewRound.FIRST, contentType);
 
                         if (firstReview.isPresent()) {
                             brandNote = firstReview.get().getBrandNote();
-                            revisionRequestedAt = firstReview.get().getRevisionRequestedAt();
                         }
 
                         return CompletedReviewResponse.CompletedReviewContent.builder()
@@ -401,7 +399,6 @@ public class CampaignReviewUsecase {
                                 .mediaUrls(mediaUrls)
                                 .postUrl(postUrl)
                                 .brandNote(brandNote)
-                                .revisionRequestedAt(revisionRequestedAt)
                                 .build();
                     }
                     return null;
@@ -460,6 +457,7 @@ public class CampaignReviewUsecase {
 
         return CompletedReviewResponse.builder()
                 .campaignId(campaignId)
+                .campaignName(creatorCampaign.getCampaign().getTitle())
                 .reviewContents(reviewContents)
                 .build();
     }

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepository.java
@@ -87,4 +87,14 @@ public interface CreatorCampaignRepository extends JpaRepository<CreatorCampaign
     List<CreatorCampaign> findReviewablesInReview(@Param("creatorId") Long creatorId,
                                                   @Param("campaignStatus") CampaignStatus campaignStatus,
                                                   @Param("statuses") Collection<ParticipationStatus> statuses);
+
+    /**
+     * 캠페인 ID와 참여 상태로 크리에이터 캠페인 조회
+     * @param campaignId 캠페인 ID
+     * @param status 참여 상태
+     * @return 해당하는 크리에이터 캠페인 목록
+     */
+    @Query("SELECT cc FROM CreatorCampaign cc WHERE cc.campaign.id = :campaignId AND cc.status = :status")
+    List<CreatorCampaign> findByCampaignIdAndStatus(@Param("campaignId") Long campaignId,
+                                                     @Param("status") ParticipationStatus status);
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #297 

## 작업 내용 💻

크리에이터가 2차 리뷰까지 모두 제출 완료후 , 마이페이지에서 VIEW NOTES 버튼을 누르면
최종 제출한 2차 리뷰를 조회할 수 있는 화면으로 넘어가야합니다.
해당 API 를 구현합니다. 


## 스크린샷 📷
<img width="1045" height="381" alt="image" src="https://github.com/user-attachments/assets/55cde614-6a4f-4e86-9386-37a1c83d4d86" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 완료된 캠페인 리뷰 조회 API 추가: 캠페인별 완료 리뷰 결과를 제공하며 콘텐츠 유형, 캡션/해시태그, 미디어 URL, 게시물 URL, 브랜드 노트 정보를 포함합니다.
- 리팩터링
  - 캠페인 상세 페이지 상태 표시 로직 조정: RECRUITING 상태의 표시 방식이 업데이트되어 상세 페이지의 상태 노출이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->