### PR TITLE
[FEAT] #360 : 인스타그램 연동방식을 페이스북을 거쳐서 하는 방식으로 수정

### DIFF
--- a/src/main/java/com/lokoko/global/auth/provider/insta/config/InstaOauthClient.java
+++ b/src/main/java/com/lokoko/global/auth/provider/insta/config/InstaOauthClient.java
@@ -4,11 +4,12 @@ import com.lokoko.domain.user.application.service.UserGetService;
 import com.lokoko.global.auth.exception.InstagramLongTokenRequestFailedException;
 import com.lokoko.global.auth.exception.InstagramRefreshTokenFailedException;
 import com.lokoko.global.auth.exception.InstagramTokenRequestFailedException;
-import com.lokoko.global.auth.provider.insta.dto.InstagramLongTokenDto;
-import com.lokoko.global.auth.provider.insta.dto.InstagramShortTokenDto;
+import com.lokoko.global.auth.provider.insta.dto.*;
 import com.lokoko.global.auth.service.OAuthStateManager;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -26,13 +27,26 @@ public class InstaOauthClient {
     private final InstaProperties props;
     private final UserGetService userGetService;
 
+    /**
+     * Instagram Graph API를 위한 Facebook OAuth URL 생성
+     * Facebook 로그인을 통해 페이지 및 Instagram 비즈니스 계정 접근 권한 요청
+     */
     public String buildAuthorizationUrl(Long userId, String returnTo) {
         String state = oAuthStateManager.generateStateWithReturnTo(userId, returnTo);
 
         String encodedRedirect = URLEncoder.encode(props.redirectUri(), StandardCharsets.UTF_8);
-        String encodedScope = URLEncoder.encode(props.scope(), StandardCharsets.UTF_8);
 
-        return InstagramConstants.AUTHORIZE_BASE_URL
+        // Instagram Graph API에 필요한 Facebook 권한 스코프
+        String scope = String.join(",",
+                InstagramConstants.SCOPE_PAGES_SHOW_LIST,
+                InstagramConstants.SCOPE_PAGES_READ_ENGAGEMENT,
+                InstagramConstants.SCOPE_INSTAGRAM_BASIC,
+                InstagramConstants.SCOPE_INSTAGRAM_MANAGE_INSIGHTS,
+                InstagramConstants.SCOPE_BUSINESS_MANAGEMENT
+        );
+        String encodedScope = URLEncoder.encode(scope, StandardCharsets.UTF_8);
+
+        return InstagramConstants.FACEBOOK_AUTHORIZE_URL
                 + "?"
                 + InstagramConstants.PARAM_CLIENT_ID + "=" + props.clientId()
                 + "&" + InstagramConstants.PARAM_REDIRECT_URI + "=" + encodedRedirect
@@ -42,8 +56,130 @@ public class InstaOauthClient {
     }
 
     /**
+     * Facebook OAuth code를 액세스 토큰으로 교환
+     */
+    public FacebookAccessTokenDto exchangeFacebookToken(String code) {
+        try {
+            FacebookAccessTokenDto dto = instagramWebClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .scheme("https")
+                            .host("graph.facebook.com")
+                            .path("/v23.0/oauth/access_token")
+                            .queryParam(InstagramConstants.PARAM_CLIENT_ID, props.clientId())
+                            .queryParam(InstagramConstants.PARAM_CLIENT_SECRET, props.clientSecret())
+                            .queryParam(InstagramConstants.PARAM_REDIRECT_URI, props.redirectUri())
+                            .queryParam(InstagramConstants.PARAM_CODE, code)
+                            .build())
+                    .retrieve()
+                    .bodyToMono(FacebookAccessTokenDto.class)
+                    .block();
+
+            if (dto == null || dto.accessToken() == null) {
+                throw new InstagramTokenRequestFailedException();
+            }
+
+            return dto;
+        } catch (Exception e) {
+            log.error("Facebook 토큰 발급 실패: {}", e.getMessage(), e);
+            throw new InstagramTokenRequestFailedException();
+        }
+    }
+
+    /**
+     * Facebook 페이지 목록 조회
+     * 각 페이지에 연결된 Instagram 비즈니스 계정을 찾기 위해 필요
+     */
+    public FacebookPagesDto getFacebookPages(String accessToken) {
+        try {
+            FacebookPagesDto dto = instagramWebClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .scheme("https")
+                            .host("graph.facebook.com")
+                            .path("/v23.0/me/accounts")
+                            .queryParam(InstagramConstants.PARAM_FIELDS, "id,name,access_token,category,tasks")
+                            .queryParam(InstagramConstants.PARAM_ACCESS_TOKEN, accessToken)
+                            .build())
+                    .retrieve()
+                    .bodyToMono(FacebookPagesDto.class)
+                    .block();
+
+            if (dto == null || dto.data() == null || dto.data().isEmpty()) {
+                log.error("연동된 Facebook 페이지가 없습니다");
+                throw new InstagramTokenRequestFailedException();
+            }
+
+            return dto;
+        } catch (Exception e) {
+            log.error("Facebook 페이지 조회 실패: {}", e.getMessage(), e);
+            throw new InstagramTokenRequestFailedException();
+        }
+    }
+
+    /**
+     * Facebook 페이지에 연결된 Instagram 비즈니스 계정 조회
+     */
+    public InstagramBusinessAccountDto getInstagramBusinessAccount(String pageId, String pageAccessToken) {
+        try {
+            InstagramBusinessAccountDto dto = instagramWebClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .scheme("https")
+                            .host("graph.facebook.com")
+                            .path("/v23.0/" + pageId)
+                            .queryParam(InstagramConstants.PARAM_FIELDS, "instagram_business_account{id,username}")
+                            .queryParam(InstagramConstants.PARAM_ACCESS_TOKEN, pageAccessToken)
+                            .build())
+                    .retrieve()
+                    .bodyToMono(InstagramBusinessAccountDto.class)
+                    .block();
+
+            if (dto == null || dto.instagramBusinessAccount() == null) {
+                log.warn("페이지 {}에 연결된 Instagram 비즈니스 계정이 없습니다", pageId);
+                return null;
+            }
+
+            return dto;
+        } catch (Exception e) {
+            log.error("Instagram 비즈니스 계정 조회 실패 (pageId: {}): {}", pageId, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Instagram 비즈니스 계정의 장기 액세스 토큰 발급
+     */
+    public InstagramGraphTokenDto exchangeLongLivedToken(String shortAccessToken) {
+        try {
+            InstagramGraphTokenDto dto = instagramWebClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .scheme("https")
+                            .host("graph.facebook.com")
+                            .path("/v23.0/oauth/access_token")
+                            .queryParam(InstagramConstants.PARAM_GRANT_TYPE, "fb_exchange_token")
+                            .queryParam("fb_exchange_token", shortAccessToken)
+                            .queryParam(InstagramConstants.PARAM_CLIENT_ID, props.clientId())
+                            .queryParam(InstagramConstants.PARAM_CLIENT_SECRET, props.clientSecret())
+                            .build())
+                    .retrieve()
+                    .bodyToMono(InstagramGraphTokenDto.class)
+                    .block();
+
+            if (dto == null || dto.accessToken() == null) {
+                throw new InstagramLongTokenRequestFailedException();
+            }
+            return dto;
+        } catch (Exception e) {
+            log.error("Instagram Graph API 장기 토큰 발급 실패: {}", e.getMessage(), e);
+            throw new InstagramLongTokenRequestFailedException();
+        }
+    }
+
+    // ========== 아래는 Basic Display API 방식 (Deprecated) ==========
+
+    /**
+     * @deprecated Instagram Basic Display API 방식 (더 이상 사용하지 않음)
      * code → 단기(Short-lived) 액세스 토큰 교환
      */
+    @Deprecated
     public InstagramShortTokenDto exchangeShortLivedToken(String code) {
         try {
             InstagramShortTokenDto dto = instagramWebClient.post()
@@ -69,9 +205,11 @@ public class InstaOauthClient {
     }
 
     /**
+     * @deprecated Instagram Basic Display API 방식 (더 이상 사용하지 않음)
      * 단기 토큰 → 장기(Long-lived) 토큰 교환
      */
-    public InstagramLongTokenDto exchangeLongLivedToken(String shortAccessToken) {
+    @Deprecated
+    public InstagramLongTokenDto exchangeLongLivedTokenBasicDisplay(String shortAccessToken) {
         try {
             InstagramLongTokenDto dto = instagramWebClient.get()
                     .uri(uriBuilder -> uriBuilder
@@ -98,8 +236,10 @@ public class InstaOauthClient {
     }
 
     /**
+     * @deprecated Instagram Basic Display API 방식 (더 이상 사용하지 않음)
      * 장기 토큰 갱신
      */
+    @Deprecated
     public InstagramLongTokenDto refreshLongLivedToken(String longAccessToken) {
         try {
             InstagramLongTokenDto dto = instagramWebClient.get()

--- a/src/main/java/com/lokoko/global/auth/provider/insta/config/InstagramConstants.java
+++ b/src/main/java/com/lokoko/global/auth/provider/insta/config/InstagramConstants.java
@@ -4,12 +4,18 @@ public class InstagramConstants {
     private InstagramConstants() {
     }
 
+    // ========== Facebook OAuth (Instagram Graph API 사용을 위한 Facebook 로그인) ==========
+    public static final String FACEBOOK_AUTHORIZE_URL = "https://www.facebook.com/v23.0/dialog/oauth";
+    public static final String FACEBOOK_TOKEN_URL = "https://graph.facebook.com/v23.0/oauth/access_token";
+    public static final String FACEBOOK_GRAPH_API_BASE = "https://graph.facebook.com/v23.0";
+
+    // ========== Instagram Basic Display API (Deprecated - 기존 방식) ==========
     public static final String AUTHORIZE_BASE_URL = "https://www.instagram.com/oauth/authorize";
     public static final String TOKEN_URL = "https://api.instagram.com/oauth/access_token";
     public static final String LONG_LIVED_TOKEN_URL = "https://graph.instagram.com/access_token";
     public static final String REFRESH_TOKEN_URL = "https://graph.instagram.com/refresh_access_token";
 
-    // query/form keys
+    // ========== Query/Form Parameters ==========
     public static final String PARAM_CLIENT_ID = "client_id";
     public static final String PARAM_CLIENT_SECRET = "client_secret";
     public static final String PARAM_REDIRECT_URI = "redirect_uri";
@@ -19,11 +25,25 @@ public class InstagramConstants {
     public static final String PARAM_ACCESS_TOKEN = "access_token";
     public static final String PARAM_CODE = "code";
     public static final String PARAM_GRANT_TYPE = "grant_type";
+    public static final String PARAM_FIELDS = "fields";
     public static final String RESPONSE_TYPE_CODE = "code";
 
-    // long-lived
+    // ========== Grant Types ==========
+    public static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
     public static final String GRANT_TYPE_IG_EXCHANGE_TOKEN = "ig_exchange_token";
-
-    // refresh
     public static final String GRANT_TYPE_IG_REFRESH_TOKEN = "ig_refresh_token";
+
+    // ========== Instagram Graph API Scopes ==========
+    // Facebook 페이지 관리 권한
+    public static final String SCOPE_PAGES_SHOW_LIST = "pages_show_list";
+    public static final String SCOPE_PAGES_READ_ENGAGEMENT = "pages_read_engagement";
+    public static final String SCOPE_PAGES_MANAGE_METADATA = "pages_manage_metadata";
+
+    // Instagram 비즈니스 계정 권한
+    public static final String SCOPE_INSTAGRAM_BASIC = "instagram_basic";
+    public static final String SCOPE_INSTAGRAM_MANAGE_INSIGHTS = "instagram_manage_insights";
+    public static final String SCOPE_INSTAGRAM_CONTENT_PUBLISH = "instagram_content_publish";
+
+    // 공통 권한
+    public static final String SCOPE_BUSINESS_MANAGEMENT = "business_management";
 }

--- a/src/main/java/com/lokoko/global/auth/provider/insta/dto/FacebookAccessTokenDto.java
+++ b/src/main/java/com/lokoko/global/auth/provider/insta/dto/FacebookAccessTokenDto.java
@@ -1,0 +1,19 @@
+package com.lokoko.global.auth.provider.insta.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Facebook OAuth 액세스 토큰 응답 DTO
+ * Instagram Graph API 사용을 위해 먼저 Facebook 로그인이 필요
+ */
+public record FacebookAccessTokenDto(
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("token_type")
+        String tokenType,
+
+        @JsonProperty("expires_in")
+        Long expiresIn
+) {
+}

--- a/src/main/java/com/lokoko/global/auth/provider/insta/dto/FacebookPagesDto.java
+++ b/src/main/java/com/lokoko/global/auth/provider/insta/dto/FacebookPagesDto.java
@@ -1,0 +1,24 @@
+package com.lokoko.global.auth.provider.insta.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Facebook Pages 목록 응답 DTO
+ */
+public record FacebookPagesDto(
+        List<FacebookPage> data
+) {
+    public record FacebookPage(
+            String id,
+            String name,
+
+            @JsonProperty("access_token")
+            String accessToken,
+
+            String category,
+
+            List<String> tasks
+    ) {
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/provider/insta/dto/InstagramBusinessAccountDto.java
+++ b/src/main/java/com/lokoko/global/auth/provider/insta/dto/InstagramBusinessAccountDto.java
@@ -1,0 +1,18 @@
+package com.lokoko.global.auth.provider.insta.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Instagram Business Account 정보 DTO
+ * Facebook Page에 연결된 Instagram 비즈니스 계정 정보
+ */
+public record InstagramBusinessAccountDto(
+        @JsonProperty("instagram_business_account")
+        InstagramAccount instagramBusinessAccount
+) {
+    public record InstagramAccount(
+            String id,
+            String username
+    ) {
+    }
+}

--- a/src/main/java/com/lokoko/global/auth/provider/insta/dto/InstagramGraphTokenDto.java
+++ b/src/main/java/com/lokoko/global/auth/provider/insta/dto/InstagramGraphTokenDto.java
@@ -1,0 +1,18 @@
+package com.lokoko.global.auth.provider.insta.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Instagram Graph API 장기 토큰 DTO
+ */
+public record InstagramGraphTokenDto(
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("token_type")
+        String tokenType,
+
+        @JsonProperty("expires_in")
+        Long expiresIn
+) {
+}

--- a/src/main/java/com/lokoko/global/auth/provider/insta/usecase/InstaConnectionUsecase.java
+++ b/src/main/java/com/lokoko/global/auth/provider/insta/usecase/InstaConnectionUsecase.java
@@ -9,9 +9,7 @@ import com.lokoko.global.auth.exception.InstagramConnectionFailedException;
 import com.lokoko.global.auth.exception.InstagramLongTokenRequestFailedException;
 import com.lokoko.global.auth.exception.InstagramTokenRequestFailedException;
 import com.lokoko.global.auth.provider.insta.config.InstaOauthClient;
-import com.lokoko.global.auth.provider.insta.dto.InstagramConnectionResponse;
-import com.lokoko.global.auth.provider.insta.dto.InstagramLongTokenDto;
-import com.lokoko.global.auth.provider.insta.dto.InstagramShortTokenDto;
+import com.lokoko.global.auth.provider.insta.dto.*;
 import com.lokoko.global.auth.provider.insta.service.InstaRedisTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,22 +40,45 @@ public class InstaConnectionUsecase {
         try {
             User user = userGetService.findUserById(userId);
 
-            // 1) code → 단기 토큰
-            InstagramShortTokenDto shortDto = instaOAuthClient.exchangeShortLivedToken(code);
+            // 1) code → Facebook 액세스 토큰
+            FacebookAccessTokenDto facebookToken = instaOAuthClient.exchangeFacebookToken(code);
 
-            // 2) 단기 → 장기 토큰
-            InstagramLongTokenDto longDto = instaOAuthClient.exchangeLongLivedToken(shortDto.accessToken());
+            // 2) Facebook 페이지 목록 조회
+            FacebookPagesDto pages = instaOAuthClient.getFacebookPages(facebookToken.accessToken());
 
-            // 3) Redis 보관
-            instaRedisTokenService.saveLongLivedToken(userId, longDto.accessToken(), longDto.expiresIn());
+            // 3) 각 페이지에서 Instagram 비즈니스 계정 찾기
+            String instagramUserId = null;
+            String pageAccessToken = null;
 
-            // 4) 계정 연결 (Creator / Customer)
-            String instaUserId = String.valueOf(shortDto.userId());
+            for (FacebookPagesDto.FacebookPage page : pages.data()) {
+                InstagramBusinessAccountDto igAccount =
+                        instaOAuthClient.getInstagramBusinessAccount(page.id(), page.accessToken());
+
+                if (igAccount != null && igAccount.instagramBusinessAccount() != null) {
+                    instagramUserId = igAccount.instagramBusinessAccount().id();
+                    pageAccessToken = page.accessToken();
+                    log.info("Instagram 비즈니스 계정 발견: userId={}, pageId={}", instagramUserId, page.id());
+                    break;
+                }
+            }
+
+            if (instagramUserId == null) {
+                log.error("연동된 Instagram 비즈니스 계정을 찾을 수 없습니다. Facebook 페이지에 Instagram이 연결되어 있는지 확인하세요.");
+                throw new InstagramConnectionFailedException();
+            }
+
+            // 4) 장기 액세스 토큰 발급 (Page Access Token을 장기 토큰으로 변환)
+            InstagramGraphTokenDto longToken = instaOAuthClient.exchangeLongLivedToken(pageAccessToken);
+
+            // 5) Redis 보관
+            instaRedisTokenService.saveLongLivedToken(userId, longToken.accessToken(), longToken.expiresIn());
+
+            // 6) 계정 연결 (Creator / Customer)
             if (user.getRole() == Role.CREATOR) {
-                user.getCreator().connectInsta(instaUserId);
+                user.getCreator().connectInsta(instagramUserId);
                 creatorSaveService.save(user.getCreator());
             } else if (user.getRole() == Role.CUSTOMER) {
-                user.getCustomer().connectInsta(instaUserId);
+                user.getCustomer().connectInsta(instagramUserId);
                 customerSaveService.save(user.getCustomer());
             }
 


### PR DESCRIPTION
## Related issue 🛠

- closed #359 

## 작업 내용 💻

- [ ] 
- [ ] 

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - Facebook 로그인 기반으로 Instagram 비즈니스 계정 자동 검색 및 연동을 지원합니다.
  - 연결된 Facebook 페이지에서 Instagram 계정을 식별해 계정 링크를 설정합니다.

- 개선
  - 장기 액세스 토큰 발급 흐름을 강화해 연결 안정성을 높였습니다.
  - 필요한 권한 범위를 확장해 페이지 조회와 인사이트 활용을 지원합니다.
  - 오류 처리와 진단 로그를 강화해 문제 원인 파악이 쉬워졌습니다.
  - 기존 기본 디스플레이 기반 연결은 계속 사용 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->