### PR TITLE
[Feat] #340 브랜드 컨텐츠 확인 API & 2차 리뷰 업로드시 Social Clip 연관관계 세팅 

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -11,6 +11,7 @@ import com.lokoko.domain.brand.api.dto.response.BrandProfileAndStatisticsRespons
 import com.lokoko.domain.brand.api.dto.response.BrandProfileImageResponse;
 import com.lokoko.domain.brand.api.dto.response.CampaignApplicantListResponse;
 import com.lokoko.domain.brand.api.dto.response.CreatorApprovedResponse;
+import com.lokoko.domain.brand.api.dto.response.CreatorPerformanceResponse;
 import com.lokoko.domain.brand.api.message.ResponseMessage;
 import com.lokoko.domain.brand.application.usecase.BrandUsecase;
 import com.lokoko.domain.campaign.api.dto.request.CampaignDraftRequest;
@@ -292,5 +293,19 @@ public class BrandController {
     ) {
         BrandDashboardCampaignListResponse response = campaignGetService.getBrandDashboardCampaigns(brandId, page, size);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_DASHBOARD_GET_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "브랜드 컨텐츠 확인 - 캠페인별 크리에이터 성과 조회")
+    @GetMapping("/my/campaigns/{campaignId}/performances")
+    public ApiResponse<CreatorPerformanceResponse> getCreatorPerformances(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @PathVariable Long campaignId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size) {
+
+        CreatorPerformanceResponse response = brandUsecase.getCreatorPerformances(brandId, campaignId, page, size);
+
+        return ApiResponse.success(HttpStatus.OK,
+                ResponseMessage.CREATOR_PERFORMANCE_GET_SUCCESS.getMessage(), response);
     }
 }

--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/CreatorPerformanceResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/CreatorPerformanceResponse.java
@@ -1,0 +1,49 @@
+package com.lokoko.domain.brand.api.dto.response;
+
+import com.lokoko.domain.campaignReview.domain.entity.enums.ContentStatus;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import com.lokoko.global.common.response.PageableResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CreatorPerformanceResponse(
+        Long campaignId,
+        String campaignTitle,
+        ContentType firstContentPlatform,
+        ContentType secondContentPlatform,
+        List<CreatorReviewPerformance> creators,
+        PageableResponse pageableResponse
+) {
+    @Builder
+    public record CreatorReviewPerformance(
+            CreatorInfo creator,
+            List<ReviewPerformance> reviews
+    ) {
+    }
+
+    @Builder
+    public record CreatorInfo(
+            Long creatorId,
+            String creatorFullName,
+            String creatorNickname,
+            String profileImageUrl
+    ) {
+    }
+
+    @Builder
+    public record ReviewPerformance(
+            Long campaignReviewId,
+            ReviewRound reviewRound,
+            ContentType contentType,
+            ContentStatus reviewStatus,
+            String postUrl,
+            Long viewCount,
+            Long likeCount,
+            Long commentCount,
+            Long shareCount
+    ) {
+    }
+}

