### PR TITLE
[FIX] #363  Campaign 엔티티의 모집인원 수 필드를 int -> Integer 로 변경

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
@@ -46,7 +46,7 @@ public record CampaignBasicResponse(
         Instant reviewSubmissionDeadline,
 
         @Schema(requiredMode = REQUIRED, description = "모집 인원 수 ", example = "20")
-        int recruitmentNumber,
+        Integer recruitmentNumber,
 
         @Schema(requiredMode = REQUIRED, description = "캠페인 참여 보상 리스트")
         List<String> participationRewards,

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -80,11 +80,11 @@ public class Campaign extends BaseEntity {
 
     private Instant reviewSubmissionDeadline;
 
-    private int recruitmentNumber; // 모집 인원
+    private Integer recruitmentNumber; // 모집 인원
 
-    private int applicantNumber; // 지원 인원
+    private Integer applicantNumber; // 지원 인원
 
-    private int approvedNumber; // 승인 인원
+    private Integer approvedNumber; // 승인 인원
 
     /**
      * 크리에이터 참여 보상 목록
@@ -133,14 +133,14 @@ public class Campaign extends BaseEntity {
      * 캠페인 지원자 수 증가 메소드
      */
     public void increaseApplicant() {
-        this.applicantNumber += 1;
+        this.applicantNumber = (this.applicantNumber != null ? this.applicantNumber : 0) + 1;
     }
 
     /**
      * 승인 인원 수 증가 메소드
      */
     public void increaseApprovedNumber(int toUpdateCount) {
-        this.approvedNumber += toUpdateCount;
+        this.approvedNumber = (this.approvedNumber != null ? this.approvedNumber : 0) + toUpdateCount;
     }
 
     /**
@@ -234,7 +234,7 @@ public class Campaign extends BaseEntity {
                 this.applyDeadline == null,
                 this.creatorAnnouncementDate == null,
                 this.reviewSubmissionDeadline == null,
-                this.recruitmentNumber <= 0,
+                this.recruitmentNumber == null,
                 this.participationRewards == null || this.participationRewards.isEmpty(),
                 this.deliverableRequirements == null || this.deliverableRequirements.isEmpty(),
                 this.firstContentPlatform == null


### PR DESCRIPTION
## Related issue 🛠

- closed #362 

## 작업 내용 💻

- [ 캠페인 엔티티의 모집 인원 수 필드가 int 로 설정되어 있어, 캠페인 임시저장 시에 null 값을 받지 못하여 NPE 가 발생하는 문제를 해결하였습니다.] 

## 스크린샷 📷


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢



