### PR TITLE
[REFACTOR] #357  Creator 의 기본 creatorType 을 할당하지 않도록 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -74,12 +74,15 @@ public class CampaignGetService {
             if (currentUserRole.equals(Role.CREATOR.name())) {
 
                 Creator currentCreator = currentUser.getCreator();
-                if (currentCreator.getCreatorStatus() == CreatorStatus.NOT_APPROVED){
-                    creatorRoleInfo = CreatorStatus.NOT_APPROVED.name();
-                }
+
                 if (currentCreator.getCreatorType() != null){
                     creatorRoleInfo = currentCreator.getCreatorType().name();
                 }
+
+                if (currentCreator.getCreatorStatus() == CreatorStatus.NOT_APPROVED){
+                    creatorRoleInfo = CreatorStatus.NOT_APPROVED.name();
+                }
+
             }
         }
 

--- a/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
+++ b/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
@@ -98,10 +98,9 @@ public class Creator {
     @Column
     private CreatorStatus creatorStatus = CreatorStatus.NOT_APPROVED;
 
-    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column
-    private CreatorType creatorType = CreatorType.NORMAL;
+    private CreatorType creatorType;
 
     @Column
     private String tikTokUserId;


### PR DESCRIPTION
## Related issue 🛠

- closed #356 

## 작업 내용 💻

Creator 가 최초로 가입 했을 시점은 NOT_APPROVED 상테입니다. 
미승인 상태의 크리에이터는, NORMAL 또는 PRO 등급을 가질 수 없기 때문에,
@Builder.Default 로 기본 값을 NORMAL 로 초기화하는 상황은 존재하지 않아야 합니다.



## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-

