### PR TITLE
[REFACTOR] #352  캠페인 컨텐츠 확인 api 응답에 uploadedAt 정보 추가

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/CreatorPerformanceResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/CreatorPerformanceResponse.java
@@ -6,6 +6,7 @@ import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
 import com.lokoko.global.common.response.PageableResponse;
 import lombok.Builder;
 
+import java.time.Instant;
 import java.util.List;
 
 @Builder
@@ -43,7 +44,8 @@ public record CreatorPerformanceResponse(
             Long viewCount,
             Long likeCount,
             Long commentCount,
-            Long shareCount
+            Long shareCount,
+            Instant uploadedAt
     ) {
     }
 }

--- a/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
@@ -300,6 +300,7 @@ public class BrandUsecase {
         Long likeCount = null;
         Long commentCount = null;
         Long shareCount = null;
+        Instant uploadedAt = null;
 
         // 2차 리뷰(최종 업로드)인 경우에만 postUrl과 성과 지표 포함
         if (review.getReviewRound() == ReviewRound.SECOND && review.getStatus() == ReviewStatus.RESUBMITTED) {
@@ -313,6 +314,7 @@ public class BrandUsecase {
                 likeCount = clip.getLikes();
                 commentCount = clip.getComments();
                 shareCount = clip.getShares();
+                uploadedAt = clip.getUploadedAt();
             }
         }
 
@@ -326,6 +328,7 @@ public class BrandUsecase {
                 .likeCount(likeCount)
                 .commentCount(commentCount)
                 .shareCount(shareCount)
+                .uploadedAt(uploadedAt)
                 .build();
     }
 


### PR DESCRIPTION
## Related issue 🛠

- closed #351 

## 작업 내용 💻

- [ 브랜드 마인페이지 - 컨텐츠 성과 확인 API 의 응답에, 2차리뷰가 언제 업로드 되었는지 uploadedAt 정보를 추가합니다. ] 
-

## 스크린샷 📷

<img width="817" height="274" alt="image" src="https://github.com/user-attachments/assets/79d8bbe3-e199-4d29-aa35-d390416e4c24" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

