### PR TITLE
[FEAT] #375  브랜드 마이페이지 - 승인대기중 캠페인 조회 API 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -204,6 +204,17 @@ public class BrandController {
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.DRAFT_CAMPAIGN_GET_SUCCESS.getMessage(), response);
     }
 
+    @Operation(summary = "브랜드 마이페이지 - 승인 대기중 캠페인 조회")
+    @GetMapping("/my/campaigns/waiting-approval/{campaignId}")
+    public ApiResponse<CampaignBasicResponse> getWaitingApprovalCampaign(
+            @Parameter(hidden = true) @CurrentUser Long brandId,
+            @PathVariable Long campaignId) {
+
+        CampaignBasicResponse response = campaignGetService.getWaitingApprovalCampaign(brandId, campaignId);
+
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.WAITING_APPROVAL_CAMPAIGN_GET_SUCCESS.getMessage(), response);
+    }
+
     @Operation(summary = "캠페인 지원자 확인 뷰 - 브랜드 캠페인 목록 간단 조회")
     @GetMapping("/my/campaigns/infos")
     public ApiResponse<BrandMyCampaignInfoListResponse> getSimpleCampaignInfos(

--- a/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/brand/api/message/ResponseMessage.java
@@ -29,7 +29,9 @@ public enum ResponseMessage {
     DRAFT_CAMPAIGN_GET_SUCCESS("임시저장 상태의 캠페인 조회에 성공했습니다."),
 
     BRAND_DASHBOARD_GET_SUCCESS("브랜드 대시보드 캠페인 리스트 조회 성공했습니다."),
-    CREATOR_PERFORMANCE_GET_SUCCESS("캠페인 크리에이터 성과 리스트 조회에 성공했습니다.");
+    CREATOR_PERFORMANCE_GET_SUCCESS("캠페인 크리에이터 성과 리스트 조회에 성공했습니다."),
+
+    WAITING_APPROVAL_CAMPAIGN_GET_SUCCESS("브랜드 마이페이지 승인 대기중 캠페인 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -165,6 +165,25 @@ public class CampaignGetService {
         return CampaignBasicResponse.of(draftCampaign, thumbnailImages, detailImages);
     }
 
+    /**
+     * 브랜드 마이페이지 승인대기중 캠페인 조회
+     */
+    public CampaignBasicResponse getWaitingApprovalCampaign(Long brandId, Long campaignId) {
+
+        Campaign waitingApprovalCampaign = campaignRepository.findWaitingApprovalCampaignById(campaignId, CampaignStatus.WAITING_APPROVAL)
+                .orElseThrow(CampaignNotFoundException::new);
+
+        if (!waitingApprovalCampaign.getBrand().getId().equals(brandId)){
+            throw new NotCampaignOwnershipException();
+        }
+        initializeElementCollections(waitingApprovalCampaign);
+
+        List<CampaignImageResponse> thumbnailImages = campaignImageRepository.findThumbnailImagesByCampaignId(campaignId);
+        List<CampaignImageResponse> detailImages = campaignImageRepository.findDetailImagesByCampaignId(campaignId);
+
+        return CampaignBasicResponse.of(waitingApprovalCampaign, thumbnailImages, detailImages);
+    }
+
     public BrandMyCampaignInfoListResponse getSimpleCampaignInfos(Long brandId) {
         return campaignRepository.findSimpleCampaignInfoByBrandId(brandId);
     }
@@ -201,5 +220,6 @@ public class CampaignGetService {
     public BrandDashboardCampaignListResponse getBrandDashboardCampaigns(Long brandId, int page, int size) {
         return campaignRepository.findBrandDashboardCampaigns(brandId, PageRequest.of(page, size));
     }
+
 
 }

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepository.java
@@ -32,6 +32,10 @@ public interface CampaignRepository extends JpaRepository<Campaign, Long>, Campa
     @Query("SELECT c FROM Campaign c WHERE c.id = :id AND c.campaignStatus = :status")
     Optional<Campaign> findDraftCampaignById(Long id, @Param("status") CampaignStatus status);
 
+    @EntityGraph(attributePaths = {"brand"})
+    @Query("SELECT c FROM Campaign c WHERE c.id = :id AND c.campaignStatus = :status")
+    Optional<Campaign> findWaitingApprovalCampaignById(Long id, @Param("status") CampaignStatus campaignStatus);
+
     @Query("SELECT count(c) FROM Campaign c " +
             "WHERE c.brand.id = :brandId " +
             "AND c.campaignStatus NOT IN ('DRAFT', 'WAITING_APPROVAL') " +
@@ -47,4 +51,6 @@ public interface CampaignRepository extends JpaRepository<Campaign, Long>, Campa
     Integer countCompletedCampaignsById(@Param("brandId") Long brandId, @Param("now") Instant now);
 
     List<Campaign> findAllByBrandAndCampaignStatusOrderByTitleAsc(Brand brand, CampaignStatus status);
+
+
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #374 

## 작업 내용 💻

- 브랜드 마이페이지에서 승인대기중 (WAITING_APPROVAL) 상태인 캠페인의 정보를 조회할 수 있는 API 를 구현하였습니다.
코드 구조는 DRAFT 캠페인 조회 API 와 거의 동일합니다. 

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

기존에 DRAFT 상태인 캠페인을 단건 조회하는 API 가 존재했는데요,
새로운 API 를 만들지않고 해당 API 를 재활용하는 방법을 생각해보았습니다.
재활용을 하려면, 쿼리파라미터로 DRAFT, WAITING_APPROVAL 을 전달받아서 상태에 맞는 캠페인을 조회하는 방식을 사용해야겠죠.

이 방식도 물론 좋은 방식이라고 생각했으나, 쿼리파라미터로 전달 받을 값이 DRAFT, WAITING_APPROVAL 로 2개밖에 존재하지 않는 상황에서 굳이 하나의 API 에 통합할 필요는 없다고 판단했습니다.

DRAFT 상태의 캠페인은 수정이 가능하고, WAITING_APPROVAL 상태인 캠페인은 수정이 불가능하다는 요구사항도 존재하죠.
물론 이런 요구사항은 프론트엔드쪽에서 처리해야할 부분이긴하다만, 독립적인 요구사항이 존재하는 상황에서는 별도의 API 를 두는 것이 맞다고 생각했습니다.

프론트에서는 승인대기중 캠페인 클릭 -> 승인 대기중 캠페인 조회 API 호출.
DRAFT 캠페인 클릭 -> DRAFT 캠페인 조회 API 호출.
이라는 직관적인 구조를 가져갈 수도 있는 것이고요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 브랜드 사용자가 마이페이지에서 승인 대기 상태의 특정 캠페인을 ID로 조회할 수 있습니다.
  * 캠페인의 기본 정보와 연관 이미지(썸네일/상세)가 함께 제공되어 상세 확인이 용이합니다.
  * 본인 소유 캠페인만 조회되도록 보호되었습니다.
  * 성공 응답 메시지가 추가되어 처리 결과를 명확히 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->