### PR TITLE
[REFACTOR] #398 회원가입시 크리에이터의 상태를 변경하는 로직 추가

### DIFF
--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorUpdateService.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorUpdateService.java
@@ -9,6 +9,7 @@ import com.lokoko.domain.creator.api.dto.request.CreatorSnsLinkRequest;
 import com.lokoko.domain.creator.api.dto.response.CreatorProfileImageResponse;
 import com.lokoko.domain.creator.domain.entity.Creator;
 import com.lokoko.domain.creator.domain.entity.enums.CreatorStatus;
+import com.lokoko.domain.creator.domain.entity.enums.CreatorType;
 import com.lokoko.domain.creator.exception.CreatorInstaLinkInvalidException;
 import com.lokoko.domain.creator.exception.CreatorTiktokLinkInvalidException;
 import com.lokoko.domain.creator.exception.SnsNotConnectedException;
@@ -184,6 +185,7 @@ public class CreatorUpdateService {
         // (일시적 코드) 크리에이터가 SNS 링크 기입을 성공적으로 마친 뒤 크리에이터 상태를 바로 APPROVED로 변경
         if (creator.getCreatorStatus() != CreatorStatus.APPROVED) {
             creator.approve(Instant.now());
+            creator.changeCreatorType(CreatorType.NORMAL);
         }
     }
 

--- a/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
+++ b/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
@@ -16,12 +16,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.Instant;
 
 @Getter
 @Entity
@@ -180,6 +181,10 @@ public class Creator {
 
     public void changeContentLanguage(ContentLanguage contentLanguage) {
         this.contentLanguage = contentLanguage;
+    }
+
+    public void changeCreatorType(CreatorType creatorType) {
+        this.creatorType = creatorType;
     }
 
     public void connectTikTok(String tikTokUserId) {


### PR DESCRIPTION
## Related issue 🛠

- closed #397 

## 작업 내용 💻
- [x] 일시적으로 회원가입한 크리에이터의 상태를 APPROVED로 변경합니다

## 스크린샷 📷
-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자가 SNS 링크를 업데이트하면 크리에이터 상태가 자동으로 승인(APPROVED)으로 전환됩니다.
  * SNS 업데이트 시 크리에이터 유형이 기본형(NORMAL)으로 설정됩니다.
* **변경**
  * 크리에이터 유형을 변경할 수 있는 공개 메서드가 추가되어 유형 전환이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->