### PR TITLE
[HOTFIX] #331 브랜드 마이페이지 응답값에 브랜드명 추가

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyPageResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/BrandMyPageResponse.java
@@ -10,6 +10,9 @@ public record BrandMyPageResponse(
         @Schema(description = "프로필 이미지 URL")
         String profileImageUrl,
 
+        @Schema(requiredMode = REQUIRED, description = "브랜드명")
+        String brandName,
+
         @Schema(requiredMode = REQUIRED, description = "담당자 이름")
         String managerName,
 
@@ -28,6 +31,7 @@ public record BrandMyPageResponse(
     public static BrandMyPageResponse from(Brand brand, User user) {
         return new BrandMyPageResponse(
                 user.getProfileImageUrl(),
+                brand.getBrandName(),
                 brand.getManagerName(),
                 user.getEmail(),
                 brand.getPhoneNumber(),


### PR DESCRIPTION
## Related issue 🛠

- closed #330 

## 작업 내용 💻
- [x] 브랜드 마이페이지 응답값에 브랜드명을 추가했습니다

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 브랜드 마이페이지 응답에 ‘브랜드명’ 필드가 추가되어 화면과 API 응답에서 브랜드 프로필 이미지와 함께 브랜드명이 표시됩니다.
  - 목록/상세 등 브랜드 관련 화면에서 브랜드 식별 정보가 더 명확하게 노출됩니다.
  - 기존 클라이언트도 추가 필드를 수신하여 표시 영역에 자동 반영되며, 정보 확인 흐름이 자연스러워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->