### PR TITLE
FEAT #306 캠페인 상태관리 및 시간관련 로직 처리를 위한 스케쥴러 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/scheduler/application/service/CampaignEventScheduler.java
+++ b/src/main/java/com/lokoko/domain/scheduler/application/service/CampaignEventScheduler.java
@@ -1,0 +1,106 @@
+package com.lokoko.domain.scheduler.application.service;
+
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.scheduler.domain.entity.ScheduledEvent;
+import com.lokoko.domain.scheduler.domain.enums.EventStatus;
+import com.lokoko.domain.scheduler.domain.enums.EventType;
+import com.lokoko.domain.scheduler.domain.enums.TargetType;
+import com.lokoko.domain.scheduler.domain.repository.ScheduledEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 캠페인 이벤트 스케줄링 서비스
+ * 캠페인 생성/수정 시 필요한 스케줄 이벤트를 등록
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class CampaignEventScheduler {
+
+    private final ScheduledEventRepository scheduledEventRepository;
+
+    /**
+     * 캠페인 승인 시 모든 관련 이벤트 스케줄링
+     * @param campaign 승인된 캠페인 (OPEN_RESERVED 또는 RECRUITING 상태)
+     */
+    public void scheduleCampaignEvents(Campaign campaign) {
+
+        List<ScheduledEvent> events = new ArrayList<>();
+
+        // 1. 모집 시작 이벤트
+        if (campaign.getApplyStartDate() != null) {
+            events.add(ScheduledEvent.builder()
+                    .eventType(EventType.CAMPAIGN_START_RECRUITING)
+                    .targetId(campaign.getId())
+                    .targetType(TargetType.CAMPAIGN)
+                    .executeAt(campaign.getApplyStartDate())
+                    .status(EventStatus.PENDING)
+                    .build());
+        }
+
+        // 2. 모집 마감 이벤트
+        if (campaign.getApplyDeadline() != null) {
+            events.add(ScheduledEvent.builder()
+                    .eventType(EventType.CAMPAIGN_CLOSE_RECRUITMENT)
+                    .targetId(campaign.getId())
+                    .targetType(TargetType.CAMPAIGN)
+                    .executeAt(campaign.getApplyDeadline())
+                    .status(EventStatus.PENDING)
+                    .build());
+        }
+
+        // 3. 크리에이터 발표 및 리뷰 시작 이벤트
+        if (campaign.getCreatorAnnouncementDate() != null) {
+            events.add(ScheduledEvent.builder()
+                    .eventType(EventType.CREATOR_ANNOUNCEMENT_PROCESS)
+                    .targetId(campaign.getId())
+                    .targetType(TargetType.CAMPAIGN)
+                    .executeAt(campaign.getCreatorAnnouncementDate())
+                    .status(EventStatus.PENDING)
+                    .build());
+
+            // 4. 1차 리뷰 마감 이벤트 (리뷰 제출 마감 7일 전)
+            if (campaign.getReviewSubmissionDeadline() != null) {
+                events.add(ScheduledEvent.builder()
+                        .eventType(EventType.CREATOR_FIRST_REVIEW_DEADLINE)
+                        .targetId(campaign.getId())
+                        .targetType(TargetType.CAMPAIGN)
+                        .executeAt(campaign.getReviewSubmissionDeadline().minus(Duration.ofDays(7)))
+                        .status(EventStatus.PENDING)
+                        .build());
+            }
+        }
+
+        // 5. 2차 리뷰 마감 및 캠페인 완료 이벤트
+        if (campaign.getReviewSubmissionDeadline() != null) {
+            // 2차 리뷰 마감 처리
+            events.add(ScheduledEvent.builder()
+                    .eventType(EventType.CREATOR_SECOND_REVIEW_DEADLINE)
+                    .targetId(campaign.getId())
+                    .targetType(TargetType.CAMPAIGN)
+                    .executeAt(campaign.getReviewSubmissionDeadline())
+                    .status(EventStatus.PENDING)
+                    .build());
+
+            // 캠페인 완료 처리
+            events.add(ScheduledEvent.builder()
+                    .eventType(EventType.CAMPAIGN_COMPLETE)
+                    .targetId(campaign.getId())
+                    .targetType(TargetType.CAMPAIGN)
+                    .executeAt(campaign.getReviewSubmissionDeadline())
+                    .status(EventStatus.PENDING)
+                    .build());
+        }
+
+        // 이벤트 저장
+        scheduledEventRepository.saveAll(events);
+    }
+}

