### PR TITLE
[REFACTOR] #417 : 베타 환경에서 원본 파일 링크와 캡션 및 해시태그를 필수적으로 받지 않도록 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/campaignReview/api/dto/request/FirstReviewUploadRequest.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/api/dto/request/FirstReviewUploadRequest.java
@@ -17,12 +17,12 @@ public record FirstReviewUploadRequest(
          */
 
         @Schema(description = "첫번째 1차 미디어 URL 리스트(이미지 또는 영상)", example = "[\"https://s3.example.com/review/2025/09/.../img1.jpg\"]")
-        @NotEmpty
+        // @NotEmpty -> 1988 캠페인 진행 후 주석 해제
         List<String> firstMediaUrls,
 
         @Schema(description = "첫번째 캡션 + 해시태그 (최대 2200자)", example = "Hydrating mask review 💧 #hydration #mask #skincare")
-        @NotBlank
-        @Size(max = 2200)
+        // @NotBlank -> 1988 캠페인 진행 후 주석 해제
+        // @Size(max = 2200) -> 1988 캠페인 진행 후 주석 해제
         String firstCaptionWithHashtags,
 
         /**
@@ -33,7 +33,7 @@ public record FirstReviewUploadRequest(
         List<String> secondMediaUrls,
 
         @Schema(description = "두번째 1차 캡션+해시태그(선택)", example = "Hydrating mask review 💧 #hydration #mask #skincare")
-        @Size(max = 2200)
+        //@Size(max = 2200) -> 1988 캠페인 진행 후 주석 해제
         String secondCaptionWithHashtags,
 
         @Schema(description = "첫번째 포스트 URL (베타 기능, 선택)", example = "https://www.instagram.com/p/ABC123/")

--- a/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
+++ b/src/main/java/com/lokoko/domain/campaignReview/application/usecase/CampaignReviewUsecase.java
@@ -74,15 +74,25 @@ public class CampaignReviewUsecase {
         CampaignReviewValidationUtil.validateTwoSetCombination(typeA, typeB);
 
         // A 세트(캠페인에 second가 없는 단일 타입 캠페인)
-        CampaignReviewValidationUtil.requireFirstSetPresent(request.firstMediaUrls(),
-                request.firstCaptionWithHashtags());
-        MediaValidationUtil.validateTotalMediaCount(request.firstMediaUrls());
+        // 베타 버전에서는 firstMediaUrls, firstCaptionWithHashtags 에 대한 검증을 진행하지 않는다.
+        if (!betaFeatureConfig.isSimplifiedReviewFlow()) {
+            CampaignReviewValidationUtil.requireFirstSetPresent(request.firstMediaUrls(),
+                    request.firstCaptionWithHashtags());
+        }
+        if (request.firstMediaUrls() != null && !request.firstMediaUrls().isEmpty()) {
+            MediaValidationUtil.validateTotalMediaCount(request.firstMediaUrls());
+        }
 
         // B 세트(캠페인에 second가 있으면 필수, 없으면 금지)
         if (typeB != null) {
-            CampaignReviewValidationUtil.requireFirstSetPresent(
-                    request.secondMediaUrls(), request.secondCaptionWithHashtags());
-            MediaValidationUtil.validateTotalMediaCount(request.secondMediaUrls());
+            // 베타 버전에서는 secondMediaUrls, secondCaptionWithHashtags 에 대한 검증을 진행하지 않는다.
+            if (!betaFeatureConfig.isSimplifiedReviewFlow()) {
+                CampaignReviewValidationUtil.requireFirstSetPresent(
+                        request.secondMediaUrls(), request.secondCaptionWithHashtags());
+            }
+            if (request.secondMediaUrls() != null && !request.secondMediaUrls().isEmpty()) {
+                MediaValidationUtil.validateTotalMediaCount(request.secondMediaUrls());
+            }
         } else {
             CampaignReviewValidationUtil.ensureSecondSetAbsentForFirstRound(
                     request.secondMediaUrls(), request.secondCaptionWithHashtags());


### PR DESCRIPTION
1. 검증 애노테이션 주석 처리
2. 서비스단 추가 검증에 베타 플래그 추가

## Related issue 🛠

- closed #416 

## 작업 내용 💻

- 베타 환경에서 리뷰 업로드(1차 리뷰) 시 원본 파일 링크(mediaUrls) 와 캡션 및 해시태그를 필수적으로 받지 않도록 수정하였습니다,
이를 위해서는 FirstReviewUploadRequest 에서 NotEmpty, NotBlank 같은 검증 애노테이션을 제거했습니다.
또한, 서비스 계층에서 진행하는 mediaUrls 의 개수검사 같은 추가적인 검증도, 베타 환경이 아닌 환경에서만 수행하도록 변경했습니다. 이는 이전처럼 betaFeatureFlag 플래그를 두어 수정하였습니다.


## TODO : 서울 1988 캠페인 진행이 모두 끝나고 나서, 검증 애노테이션에 대한 주석을 해제해야합니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 간소화된 검토 흐름 베타 기능 도입: 해당 기능 활성화 시 미디어 및 캡션의 필수 검증 요구사항이 완화되어 더 유연한 콘텐츠 제출이 가능합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->