### PR TITLE
[FIX] #405 : Dockerfile 베이스 운영체제 변경

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jdk-jammy
 
 RUN apt-get update && apt-get install -y wget curl unzip \
     && wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jdk-jammy
 
 RUN apt-get update && apt-get install -y wget curl unzip \
     && wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \


### PR DESCRIPTION
## Related issue 🛠

- closed #404 

## 작업 내용 💻

- [Dockerfile-dev, Dockerfile-prod 의 베이스 운영체제를  openjdk:21-jdk-slim 에서 eclipse-temurin:21-jdk-jammy 로 변경합니다. ]
Dockerhub 에서 더 이상 openjdk:21-jdk-slim 이미지를 제공하지 않아 배포 오류가 발생했습니다. 이에 따라, eclipse-temurin 이미지로 변경합니다. 


## 스크린샷 📷

<img width="1219" height="731" alt="image" src="https://github.com/user-attachments/assets/c0659af6-2d8c-400d-a791-7138e5b2a4d2" />

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 기본 이미지를 업데이트하여 런타임 환경의 안정성과 호환성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->