### PR TITLE
[FIX] #412 : 업로드 가능한 리뷰 조회시 캠페인 상태 필터링 범위를 확장

### DIFF
--- a/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
@@ -193,8 +193,18 @@ public class CampaignReviewUsecase {
     @Transactional
     public CampaignParticipatedResponse getMyReviewableCampaign(Long userId, Long campaignId, ReviewRound round) {
         Creator creator = creatorGetService.findByUserId(userId);
-        CreatorCampaign creatorCampaign =
-                creatorCampaignGetService.findReviewableInReviewByCampaign(creator.getId(), campaignId);
+
+        // 베타버전에서는 여러 캠페인 상태에서 리뷰 업로드 가능
+        CreatorCampaign creatorCampaign;
+        if (betaFeatureConfig.isSimplifiedReviewFlow()) {
+            // 베타버전: RECRUITING, RECRUITMENT_CLOSED, IN_REVIEW 상태 모두 허용
+            creatorCampaign = creatorCampaignGetService.findReviewableInMultipleStatusesForBeta(
+                    creator.getId(), campaignId);
+        } else {
+            // 정식버전: IN_REVIEW 상태만 허용
+            creatorCampaign = creatorCampaignGetService.findReviewableInReviewByCampaign(
+                    creator.getId(), campaignId);
+        }
 
         // ACTIVE 상태에서만 업로드 가능
         if (creatorCampaign.getStatus() != ParticipationStatus.ACTIVE) {

--- a/src/main/java/com/lokoko/domain/creatorCampaign/application/service/CreatorCampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/application/service/CreatorCampaignGetService.java
@@ -114,6 +114,32 @@ public class CreatorCampaignGetService {
     }
 
     /**
+     * 베타버전 전용: 여러 캠페인 상태에서 리뷰 작성 가능한 CreatorCampaign 조회
+     * RECRUITING, RECRUITMENT_CLOSED, IN_REVIEW 상태 모두에서 리뷰 업로드 가능
+     *
+     * @param creatorId 크리에이터 고유 ID
+     * @param campaignId 캠페인 고유 ID
+     * @return 리뷰 작성 가능한 CreatorCampaign
+     * @throws CampaignReviewAbleNotFoundException 리뷰 작성 조건을 만족하지 않는 경우 발생
+     */
+    @Transactional(readOnly = true)
+    public CreatorCampaign findReviewableInMultipleStatusesForBeta(Long creatorId, Long campaignId) {
+        return creatorCampaignRepository.findReviewableInMultipleStatusesForBeta(
+                        creatorId,
+                        campaignId,
+                        List.of(
+                                CampaignStatus.RECRUITING,        // 모집 중
+                                CampaignStatus.RECRUITMENT_CLOSED, // 모집 종료
+                                CampaignStatus.IN_REVIEW          // 리뷰 진행 중
+                        ),
+                        List.of(
+                                ParticipationStatus.ACTIVE  // 활성 상태만 허용
+                        )
+                )
+                .orElseThrow(CampaignReviewAbleNotFoundException::new);
+    }
+
+    /**
      * (campaign, creatorId) 조합으로 CreatorCampaign 단건을 조회 메서드 - 존재하지 않을 경우 예외 발생
      *
      * @param campaign  캠페인 엔티티 (도메인 인자 전달)

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepository.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepository.java
@@ -123,4 +123,31 @@ public interface CreatorCampaignRepository extends JpaRepository<CreatorCampaign
     @Query("UPDATE CreatorCampaign cc SET cc.status = :toStatus WHERE cc.id IN :ids")
     int bulkUpdateStatusByIds(@Param("ids") List<Long> ids,
                               @Param("toStatus") ParticipationStatus toStatus);
+
+    /**
+     * 베타버전 전용: 여러 캠페인 상태에서 리뷰 작성 가능한 CreatorCampaign 조회
+     * RECRUITING, RECRUITMENT_CLOSED, IN_REVIEW 상태 모두 허용
+     *
+     * @param creatorId 크리에이터 ID
+     * @param campaignId 캠페인 ID
+     * @param campaignStatuses 허용할 캠페인 상태 목록
+     * @param allowedStatuses 허용할 참여 상태 목록
+     * @return 리뷰 작성 가능한 CreatorCampaign
+     */
+    @Query("""
+                select cc
+                from CreatorCampaign cc
+                join cc.campaign c
+                where cc.creator.id = :creatorId
+                  and c.id = :campaignId
+                  and c.campaignStatus in :campaignStatuses
+                  and cc.status in :allowedStatuses
+                  and cc.addressConfirmed = true
+            """)
+    Optional<CreatorCampaign> findReviewableInMultipleStatusesForBeta(
+            @Param("creatorId") Long creatorId,
+            @Param("campaignId") Long campaignId,
+            @Param("campaignStatuses") Collection<CampaignStatus> campaignStatuses,
+            @Param("allowedStatuses") Collection<ParticipationStatus> allowedStatuses
+    );
 }

--- a/src/main/java/com/lokoko/global/config/SecurityConfig.java
+++ b/src/main/java/com/lokoko/global/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(
                 Arrays.asList("https://52.79.208.129.nip.io", "https://15.164.250.59.nip.io",
                         "http://localhost:3000", "https://localhost:3000",
-                        "https://lococo-test.vercel.app/",
+                        "https://lococo-test.vercel.app/", "https://lococo-client-web.vercel.app/ko",
                         "https://www.lococo.beauty", "https://lococo.beauty"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));


### PR DESCRIPTION

## Related issue 🛠

- closed #411 

## 작업 내용 💻

- 기존에는 업로드 가능한 리뷰 정보를 조회할때, IN_REVIEW , 즉 캠페인 상태가 IN_REVIEW 일때만 조회 가능하였습니다. 하지만, 베타 버전에서 신속한 리뷰 업로드 플로우가 필요함에 따라, 모집중, 모집완료 상태에서도 크리에이터는 리뷰 업로드를 진행할 수 있어야 합니다. 업로드 가능한 리뷰를 조회해오는 쿼리의 필터링 조건에 RECRUITING, RECRUITMENT_CLOSD 상태를 추가했습니다.

- UseCase 클래스에는 beta feature flag 를 두어 베타버전 전용 기능임을 명시하였습니다. 


- cors 설정에 클라이언트가 요청한 주소를 추가해주었습니다.

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 베타 사용자를 위해 간소화된 리뷰 플로우 추가됨. 이제 모집 중, 모집 종료, 검토 중 상태의 캠페인도 리뷰 대상으로 확대됨.

* **기타**
  * CORS 설정 업데이트됨.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->