### PR TITLE
[REFACTOR]  #409 서울 1988 캠페인 진행 환경에서 크리에이터 발표 시점 관련 로직에 feature flag 를 추가 

### DIFF
--- a/src/main/java/com/lokoko/domain/creatorCampaign/application/mapper/CreatorCampaignMapper.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/application/mapper/CreatorCampaignMapper.java
@@ -15,6 +15,8 @@ import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
 import com.lokoko.global.common.response.PageableResponse;
 import java.time.Instant;
 import java.util.List;
+
+import com.lokoko.global.config.BetaFeatureConfig;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
@@ -25,6 +27,7 @@ public class CreatorCampaignMapper {
 
     private final CampaignReviewRepository campaignReviewRepository;
     private final CampaignImageRepository campaignImageRepository;
+    private final BetaFeatureConfig betaFeatureConfig;
 
     public CreatorCampaign toCampaignParticipation(Creator creator, Campaign campaign, Instant now) {
         return CreatorCampaign.builder()
@@ -95,7 +98,7 @@ public class CreatorCampaignMapper {
         ParticipationStatus actualStatus = participation.getStatus();
 
         // APPROVED 상태이고 creatorAnnouncementDate가 아직 지나지 않았다면 PENDING으로 표시
-        if (actualStatus == ParticipationStatus.APPROVED
+        if (actualStatus == ParticipationStatus.APPROVED && !betaFeatureConfig.isSimplifiedAnnouncementFlow()
             && campaign.getCreatorAnnouncementDate() != null
             && Instant.now().isBefore(campaign.getCreatorAnnouncementDate())) {
             return ParticipationStatus.PENDING;

--- a/src/main/java/com/lokoko/global/config/BetaFeatureConfig.java
+++ b/src/main/java/com/lokoko/global/config/BetaFeatureConfig.java
@@ -22,4 +22,11 @@ public class BetaFeatureConfig {
      * 1차 리뷰 업로드시, post URL 을 포함할지 말지 여부를 결정
      */
     private boolean firstReviewUrlEnabled = true;
+
+    /**
+     * 베타버젼 진행에서, true 설정
+     * 정식 버전에서, false 설정
+     * 브랜드가 크리에이터 승인 할 경우, 크리에이터가 크리에이터 발표 시점 이전에도 승인 상태를 볼 수 있도록 한다.
+     */
+    private boolean simplifiedAnnouncementFlow = true;
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #408 

## 작업 내용 💻

- 서울 1988 캠페인 진행 환경에서는 브랜드가 크리에이터를 승인했을 시, 크리에이터는  "크리에이터 발표 시점 (creatorAnnouncementDate) " 이전에도 자신의 승인 상태를 확인하고, 바로 배송지 입력을 할 수 있도록 해야합니다.

관련된 기능을 담당하는 코드에 BetaFeatureFlag 의존성을 추가하여, 베타 환경에서의 플로우를 구분해주었습니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 크리에이터 캠페인의 공지 프로세스를 제어하는 새로운 베타 기능 플래그가 추가되었습니다. 미래 공지 날짜가 있는 캠페인의 표시 상태 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->