### PR TITLE
[FIX] #414 : 구글 프로필 이미지를 업데이트 하지 않도록 수정

### DIFF
--- a/src/main/java/com/lokoko/global/auth/service/AuthService.java
+++ b/src/main/java/com/lokoko/global/auth/service/AuthService.java
@@ -175,7 +175,6 @@ public class AuthService {
                 user.updateDisplayName(displayName);
                 user.updateFirstName(firstName);
                 user.updateLastName(lastName);
-                user.updateProfileImage(profileImageUrl);
 
                 if (user.getRole() == Role.PENDING) {
                     loginStatus = OauthLoginStatus.REGISTER;


### PR DESCRIPTION
## Related issue 🛠

- closed #413 

## 작업 내용 💻
- [x] 프로필 이미지가 계속 기본 이미지로 업데이트되는 오류 수정

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- Google 계정으로 로그인 시 기존 사용자의 프로필 이미지 URL이 더 이상 업데이트되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->