### PR TITLE
[FIX] #370  인스타그램 비즈니스 계정 조회 API 의 쿼리파라미터를 직접 인코딩 방식으로 수정

### DIFF
--- a/src/main/java/com/lokoko/global/auth/provider/insta/config/InstaOauthClient.java
+++ b/src/main/java/com/lokoko/global/auth/provider/insta/config/InstaOauthClient.java
@@ -120,14 +120,12 @@ public class InstaOauthClient {
      */
     public InstagramBusinessAccountDto getInstagramBusinessAccount(String pageId, String pageAccessToken) {
         try {
+            String fields = URLEncoder.encode("instagram_business_account{id,username}", StandardCharsets.UTF_8);
+
             InstagramBusinessAccountDto dto = instagramWebClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .scheme("https")
-                            .host("graph.facebook.com")
-                            .path("/v23.0/" + pageId)
-                            .queryParam(InstagramConstants.PARAM_FIELDS, "instagram_business_account{id,username}")
-                            .queryParam(InstagramConstants.PARAM_ACCESS_TOKEN, pageAccessToken)
-                            .build())
+                    .uri("https://graph.facebook.com/v23.0/" + pageId
+                            + "?" + InstagramConstants.PARAM_FIELDS + "=" + fields
+                            + "&" + InstagramConstants.PARAM_ACCESS_TOKEN + "=" + pageAccessToken)
                     .retrieve()
                     .bodyToMono(InstagramBusinessAccountDto.class)
                     .block();


### PR DESCRIPTION
## Related issue 🛠

- closed #369 

## 작업 내용 💻

- 기존에 urlbuilder 를 사용하였을때, 중괄호를 인식하지 못하여 아래와 같은 에러 로그가 발생하였습니다.
- `Not enough variable values available to expand 'id,username'`
- UrlBuilder 대신, 직접 인코딩 방식을 사용하여 쿼리 파라미터를 처리하도록 수정하였습니다. 

## 스크린샷 📷

<img width="845" height="232" alt="image" src="https://github.com/user-attachments/assets/52d6328c-96cf-4f19-8a4f-0bf9f499006c" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터링
  - 인스타그램 비즈니스 계정 정보를 조회하는 네트워크 요청 구성 방식을 단순화했습니다.
  - 내부 구현 변경으로 사용자 화면이나 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->