### PR TITLE
[REFACTOR] #353 브랜드 컨텐츠 확인 응답 dto 수정 및 쿼리 최적화

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/dto/response/CreatorPerformanceResponse.java
+++ b/src/main/java/com/lokoko/domain/brand/api/dto/response/CreatorPerformanceResponse.java
@@ -55,29 +55,37 @@ public record CreatorPerformanceResponse(
             @Schema(requiredMode = REQUIRED, description = "리뷰 라운드", example = "SECOND")
             ReviewRound reviewRound,
 
-            @Schema(requiredMode = REQUIRED, description = "콘텐츠 타입", example = "TIKTOK_VIDEO")
-            ContentType contentType,
-
             @Schema(requiredMode = REQUIRED, description = "리뷰 상태", example = "FINAL_UPLOADED")
             ContentStatus reviewStatus,
 
             @Schema(requiredMode = NOT_REQUIRED, description = "게시물 URL (2차 리뷰만)", example = "https://www.instagram.com/p/ABC123/")
             String postUrl,
 
-            @Schema(requiredMode = NOT_REQUIRED, description = "조회수 (2차 리뷰만)", example = "15000")
-            Long viewCount,
-
-            @Schema(requiredMode = NOT_REQUIRED, description = "좋아요 수 (2차 리뷰만)", example = "1200")
-            Long likeCount,
-
-            @Schema(requiredMode = NOT_REQUIRED, description = "댓글 수 (2차 리뷰만)", example = "85")
-            Long commentCount,
-
-            @Schema(requiredMode = NOT_REQUIRED, description = "공유 수 (2차 리뷰만)", example = "30")
-            Long shareCount,
+            @Schema(requiredMode = NOT_REQUIRED, description = "콘텐츠 정보 (2차 리뷰만)")
+            ContentMetrics contents,
 
             @Schema(requiredMode = NOT_REQUIRED, description = "업로드 시간 (2차 리뷰만)", example = "2024-01-15T10:30:00Z")
             Instant uploadedAt
+    ) {
+    }
+
+    @Builder
+    @Schema(description = "콘텐츠 성과 지표")
+    public record ContentMetrics(
+            @Schema(requiredMode = REQUIRED, description = "콘텐츠 타입", example = "INSTA_REELS")
+            ContentType contentType,
+
+            @Schema(requiredMode = NOT_REQUIRED, description = "조회수", example = "234")
+            Long viewCount,
+
+            @Schema(requiredMode = NOT_REQUIRED, description = "좋아요 수", example = "2342")
+            Long likeCount,
+
+            @Schema(requiredMode = NOT_REQUIRED, description = "댓글 수", example = "23423")
+            Long commentCount,
+
+            @Schema(requiredMode = NOT_REQUIRED, description = "공유 수", example = "2342")
+            Long shareCount
     ) {
     }
 }

--- a/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
@@ -282,8 +282,10 @@ public class BrandUsecase {
 
                     performances.add(CreatorPerformanceResponse.ReviewPerformance.builder()
                             .reviewRound(ReviewRound.FIRST)
-                            .contentType(contentType)
                             .reviewStatus(contentStatus)
+                            .contents(CreatorPerformanceResponse.ContentMetrics.builder()
+                                    .contentType(contentType)
+                                    .build())
                             .build());
                 }
             }
@@ -320,16 +322,23 @@ public class BrandUsecase {
             }
         }
 
+        CreatorPerformanceResponse.ContentMetrics contents = null;
+        if (review.getContentType() != null) {
+            contents = CreatorPerformanceResponse.ContentMetrics.builder()
+                    .contentType(review.getContentType())
+                    .viewCount(viewCount)
+                    .likeCount(likeCount)
+                    .commentCount(commentCount)
+                    .shareCount(shareCount)
+                    .build();
+        }
+
         return CreatorPerformanceResponse.ReviewPerformance.builder()
                 .campaignReviewId(review.getId())
                 .reviewRound(review.getReviewRound())
-                .contentType(review.getContentType())
                 .reviewStatus(contentStatus)
                 .postUrl(postUrl)
-                .viewCount(viewCount)
-                .likeCount(likeCount)
-                .commentCount(commentCount)
-                .shareCount(shareCount)
+                .contents(contents)
                 .uploadedAt(uploadedAt)
                 .build();
     }

--- a/src/main/java/com/lokoko/domain/media/socialclip/application/service/SocialClipGetService.java
+++ b/src/main/java/com/lokoko/domain/media/socialclip/application/service/SocialClipGetService.java
@@ -20,8 +20,6 @@ public class SocialClipGetService {
      * CampaignReview로 SocialClip 조회
      */
     public Optional<SocialClip> findByCampaignReview(CampaignReview campaignReview) {
-        return socialClipRepository.findAll().stream()
-                .filter(clip -> clip.getCampaignReview().equals(campaignReview))
-                .findFirst();
+        return socialClipRepository.findByCampaignReview(campaignReview);
     }
 }

--- a/src/main/java/com/lokoko/domain/media/socialclip/domain/repository/SocialClipRepository.java
+++ b/src/main/java/com/lokoko/domain/media/socialclip/domain/repository/SocialClipRepository.java
@@ -1,7 +1,11 @@
 package com.lokoko.domain.media.socialclip.domain.repository;
 
+import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
 import com.lokoko.domain.media.socialclip.domain.SocialClip;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SocialClipRepository extends JpaRepository<SocialClip, Long> {
+    Optional<SocialClip> findByCampaignReview(CampaignReview campaignReview);
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #

## 작업 내용 💻

- [브랜드 컨텐츠 확인 응답 dto 를 수정합니다. 컨텐츠 관련 정보를 contents 로 묶어서 반환합니다 (클라이언트 요청 사항) ] 
- [ SocialClipGetService 에서 findAll 메소드를 제거하고, 캠페인 리뷰 id 를 기준으로 조회하도록 변경합니다.  ] 

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