--- a/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
@@ -28,7 +28,8 @@ public enum ResponseMessage {
     BRAND_PROFILE_AND_STATISTICS_GET_SUCCESS("브랜드 마이페이지 프로필 및 통계 정보 조회에 성공했습니다"),
     DRAFT_CAMPAIGN_GET_SUCCESS("임시저장 상태의 캠페인 조회에 성공했습니다."),
 
-    BRAND_DASHBOARD_GET_SUCCESS("브랜드 대시보드 캠페인 리스트 조회 성공했습니다.");
+    BRAND_DASHBOARD_GET_SUCCESS("브랜드 대시보드 캠페인 리스트 조회 성공했습니다."),
+    CREATOR_PERFORMANCE_GET_SUCCESS("캠페인 크리에이터 성과 리스트 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
@@ -7,6 +7,7 @@ import com.lokoko.domain.brand.api.dto.response.BrandIssuedCampaignResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandMyPageResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandProfileAndStatisticsResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandProfileImageResponse;
+import com.lokoko.domain.brand.api.dto.response.CreatorPerformanceResponse;
 import com.lokoko.domain.brand.application.service.BrandGetService;
 import com.lokoko.domain.brand.application.service.BrandUpdateService;
 import com.lokoko.domain.brand.domain.entity.Brand;
@@ -19,15 +20,24 @@ import com.lokoko.domain.campaignReview.application.mapper.CampaignReviewMapper;
 import com.lokoko.domain.campaignReview.application.service.CampaignReviewGetService;
 import com.lokoko.domain.campaignReview.application.service.CampaignReviewStatusManager;
 import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ContentStatus;
 import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewStatus;
+import com.lokoko.domain.creator.domain.entity.Creator;
 import com.lokoko.domain.creatorCampaign.application.service.CreatorCampaignGetService;
 import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
+import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
+import com.lokoko.domain.media.socialclip.application.service.SocialClipGetService;
+import com.lokoko.domain.media.socialclip.domain.SocialClip;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import com.lokoko.global.common.response.PageableResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +47,7 @@ public class BrandUsecase {
     private final CampaignGetService campaignGetService;
     private final CreatorCampaignGetService creatorCampaignGetService;
     private final CampaignReviewGetService campaignReviewGetService;
+    private final SocialClipGetService socialClipGetService;
 
     private final BrandUpdateService brandUpdateService;
 
@@ -132,5 +143,197 @@ public class BrandUsecase {
     public void updateBrandMyPage(Long brandId, BrandMyPageUpdateRequest request) {
         Brand brand = brandGetService.getBrandById(brandId);
         brandUpdateService.updateBrandMyPage(brand, request);
+    }
+
+    /**
+     * 브랜드 컨텐츠 확인 API - 캠페인별 크리에이터 성과 조회
+     */
+    @Transactional(readOnly = true)
+    public CreatorPerformanceResponse getCreatorPerformances(Long brandId, Long campaignId, int page, int size) {
+        Brand brand = brandGetService.getBrandById(brandId);
+        Campaign campaign = campaignGetService.findByCampaignId(campaignId);
+
+        // 브랜드 권한 검증
+        if (!campaign.getBrand().getId().equals(brandId)) {
+            throw new NotCampaignOwnershipException();
+        }
+
+        // 해당 캠페인에 참여한 승인된 CreatorCampaign만 조회 (REJECTED 제외)
+        List<CreatorCampaign> creatorCampaigns = creatorCampaignGetService.findAllByCampaign(campaign).stream()
+                .filter(cc -> cc.getStatus() != ParticipationStatus.REJECTED)
+                .toList();
+
+        // 크리에이터별로 그룹화하여 리뷰 정보 구성
+        List<CreatorPerformanceResponse.CreatorReviewPerformance> allCreatorPerformances = creatorCampaigns.stream()
+                .collect(Collectors.groupingBy(CreatorCampaign::getCreator))
+                .entrySet().stream()
+                .map(entry -> {
+                    Creator creator = entry.getKey();
+                    List<CreatorCampaign> ccList = entry.getValue();
+
+                    // 해당 크리에이터의 모든 리뷰 조회
+                    List<CreatorPerformanceResponse.ReviewPerformance> reviews = buildReviewPerformances(campaign, ccList);
+
+                    return CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+                            .creator(CreatorPerformanceResponse.CreatorInfo.builder()
+                                    .creatorId(creator.getId())
+                                    .creatorFullName(creator.getUser().getName())
+                                    .creatorNickname(creator.getCreatorName())
+                                    .profileImageUrl(creator.getUser().getProfileImageUrl())
+                                    .build())
+                            .reviews(reviews)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        // 페이징 처리
+        long totalElements = allCreatorPerformances.size();
+        int startIndex = page * size;
+        int endIndex = Math.min(startIndex + size, allCreatorPerformances.size());
+
+        List<CreatorPerformanceResponse.CreatorReviewPerformance> pagedCreatorPerformances =
+                allCreatorPerformances.subList(startIndex, endIndex);
+
+        PageableResponse pageableResponse = PageableResponse.of(
+                page,
+                size,
+                pagedCreatorPerformances.size(),
+                endIndex >= allCreatorPerformances.size(),
+                totalElements
+        );
+
+        return CreatorPerformanceResponse.builder()
+                .campaignId(campaign.getId())
+                .campaignTitle(campaign.getTitle())
+                .firstContentPlatform(campaign.getFirstContentPlatform())
+                .secondContentPlatform(campaign.getSecondContentPlatform())
+                .creators(pagedCreatorPerformances)
+                .pageableResponse(pageableResponse)
+                .build();
+    }
+
+    /**
+     * 크리에이터의 리뷰 성과 정보 구성
+     */
+    private List<CreatorPerformanceResponse.ReviewPerformance> buildReviewPerformances(
+            Campaign campaign, List<CreatorCampaign> creatorCampaigns) {
+
+        // 캠페인의 콘텐츠 타입들
+        List<ContentType> contentTypes = new ArrayList<>();
+        contentTypes.add(campaign.getFirstContentPlatform());
+        if (campaign.getSecondContentPlatform() != null) {
+            contentTypes.add(campaign.getSecondContentPlatform());
+        }
+
+        List<CreatorPerformanceResponse.ReviewPerformance> performances = new ArrayList<>();
+
+        // 각 CreatorCampaign에 대해 처리
+        for (CreatorCampaign cc : creatorCampaigns) {
+            // 해당 CreatorCampaign의 모든 리뷰 조회
+            List<CampaignReview> reviews = campaignReviewGetService.findAllByCreatorCampaignId(cc.getId());
+
+            // contentType별로 리뷰를 맵으로 구성 (1차/2차 구분)
+            Map<ContentType, CampaignReview> firstReviews = reviews.stream()
+                    .filter(r -> r.getReviewRound() == ReviewRound.FIRST)
+                    .collect(Collectors.toMap(CampaignReview::getContentType, r -> r, (a, b) -> a));
+
+            Map<ContentType, CampaignReview> secondReviews = reviews.stream()
+                    .filter(r -> r.getReviewRound() == ReviewRound.SECOND)
+                    .collect(Collectors.toMap(CampaignReview::getContentType, r -> r, (a, b) -> a));
+
+            // 각 contentType에 대해 리뷰 성과 정보 생성
+            for (ContentType contentType : contentTypes) {
+                CampaignReview secondReview = secondReviews.get(contentType);
+                CampaignReview firstReview = firstReviews.get(contentType);
+
+                if (secondReview != null) {
+                    // 2차 리뷰가 있는 경우
+                    performances.add(buildReviewPerformance(secondReview));
+                } else if (firstReview != null) {
+                    // 1차 리뷰만 있는 경우
+                    performances.add(buildReviewPerformance(firstReview));
+                } else {
+                    // 리뷰가 없는 경우
+                    ContentStatus contentStatus;
+
+                    // 배송지 입력 여부에 따라 상태 결정
+                    if (cc.getAddressConfirmed() != null && cc.getAddressConfirmed()) {
+                        // 배송지는 입력했지만 1차 리뷰 미업로드 = 진행중
+                        contentStatus = ContentStatus.IN_PROGRESS;
+                    } else {
+                        // 배송지 미입력 = 미제출
+                        contentStatus = ContentStatus.NOT_SUBMITTED;
+                    }
+
+                    performances.add(CreatorPerformanceResponse.ReviewPerformance.builder()
+                            .reviewRound(ReviewRound.FIRST)
+                            .contentType(contentType)
+                            .reviewStatus(contentStatus)
+                            .build());
+                }
+            }
+        }
+
+        return performances;
+    }
+
+    /**
+     * 개별 리뷰의 성과 정보 생성
+     */
+    private CreatorPerformanceResponse.ReviewPerformance buildReviewPerformance(CampaignReview review) {
+        ContentStatus contentStatus = getReviewContentStatus(review);
+        String postUrl = null;
+        Long viewCount = null;
+        Long likeCount = null;
+        Long commentCount = null;
+        Long shareCount = null;
+
+        // 2차 리뷰(최종 업로드)인 경우에만 postUrl과 성과 지표 포함
+        if (review.getReviewRound() == ReviewRound.SECOND && review.getStatus() == ReviewStatus.RESUBMITTED) {
+            postUrl = review.getPostUrl();
+
+            // SocialClip에서 성과 지표 조회
+            Optional<SocialClip> socialClip = socialClipGetService.findByCampaignReview(review);
+            if (socialClip.isPresent()) {
+                SocialClip clip = socialClip.get();
+                viewCount = clip.getPlays();
+                likeCount = clip.getLikes();
+                commentCount = clip.getComments();
+                shareCount = clip.getShares();
+            }
+        }
+
+        return CreatorPerformanceResponse.ReviewPerformance.builder()
+                .campaignReviewId(review.getId())
+                .reviewRound(review.getReviewRound())
+                .contentType(review.getContentType())
+                .reviewStatus(contentStatus)
+                .postUrl(postUrl)
+                .viewCount(viewCount)
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .shareCount(shareCount)
+                .build();
+    }
+
+    /**
+     * 리뷰 상태를 ContentStatus enum으로 변환
+     * PENDING_REVISION: 브랜드 리뷰 대기중 또는 수정 요청 후 크리에이터 노트 미확인
+     * REVISING: 브랜드가 수정 요청 + 크리에이터가 노트 확인
+     */
+    private ContentStatus getReviewContentStatus(CampaignReview review) {
+        ReviewStatus status = review.getStatus();
+
+        return switch (status) {
+            case SUBMITTED -> ContentStatus.PENDING_REVISION;
+            case REVISION_REQUESTED -> {
+                if (review.isNoteViewed()) {
+                    yield ContentStatus.REVISING;
+                } else {
+                    yield ContentStatus.PENDING_REVISION;
+                }
+            }
+            case RESUBMITTED -> ContentStatus.FINAL_UPLOADED;
+        };
     }
 }

--- a/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
@@ -100,6 +100,7 @@ public class BrandUsecase {
         // 연관 엔티티들
         CreatorCampaign creatorCampaign = review.getCreatorCampaign();
         Campaign campaign = creatorCampaign.getCampaign();
+        Creator creator = creatorCampaign.getCreator();
 
         // 브랜드 권한 검증 (해당 브랜드가 발행한 캠페인인지 아닌지)
         if (!campaign.getBrand().getId().equals(brandId)) {
@@ -118,18 +119,30 @@ public class BrandUsecase {
         // 업로드 된 미디어 URL 조회
         List<String> mediaUrls = campaignReviewGetService.getOrderedMediaUrls(review);
 
-
         // 만약 2차 리뷰이고, postUrl이 존재한다면 같이 내려주기
         String postUrl = null;
         if (round == ReviewRound.SECOND && review.getPostUrl() != null) {
             postUrl = review.getPostUrl();
         }
+
+        // 크리에이터 정보
+        CampaignReviewDetailListResponse.CreatorInfo creatorInfo = CampaignReviewDetailListResponse.CreatorInfo.builder()
+                .profileImageUrl(creator.getUser().getProfileImageUrl())
+                .fullName(creator.getUser().getName())
+                .creatorName(creator.getCreatorName())
+                .build();
+
+        // 검토 요청 시간 (브랜드가 수정 요청한 시간)
+        Instant reviewRequestedAt = review.getRevisionRequestedAt();
+
         return campaignReviewMapper.toDetailListResponse(
                 campaign,
                 review,
                 round,
                 mediaUrls,
-                postUrl
+                postUrl,
+                creatorInfo,
+                reviewRequestedAt
         );
     }
 

--- a/src/main/java/com/lokoko/domain/campaignReview/api/dto/response/CampaignReviewDetailListResponse.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/api/dto/response/CampaignReviewDetailListResponse.java
@@ -40,6 +40,24 @@ public record CampaignReviewDetailListResponse(
         Instant brandNoteDeadline,
 
         @Schema(description = "2차 리뷰 완료 시 실제 게시물 URL")
-        String postUrl
+        String postUrl,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 정보")
+        CreatorInfo creator,
+
+        @Schema(description = "검토 요청 시간 (브랜드가 수정 요청한 시간)")
+        Instant reviewRequestedAt
 ) {
+        @Builder
+        public record CreatorInfo(
+                @Schema(requiredMode = REQUIRED, description = "크리에이터 프로필 이미지 URL")
+                String profileImageUrl,
+
+                @Schema(requiredMode = REQUIRED, description = "크리에이터 풀 네임")
+                String fullName,
+
+                @Schema(requiredMode = REQUIRED, description = "크리에이터 닉네임")
+                String creatorName
+        ) {
+        }
 }

--- a/src/main/java/com/lokoko/domain/campaignReview/application/mapper/CampaignReviewMapper.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/application/mapper/CampaignReviewMapper.java
@@ -96,7 +96,9 @@ public class CampaignReviewMapper {
     public CampaignReviewDetailListResponse toDetailListResponse(Campaign campaign, CampaignReview review,
                                                                  ReviewRound round,
                                                                  List<String> mediaUrls,
-                                                                 String postUrl) {
+                                                                 String postUrl,
+                                                                 CampaignReviewDetailListResponse.CreatorInfo creatorInfo,
+                                                                 Instant reviewRequestedAt) {
 
         // 브랜드 노트 마감일은 캠페인 deadLine으로부터 4일 전
         Instant brandNoteDeadline = campaign.getReviewSubmissionDeadline().minus(Duration.ofDays(4));
@@ -111,6 +113,8 @@ public class CampaignReviewMapper {
                 .brandNote(review.getBrandNote())
                 .brandNoteDeadline(brandNoteDeadline)
                 .postUrl(postUrl)
+                .creator(creatorInfo)
+                .reviewRequestedAt(reviewRequestedAt)
                 .build();
     }
 }

--- a/src/main/java/com/lokoko/domain/campaignReview/application/service/CampaignReviewGetService.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/application/service/CampaignReviewGetService.java
@@ -169,4 +169,11 @@ public class CampaignReviewGetService {
         return campaignReviewRepository.findTopByCreatorCampaignIdAndReviewRoundAndContentTypeOrderByIdAsc(
                 creatorCampaignId, reviewRound, contentType);
     }
+
+    /**
+     * 특정 CreatorCampaign의 모든 리뷰 조회
+     */
+    public List<CampaignReview> findAllByCreatorCampaignId(Long creatorCampaignId) {
+        return campaignReviewRepository.findAllByCreatorCampaignId(creatorCampaignId);
+    }
 }

--- a/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
@@ -15,6 +15,7 @@ import com.lokoko.domain.campaignReview.application.service.CampaignReviewSaveSe
 import com.lokoko.domain.campaignReview.application.service.CampaignReviewStatusManager;
 import com.lokoko.domain.campaignReview.application.service.CampaignReviewUpdateService;
 import com.lokoko.domain.campaignReview.application.service.CreatorCampaignUpdateService;
+import com.lokoko.domain.media.socialclip.application.service.SocialClipSaveService;
 import com.lokoko.domain.campaignReview.application.utils.CampaignReviewValidationUtil;
 import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
 import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
@@ -47,6 +48,7 @@ public class CampaignReviewUsecase {
     private final CampaignReviewSaveService campaignReviewSaveService;
     private final CreatorCampaignUpdateService creatorCampaignUpdateService;
     private final CampaignReviewUpdateService campaignReviewUpdateService;
+    private final SocialClipSaveService socialClipSaveService;
 
     private final CampaignReviewStatusManager campaignReviewStatusManager;
 
@@ -154,6 +156,9 @@ public class CampaignReviewUsecase {
         CampaignReview savedA = campaignReviewSaveService.saveReview(secondA);
         campaignReviewSaveService.saveMedia(savedA, request.firstMediaUrls());
 
+        // 2차 리뷰 업로드 시 SocialClip 생성 (성과 지표 0으로 초기화)
+        socialClipSaveService.createForSecondReview(savedA);
+
         // B(옵션)
         if (typeB != null) {
             campaignReviewGetService.getFirstOrThrow(participation.getId(), typeB);
@@ -161,6 +166,9 @@ public class CampaignReviewUsecase {
                     participation, typeB, request.secondCaptionWithHashtags(), request.secondPostUrl());
             CampaignReview savedB = campaignReviewSaveService.saveReview(secondB);
             campaignReviewSaveService.saveMedia(savedB, request.secondMediaUrls());
+
+            // 2차 리뷰 업로드 시 SocialClip 생성 (성과 지표 0으로 초기화)
+            socialClipSaveService.createForSecondReview(savedB);
         }
 
         creatorCampaignUpdateService.refreshParticipationStatus(participation.getId());

--- a/src/main/java/com/lokoko/domain/campaignReview/domain/entity/enums/ContentStatus.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/domain/entity/enums/ContentStatus.java
@@ -1,0 +1,17 @@
+package com.lokoko.domain.campaignReview.domain.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ContentStatus {
+    NOT_SUBMITTED("미제출"),
+    IN_PROGRESS("진행중"),
+    PENDING_REVISION("검토 요청"),
+    REVISING("수정중"),
+    FINAL_UPLOADED("최종 업로드"),
+    UNKNOWN("알 수 없음");
+
+    private final String description;
+}

--- a/src/main/java/com/lokoko/domain/campaignReview/domain/repository/CampaignReviewRepository.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/domain/repository/CampaignReviewRepository.java
@@ -47,4 +47,6 @@ public interface CampaignReviewRepository extends JpaRepository<CampaignReview, 
 
     Optional<CampaignReview> findTopByCreatorCampaignAndReviewRoundOrderByIdDesc(
             CreatorCampaign creatorCampaign, ReviewRound reviewRound);
+
+    List<CampaignReview> findAllByCreatorCampaignId(Long creatorCampaignId);
 }

--- a/src/main/java/com/lokoko/domain/creatorCampaign/application/service/CreatorCampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/application/service/CreatorCampaignGetService.java
@@ -124,4 +124,11 @@ public class CreatorCampaignGetService {
         return creatorCampaignRepository.findByCampaignAndCreator_Id(campaign, creatorId)
                 .orElseThrow(CreatorCampaignNotFoundException::new);
     }
+
+    /**
+     * 특정 캠페인에 참여한 모든 CreatorCampaign 조회
+     */
+    public List<CreatorCampaign> findAllByCampaign(Campaign campaign) {
+        return creatorCampaignRepository.findAllByCampaign(campaign);
+    }
 }

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepository.java
@@ -97,4 +97,6 @@ public interface CreatorCampaignRepository extends JpaRepository<CreatorCampaign
     @Query("SELECT cc FROM CreatorCampaign cc WHERE cc.campaign.id = :campaignId AND cc.status = :status")
     List<CreatorCampaign> findByCampaignIdAndStatus(@Param("campaignId") Long campaignId,
                                                      @Param("status") ParticipationStatus status);
+
+    List<CreatorCampaign> findAllByCampaign(Campaign campaign);
 }

--- a/src/main/java/com/lokoko/domain/media/socialclip/application/service/SocialClipGetService.java
+++ b/src/main/java/com/lokoko/domain/media/socialclip/application/service/SocialClipGetService.java
@@ -1,0 +1,27 @@
+package com.lokoko.domain.media.socialclip.application.service;
+
+import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
+import com.lokoko.domain.media.socialclip.domain.SocialClip;
+import com.lokoko.domain.media.socialclip.domain.repository.SocialClipRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SocialClipGetService {
+
+    private final SocialClipRepository socialClipRepository;
+
+    /**
+     * CampaignReview로 SocialClip 조회
+     */
+    public Optional<SocialClip> findByCampaignReview(CampaignReview campaignReview) {
+        return socialClipRepository.findAll().stream()
+                .filter(clip -> clip.getCampaignReview().equals(campaignReview))
+                .findFirst();
+    }
+}

--- a/src/main/java/com/lokoko/domain/media/socialclip/application/service/SocialClipSaveService.java
+++ b/src/main/java/com/lokoko/domain/media/socialclip/application/service/SocialClipSaveService.java
@@ -1,0 +1,35 @@
+package com.lokoko.domain.media.socialclip.application.service;
+
+import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
+import com.lokoko.domain.media.socialclip.domain.SocialClip;
+import com.lokoko.domain.media.socialclip.domain.repository.SocialClipRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class SocialClipSaveService {
+
+    private final SocialClipRepository socialClipRepository;
+
+    /**
+     * 2차 리뷰 작성 시 SocialClip 생성
+     * 조회수, 좋아요수, 댓글수, 공유수 모두 기본 0으로 세팅
+     */
+    @Transactional
+    public void createForSecondReview(CampaignReview campaignReview) {
+        SocialClip socialClip = SocialClip.builder()
+                .campaignReview(campaignReview)
+                .plays(0L)
+                .likes(0L)
+                .comments(0L)
+                .shares(0L)
+                .uploadedAt(Instant.now())
+                .build();
+
+        socialClipRepository.save(socialClip);
+    }
+}

--- a/src/main/java/com/lokoko/domain/media/socialclip/domain/repository/SocialClipRepository.java
+++ b/src/main/java/com/lokoko/domain/media/socialclip/domain/repository/SocialClipRepository.java
@@ -1,0 +1,7 @@
+package com.lokoko.domain.media.socialclip.domain.repository;
+
+import com.lokoko.domain.media.socialclip.domain.SocialClip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SocialClipRepository extends JpaRepository<SocialClip, Long> {
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #284 

## 작업 내용 💻

![Uploading image.png…]()


- [ 브랜드 컨텐츠 확인 API 를 구현합니다. ] 
- [크리에이터가 2차 리뷰를 업로드할때, Social Clip 엔티티의 좋아요수 ,공유수, 댓글 수 등을 0으로 초기화하여 생성합니다. ] 

## 스크린샷 📷


<img width="593" height="378" alt="image" src="https://github.com/user-attachments/assets/f959dd3e-bee2-40e2-a892-37e15744d439" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 브랜드가 캠페인별로 크리에이터별 성과(리뷰 라운드·상태, 게시물 링크 및 조회수·좋아요·댓글·공유 등)를 조회할 수 있는 엔드포인트가 추가되었습니다.
  - 크리에이터 메타정보(프로필·이름)와 리뷰 요청 시간 등 상세 정보가 응답에 포함됩니다.
  - 기본 페이지네이션이 적용됩니다 (page=0, size=5).
  - 두 번째 라운드 업로드 시 소셜 지표 수집이 자동으로 생성됩니다.
- 기타
  - 관련 성공 메시지가 추가되어 응답 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->