--- a/src/main/java/com/lokoko/domain/scheduler/application/service/EventExecutionService.java
+++ b/src/main/java/com/lokoko/domain/scheduler/application/service/EventExecutionService.java
@@ -1,0 +1,287 @@
+package com.lokoko.domain.scheduler.application.service;
+
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
+import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
+import com.lokoko.domain.campaign.exception.CampaignNotFoundException;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
+import com.lokoko.domain.campaignReview.domain.repository.CampaignReviewRepository;
+import com.lokoko.domain.creator.exception.CreatorCampaignNotFoundException;
+import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
+import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
+import com.lokoko.domain.creatorCampaign.domain.repository.CreatorCampaignRepository;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import com.lokoko.domain.scheduler.domain.entity.ScheduledEvent;
+import com.lokoko.domain.scheduler.domain.enums.EventType;
+import com.lokoko.domain.scheduler.domain.enums.TargetType;
+import com.lokoko.domain.scheduler.domain.repository.ScheduledEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class EventExecutionService {
+
+    private final CampaignRepository campaignRepository;
+    private final CreatorCampaignRepository creatorCampaignRepository;
+    private final ScheduledEventRepository scheduledEventRepository;
+
+    // CampaignReview 관련 Repository 추가
+    private final CampaignReviewRepository campaignReviewRepository;
+
+    /**
+     * 스케줄된 이벤트 실행
+     */
+    public void execute(ScheduledEvent event) {
+        switch (event.getEventType()) {
+            // 1. 캠페인 모집 시작
+            case CAMPAIGN_START_RECRUITING:
+                handleCampaignStartRecruiting(event.getTargetId());
+                break;
+
+            // 2. 캠페인 모집 마감
+            case CAMPAIGN_CLOSE_RECRUITMENT:
+                handleCampaignCloseRecruitment(event.getTargetId());
+                break;
+
+            // 3. 크리에이터 발표 (미승인자 REJECTED 처리)
+            case CREATOR_ANNOUNCEMENT_PROCESS:
+                handleCreatorAnnouncement(event.getTargetId());
+                break;
+
+            // 4. 배송지 입력 마감 (24시간 후)
+            case CREATOR_ADDRESS_DEADLINE:
+                handleAddressDeadline(event.getTargetId());
+                break;
+
+            // 5. 캠페인 리뷰 시작 (크리에이터 발표와 동시)
+            case CAMPAIGN_START_REVIEW:
+                handleCampaignStartReview(event.getTargetId());
+                break;
+
+            // 6. 1차 리뷰 제출 마감 (리뷰 마감 7일 전)
+            case CREATOR_FIRST_REVIEW_DEADLINE:
+                handleFirstReviewDeadline(event.getTargetId());
+                break;
+
+            // 7. 2차 리뷰 제출 마감 (최종 마감일)
+            case CREATOR_SECOND_REVIEW_DEADLINE:
+                handleSecondReviewDeadline(event.getTargetId());
+                break;
+
+            // 8. 캠페인 완료
+            case CAMPAIGN_COMPLETE:
+                handleCampaignComplete(event.getTargetId());
+                break;
+
+            default:
+                throw new IllegalArgumentException("Unknown event type: " + event.getEventType());
+        }
+    }
+
+    /**
+     * 캠페인 모집 시작 처리
+     */
+    private void handleCampaignStartRecruiting(Long campaignId) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        if (campaign.getCampaignStatus() == CampaignStatus.OPEN_RESERVED) {
+            campaign.changeStatus(CampaignStatus.RECRUITING);
+        }
+    }
+
+    /**
+     * 캠페인 모집 마감 처리
+     */
+    private void handleCampaignCloseRecruitment(Long campaignId) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        if (campaign.getCampaignStatus() == CampaignStatus.RECRUITING) {
+            campaign.changeStatus(CampaignStatus.RECRUITMENT_CLOSED);
+        }
+    }
+
+    /**
+     * 캠페인 리뷰 시작 처리
+     */
+    private void handleCampaignStartReview(Long campaignId) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        if (campaign.getCampaignStatus() == CampaignStatus.RECRUITMENT_CLOSED) {
+            campaign.changeStatus(CampaignStatus.IN_REVIEW);
+        }
+    }
+
+    /**
+     * 캠페인 완료 처리
+     */
+    private void handleCampaignComplete(Long campaignId) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        if (campaign.getCampaignStatus() == CampaignStatus.IN_REVIEW) {
+            campaign.changeStatus(CampaignStatus.COMPLETED);
+        }
+    }
+
+    /**
+     * 크리에이터 발표 처리
+     * - 캠페인 상태를 IN_REVIEW로 변경
+     * - 승인되지 않은 크리에이터들을 REJECTED로 변경
+     * - 승인된 크리에이터들의 배송지 입력 마감 이벤트 등록
+     */
+    private void handleCreatorAnnouncement(Long campaignId) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        // 캠페인 상태 변경
+        if (campaign.getCampaignStatus() == CampaignStatus.RECRUITMENT_CLOSED) {
+            campaign.changeStatus(CampaignStatus.IN_REVIEW);
+        }
+
+        // PENDING 상태의 크리에이터를 모두 REJECTED로 변경
+        List<CreatorCampaign> pendingCreators = creatorCampaignRepository
+                .findByCampaignIdAndStatus(campaignId, ParticipationStatus.PENDING);
+
+        for (CreatorCampaign creatorCampaign : pendingCreators) {
+            creatorCampaign.changeStatus(ParticipationStatus.REJECTED);
+        }
+
+        // APPROVED 상태의 크리에이터들에 대해 배송지 입력 마감 이벤트 등록
+        List<CreatorCampaign> approvedCreators = creatorCampaignRepository
+                .findByCampaignIdAndStatus(campaignId, ParticipationStatus.APPROVED);
+
+        Instant addressDeadline = Instant.now().plus(Duration.ofHours(24));
+        for (CreatorCampaign creatorCampaign : approvedCreators) {
+            ScheduledEvent addressEvent = ScheduledEvent.builder()
+                    .eventType(EventType.CREATOR_ADDRESS_DEADLINE)
+                    .targetId(creatorCampaign.getId())
+                    .targetType(TargetType.CREATOR_CAMPAIGN)
+                    .executeAt(addressDeadline)
+                    .build();
+            scheduledEventRepository.save(addressEvent);
+        }
+    }
+
+    /**
+     * 1차 리뷰 제출 마감 처리
+     * - 리뷰 제출 마감 7일 전까지 미제출한 크리에이터를 EXPIRED로 변경
+     */
+    private void handleFirstReviewDeadline(Long campaignId) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        // ACTIVE 상태의 크리에이터들을 조회
+        List<CreatorCampaign> activeCreators = creatorCampaignRepository
+                .findByCampaignIdAndStatus(campaignId, ParticipationStatus.ACTIVE);
+
+        for (CreatorCampaign creatorCampaign : activeCreators) {
+            if (!hasSubmittedFirstReview(creatorCampaign, campaign)) {
+                creatorCampaign.changeStatus(ParticipationStatus.EXPIRED);
+            }
+        }
+    }
+
+    /**
+     * 2차 리뷰 제출 마감 처리
+     * - 리뷰 제출 마감일까지 미제출한 크리에이터를 EXPIRED로 변경
+     */
+    private void handleSecondReviewDeadline(Long campaignId) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        // ACTIVE 상태의 크리에이터들을 조회
+        List<CreatorCampaign> activeCreators = creatorCampaignRepository
+                .findByCampaignIdAndStatus(campaignId, ParticipationStatus.ACTIVE);
+
+        for (CreatorCampaign creatorCampaign : activeCreators) {
+            if (!hasSubmittedSecondReview(creatorCampaign, campaign)) {
+                creatorCampaign.changeStatus(ParticipationStatus.EXPIRED);
+            }
+        }
+    }
+
+    /**
+     * 배송지 입력 마감 처리
+     * - 발표 후 24시간 내에 배송지를 확인하지 않은 크리에이터를 EXPIRED로 변경
+     */
+    private void handleAddressDeadline(Long creatorCampaignId) {
+        CreatorCampaign creatorCampaign = creatorCampaignRepository.findById(creatorCampaignId)
+                .orElseThrow(CreatorCampaignNotFoundException::new);
+
+        // 배송지 미확인 && APPROVED 상태인 경우 EXPIRED로 변경
+        if (creatorCampaign.getStatus() == ParticipationStatus.APPROVED &&
+                (creatorCampaign.getAddressConfirmed() == null || !creatorCampaign.getAddressConfirmed())) {
+            creatorCampaign.changeStatus(ParticipationStatus.EXPIRED);
+        }
+    }
+
+    /**
+     * 1차 리뷰 제출 여부 확인
+     * 캠페인에 설정된 모든 콘텐츠 타입에 대해 제출되었는지 확인
+     */
+    private boolean hasSubmittedFirstReview(CreatorCampaign creatorCampaign, Campaign campaign) {
+        List<ContentType> requiredContentTypes = getRequiredContentTypes(campaign);
+
+        for (ContentType contentType : requiredContentTypes) {
+            boolean hasSubmitted = campaignReviewRepository.existsByCreatorCampaignIdAndReviewRoundAndContentType(
+                    creatorCampaign.getId(),
+                    ReviewRound.FIRST,
+                    contentType
+            );
+
+            if (!hasSubmitted) return false;
+        }
+        return true;
+    }
+
+    /**
+     * 2차 리뷰 제출 여부 확인
+     * 캠페인에 설정된 모든 콘텐츠 타입에 대해 제출되었는지 확인
+     */
+    private boolean hasSubmittedSecondReview(CreatorCampaign creatorCampaign, Campaign campaign) {
+        List<ContentType> requiredContentTypes = getRequiredContentTypes(campaign);
+
+        for (ContentType contentType : requiredContentTypes) {
+            boolean hasSubmitted = campaignReviewRepository.existsByCreatorCampaignIdAndReviewRoundAndContentType(
+                    creatorCampaign.getId(),
+                    ReviewRound.SECOND,
+                    contentType
+            );
+
+            if (!hasSubmitted) return false;
+        }
+        return true;
+    }
+
+    /**
+     * 캠페인에 설정된 필수 콘텐츠 타입 목록 반환
+     * firstContentPlatform, secondContentPlatform 설정에 따라 1~2개 반환
+     */
+    private List<ContentType> getRequiredContentTypes(Campaign campaign) {
+        List<ContentType> contentTypes = new ArrayList<>();
+
+        if (campaign.getFirstContentPlatform() != null) {
+            contentTypes.add(campaign.getFirstContentPlatform());
+        }
+
+        if (campaign.getSecondContentPlatform() != null &&
+            !campaign.getSecondContentPlatform().equals(campaign.getFirstContentPlatform())) {
+            contentTypes.add(campaign.getSecondContentPlatform());
+        }
+
+        return contentTypes;
+    }
+}

