### PR TITLE
[REFACTOR] #384 캠페인 지원자 확인 API - creatorSocialStats join 방식을 inner 에서 left 로 변경

### DIFF
--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
@@ -60,7 +60,7 @@ public class CreatorCampaignRepositoryImpl implements CreatorCampaignRepositoryC
                                 user.profileImageUrl
                         ),
                         Projections.constructor(CampaignApplicantResponse.FollowerCount.class,
-l                                creatorSocialStats.instagramFollower.coalesce(0),
+                              creatorSocialStats.instagramFollower.coalesce(0),
                                 creatorSocialStats.tiktokFollower.coalesce(0)
                         ),
                         JPAExpressions


### PR DESCRIPTION
## Related issue 🛠

- closed #383 

## 작업 내용 💻

- 기존에는, 캠페인에 지원한 지원자를 조회할 때 creatorSocialStats 를 innerJoin 하였습니다.
즉, creatorSoicalStats(인스타 팔로워수, 틱톡 팔로워 수) 테이블에 row 가 존재하는 크리에이터만 지원자 조회에 포함되는 상황입니다.

그러나, 현재 환경상 인스타, 틱톡의 정식 API 를 승인 받기전까지는 해당 메타데이터를 조회할 수 없기 때문에,
캠페인에 대한 지원자가 생겼을 때, 해당 지원자에 대한 팔로워 수 더미데이터를 넣어서 테스트하고 있던 상황이었습니다. 
creatorSocialStats 테이블에 더미데이터를 넣지 않으면, 지원자 조회의 반환 결과에 크리에이터 정보가 나오지 않습니다. innerJoin 상황이기때문입니다.

이런 과정을 일일이 반복하기에는 번거로움이 있다고 판단하여, innerJoin 을 leftJoin 으로 변경하였습니다.
leftJoin 으로 변경후, null 값 등장시 coalesce(0) 으로 설정하는 과정을 통해 , creatorSocialStats 가 없는 크리에이터의 팔로워 수 메타데이터는 기본값 0으로 설정하여 반환하도록 수정하였습니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 크리에이터 캠페인 신청자 조회에서 인스타그램 및 틱톡 팔로워 수가 없을 때 0으로 처리되어 안정적인 수치 표시가 보장됩니다.
  * 소셜 미디어 통계가 없는 크리에이터도 캠페인 신청자 목록에 포함되어 누락 없는 신청자 조회가 가능합니다.
  * 관련 조회 결과의 누락 및 예외 발생 가능성이 감소되어 조회 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->