### PR TITLE
[CHORE] #381  어드민 캠페인 신청 api 를 스웨거에 노출하도록 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/user/api/AdminController.java
+++ b/src/main/java/com/lokoko/domain/user/api/AdminController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Hidden
 @Tag(name = "ADMIN")
 @RestController
 @RequestMapping("/api/admin")
@@ -25,6 +24,7 @@ public class AdminController {
 
     private final AdminUsecase adminUsecase;
 
+    @Hidden
     @Operation(summary = "어드민 리뷰 삭제")
     @DeleteMapping("/reviews/{reviewId}")
     public ApiResponse<Void> deleteReviewByAdmin(@Parameter(hidden = true) @CurrentUser Long userId,
@@ -41,6 +41,7 @@ public class AdminController {
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CAMPAIGN_APPROVAL_SUCCESS.getMessage());
     }
 
+    @Hidden
     @Operation(summary = "어드민 크리에이터 회원가입 승인")
     @PostMapping("/creators/{userId}/registration/approval")
     public ApiResponse<Void> approveCreator(@Parameter(hidden = true) @CurrentUser Long adminUserId,


### PR DESCRIPTION
## Related issue 🛠

- closed #380 

## 작업 내용 💻

- 기획 쪽 요구에 따라서, 어드민 캠페인 신청 api 를 스웨거에 노출하도록 수정하였습니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * API 문서 공개 범위를 조정했습니다. 일부 관리자 기능의 API 문서 가시성이 변경되었으나, 사용자에게 보이는 기능상 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->