--- a/src/main/java/com/lokoko/domain/scheduler/application/service/EventProcessor.java
+++ b/src/main/java/com/lokoko/domain/scheduler/application/service/EventProcessor.java
@@ -1,0 +1,122 @@
+package com.lokoko.domain.scheduler.application.service;
+
+import com.lokoko.domain.scheduler.domain.entity.ScheduledEvent;
+import com.lokoko.domain.scheduler.domain.enums.EventStatus;
+import com.lokoko.domain.scheduler.domain.repository.ScheduledEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 스케줄된 이벤트를 처리하는 메인 스케줄러
+ * 1분마다 실행되어 대기중인 이벤트를 확인하고 실행
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EventProcessor {
+
+    private final ScheduledEventRepository scheduledEventRepository;
+    private final EventExecutionService eventExecutionService;
+
+    /**
+     * 1분마다 실행되는 스케줄러
+     * 실행 시간이 된 이벤트들을 찾아서 처리
+     */
+    @Scheduled(fixedRate = 60000) // 1분(60초 = 60000ms)마다 실행
+    public void processScheduledEvents() {
+        Instant now = Instant.now();
+
+        // 실행해야 할 이벤트들 조회
+        List<ScheduledEvent> eventsToExecute = scheduledEventRepository
+                .findPendingEventsBefore(now);
+
+        if (eventsToExecute.isEmpty()) {
+            return;
+        }
+
+        log.info("Processing {} scheduled events at {}", eventsToExecute.size(), now);
+
+        // 각 이벤트를 개별적으로 처리 (하나의 실패가 다른 이벤트 처리를 막지 않도록)
+        for (ScheduledEvent event : eventsToExecute) {
+            try {
+                processEvent(event);
+            } catch (Exception e) {
+                log.error("Failed to process event {}: {}", event.getId(), e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * 개별 이벤트 처리
+     */
+    @Transactional
+    protected void processEvent(ScheduledEvent event) {
+        log.debug("Processing event: {} for target: {} ({})",
+                event.getEventType(), event.getTargetId(), event.getTargetType());
+
+        try {
+            // 이벤트 실행
+            eventExecutionService.execute(event);
+
+            // 성공 처리
+            event.markAsExecuted();
+            scheduledEventRepository.save(event);
+
+            log.info("Successfully executed event: {} for target: {} ({})",
+                    event.getEventType(), event.getTargetId(), event.getTargetType());
+
+        } catch (Exception e) {
+            // 실패 처리
+            event.markAsFailed(e.getMessage());
+            scheduledEventRepository.save(event);
+
+            log.error("Failed to execute event: {} for target: {} - Error: {}",
+                    event.getEventType(), event.getTargetId(), e.getMessage());
+
+            // 재시도 가능한 경우 재시도 이벤트 생성
+            if (event.isRetryable()) {
+                scheduleRetry(event);
+            }
+        }
+    }
+
+    /**
+     * 실패한 이벤트 재시도 스케줄링
+     */
+    private void scheduleRetry(ScheduledEvent failedEvent) {
+        // 5분 후 재시도
+        Instant retryAt = Instant.now().plus(Duration.ofMinutes(5));
+
+        ScheduledEvent retryEvent = ScheduledEvent.builder()
+                .eventType(failedEvent.getEventType())
+                .targetId(failedEvent.getTargetId())
+                .targetType(failedEvent.getTargetType())
+                .executeAt(retryAt)
+                .retryCount(failedEvent.getRetryCount())
+                .status(EventStatus.PENDING)
+                .build();
+
+        scheduledEventRepository.save(retryEvent);
+    }
+
+    /**
+     * 매일 자정에 실행되는 정리 작업
+     * 30일 이상 지난 실행 완료 이벤트를 삭제
+     */
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정
+    @Transactional
+    public void cleanupOldEvents() {
+        Instant thirtyDaysAgo = Instant.now().minus(Duration.ofDays(30));
+
+        scheduledEventRepository.deleteOldExecutedEvents(thirtyDaysAgo);
+
+        log.info("Cleaned up executed events older than {}", thirtyDaysAgo);
+    }
+}

--- a/src/main/java/com/lokoko/domain/scheduler/domain/entity/ScheduledEvent.java
+++ b/src/main/java/com/lokoko/domain/scheduler/domain/entity/ScheduledEvent.java
@@ -1,0 +1,82 @@
+package com.lokoko.domain.scheduler.domain.entity;
+
+import com.lokoko.domain.scheduler.domain.enums.EventStatus;
+import com.lokoko.domain.scheduler.domain.enums.EventType;
+import com.lokoko.domain.scheduler.domain.enums.TargetType;
+import com.lokoko.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "scheduled_events",
+    indexes = {
+        @Index(name = "idx_execute_at_status", columnList = "execute_at, status"),
+        @Index(name = "idx_target_type_id", columnList = "target_type, target_id")
+    }
+)
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ScheduledEvent extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private EventType eventType;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private TargetType targetType;
+
+    @Column(nullable = false)
+    private Instant executeAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private EventStatus status = EventStatus.PENDING;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer retryCount = 0;
+
+    private Instant executedAt;
+
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
+
+    /**
+     * 이벤트 실행 완료 처리
+     */
+    public void markAsExecuted() {
+        this.status = EventStatus.EXECUTED;
+        this.executedAt = Instant.now();
+    }
+
+    /**
+     * 이벤트 실패 처리
+     */
+    public void markAsFailed(String error) {
+        this.status = EventStatus.FAILED;
+        this.errorMessage = error;
+        this.retryCount++;
+    }
+
+    /**
+     * 재시도 가능 여부 확인
+     */
+    public boolean isRetryable() {
+        return this.retryCount < 3 && this.status == EventStatus.FAILED;
+    }
+}

--- a/src/main/java/com/lokoko/domain/scheduler/domain/enums/EventStatus.java
+++ b/src/main/java/com/lokoko/domain/scheduler/domain/enums/EventStatus.java
@@ -1,0 +1,18 @@
+package com.lokoko.domain.scheduler.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 스케줄링 이벤트 상태
+ */
+@Getter
+@RequiredArgsConstructor
+public enum EventStatus {
+
+    PENDING("대기중"),
+    EXECUTED("실행완료"),
+    FAILED("실패");
+
+    private final String description;
+}

--- a/src/main/java/com/lokoko/domain/scheduler/domain/enums/EventType.java
+++ b/src/main/java/com/lokoko/domain/scheduler/domain/enums/EventType.java
@@ -1,0 +1,26 @@
+package com.lokoko.domain.scheduler.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 스케줄링 이벤트 타입
+ */
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+
+    // 캠페인 상태 변경 이벤트
+    CAMPAIGN_START_RECRUITING("캠페인 모집 시작"),
+    CAMPAIGN_CLOSE_RECRUITMENT("캠페인 모집 마감"),
+    CAMPAIGN_START_REVIEW("캠페인 리뷰 시작"),
+    CAMPAIGN_COMPLETE("캠페인 완료"),
+
+    // 크리에이터 관련 이벤트
+    CREATOR_ANNOUNCEMENT_PROCESS("크리에이터 발표 처리"),
+    CREATOR_FIRST_REVIEW_DEADLINE("1차 리뷰 마감 처리"),
+    CREATOR_SECOND_REVIEW_DEADLINE("2차 리뷰 마감 처리"),
+    CREATOR_ADDRESS_DEADLINE("배송지 입력 마감 처리");
+
+    private final String description;
+}

--- a/src/main/java/com/lokoko/domain/scheduler/domain/enums/TargetType.java
+++ b/src/main/java/com/lokoko/domain/scheduler/domain/enums/TargetType.java
@@ -1,0 +1,17 @@
+package com.lokoko.domain.scheduler.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 스케줄링 대상 타입
+ */
+@Getter
+@RequiredArgsConstructor
+public enum TargetType {
+
+    CAMPAIGN("캠페인"),
+    CREATOR_CAMPAIGN("크리에이터 캠페인");
+
+    private final String description;
+}

--- a/src/main/java/com/lokoko/domain/scheduler/domain/repository/ScheduledEventRepository.java
+++ b/src/main/java/com/lokoko/domain/scheduler/domain/repository/ScheduledEventRepository.java
@@ -1,0 +1,82 @@
+package com.lokoko.domain.scheduler.domain.repository;
+
+import com.lokoko.domain.scheduler.domain.entity.ScheduledEvent;
+import com.lokoko.domain.scheduler.domain.enums.EventStatus;
+import com.lokoko.domain.scheduler.domain.enums.TargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public interface ScheduledEventRepository extends JpaRepository<ScheduledEvent, Long> {
+
+    /**
+     * 실행해야 할 대기중인 이벤트 조회
+     * @param now 현재 시간
+     * @return 실행 대상 이벤트 목록
+     */
+    @Query("SELECT e FROM ScheduledEvent e WHERE e.executeAt <= :now AND e.status = :status ORDER BY e.executeAt")
+    List<ScheduledEvent> findPendingEventsBefore(@Param("now") Instant now, @Param("status") EventStatus status);
+
+    default List<ScheduledEvent> findPendingEventsBefore(Instant now) {
+        return findPendingEventsBefore(now, EventStatus.PENDING);
+    }
+
+    /**
+     * 특정 대상의 대기중인 이벤트 조회
+     * @param targetType 대상 타입
+     * @param targetId 대상 ID
+     * @return 대기중인 이벤트 목록
+     */
+    @Query("SELECT e FROM ScheduledEvent e WHERE e.targetType = :targetType AND e.targetId = :targetId AND e.status = :status")
+    List<ScheduledEvent> findPendingEventsByTarget(
+            @Param("targetType") TargetType targetType,
+            @Param("targetId") Long targetId,
+            @Param("status") EventStatus status
+    );
+
+    default List<ScheduledEvent> findPendingEventsByTarget(TargetType targetType, Long targetId) {
+        return findPendingEventsByTarget(targetType, targetId, EventStatus.PENDING);
+    }
+
+    /**
+     * 특정 대상의 대기중인 이벤트 삭제
+     * @param targetType 대상 타입
+     * @param targetId 대상 ID
+     */
+    @Modifying
+    @Query("DELETE FROM ScheduledEvent e WHERE e.targetType = :targetType AND e.targetId = :targetId AND e.status = 'PENDING'")
+    void deletePendingEventsByTarget(
+            @Param("targetType") TargetType targetType,
+            @Param("targetId") Long targetId
+    );
+
+    /**
+     * 실패한 이벤트 중 재시도 가능한 이벤트 조회
+     * @param maxRetryCount 최대 재시도 횟수
+     * @return 재시도 가능한 이벤트 목록
+     */
+    @Query("SELECT e FROM ScheduledEvent e WHERE e.status = 'FAILED' AND e.retryCount < :maxRetryCount")
+    List<ScheduledEvent> findRetryableEvents(@Param("maxRetryCount") Integer maxRetryCount);
+
+    /**
+     * 오래된 실행 완료 이벤트 삭제
+     * @param beforeDate 이 날짜 이전에 실행된 이벤트 삭제
+     */
+    @Modifying
+    @Query("DELETE FROM ScheduledEvent e WHERE e.status = 'EXECUTED' AND e.executedAt < :beforeDate")
+    void deleteOldExecutedEvents(@Param("beforeDate") Instant beforeDate);
+
+    /**
+     * 특정 캠페인의 모든 이벤트 조회
+     * @param campaignId 캠페인 ID
+     * @return 캠페인 관련 모든 이벤트
+     */
+    @Query("SELECT e FROM ScheduledEvent e WHERE e.targetType = 'CAMPAIGN' AND e.targetId = :campaignId ORDER BY e.executeAt")
+    List<ScheduledEvent> findByCampaignId(@Param("campaignId") Long campaignId);
+}

--- a/src/main/java/com/lokoko/domain/user/application/service/AdminCampaignUpdateService.java
+++ b/src/main/java/com/lokoko/domain/user/application/service/AdminCampaignUpdateService.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.user.application.service;
 import com.lokoko.domain.campaign.application.service.CampaignGetService;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
+import com.lokoko.domain.scheduler.application.service.CampaignEventScheduler;
 import com.lokoko.domain.user.exception.CampaignApprovalNotAllowedException;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminCampaignUpdateService {
 
     private final CampaignGetService campaignGetService;
+    private final CampaignEventScheduler campaignEventScheduler;
 
     @Transactional
     public void approve(Long campaignId, Instant now) {
@@ -30,5 +32,8 @@ public class AdminCampaignUpdateService {
         }
 
         campaign.changeStatus(next);
+
+        // 관리자 승인 후 스케줄 이벤트 등록
+        campaignEventScheduler.scheduleCampaignEvents(campaign);
     }
 }

--- a/src/main/java/com/lokoko/global/config/SchedulingConfig.java
+++ b/src/main/java/com/lokoko/global/config/SchedulingConfig.java
@@ -1,0 +1,28 @@
+package com.lokoko.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * 스케줄링 설정
+ */
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+    /**
+     * 스케줄러 스레드 풀 설정
+     */
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5); // 스레드 풀 크기
+        scheduler.setThreadNamePrefix("scheduler-"); // 스레드 이름 prefix
+        scheduler.setAwaitTerminationSeconds(60); // 종료 대기 시간
+        scheduler.setWaitForTasksToCompleteOnShutdown(true); // 종료 시 작업 완료 대기
+        scheduler.initialize();
+        return scheduler;
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #305 

## 작업 내용 💻

- Event 테이블 생성
- 스케쥴러를 1분 간격으로 실행하여, Event 테이블에 실행해야할 이벤트가 있는지 확인
- 캠페인 관련 상태변경처리

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

