### PR TITLE
[REFACTOR] #305 : 크리에이터 최종 리뷰 조회 응답값에서 postUrl 과 brandNote 를 제거

### DIFF
--- a/src/main/java/com/lokoko/domain/campaignReview/api/dto/response/CompletedReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/api/dto/response/CompletedReviewResponse.java
@@ -29,12 +29,6 @@ public record CompletedReviewResponse(
             String captionWithHashtags,
 
             @Schema(description = "최종 제출한 미디어 URL 목록")
-            List<String> mediaUrls,
-
-            @Schema(description = "최종 제출한 포스트 URL", example = "https://instagram.com/p/...")
-            String postUrl,
-
-            @Schema(description = "1차 리뷰에 대한 브랜드 노트", example = "흠 이건 좀 수정하셔야 될 것 같은데요?")
-            String brandNote
+            List<String> mediaUrls
     ) {}
 }

--- a/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
@@ -382,23 +382,11 @@ public class CampaignReviewUsecase {
                         CampaignReview review = secondReview.get();
                         String captionWithHashtags = review.getCaptionWithHashtags();
                         List<String> mediaUrls = campaignReviewGetService.getOrderedMediaUrls(review);
-                        String postUrl = review.getPostUrl();
-
-                        // 1차 리뷰에서 브랜드 노트 가져오기
-                        String brandNote = null;
-                        Optional<CampaignReview> firstReview = campaignReviewGetService
-                                .findByContentType(creatorCampaign.getId(), ReviewRound.FIRST, contentType);
-
-                        if (firstReview.isPresent()) {
-                            brandNote = firstReview.get().getBrandNote();
-                        }
 
                         return CompletedReviewResponse.CompletedReviewContent.builder()
                                 .contentType(contentType)
                                 .captionWithHashtags(captionWithHashtags)
                                 .mediaUrls(mediaUrls)
-                                .postUrl(postUrl)
-                                .brandNote(brandNote)
                                 .build();
                     }
                     return null;


### PR DESCRIPTION
## Related issue 🛠

- closed #304 

## 작업 내용 💻

- 크리에이터 최종 리뷰 조회 응답값에서 postUrl 과 brandNote 를 제거합니다.


## 스크린샷 📷

<img width="606" height="895" alt="image" src="https://github.com/user-attachments/assets/7d2f577a-1ae9-4b64-8e77-62e058d87558" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

