### PR TITLE
[REFACTOR] #419 : 캠페인 정보 조회에서 종료된 캠페인도 조회할 수 있도록 수정

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -74,9 +74,8 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
                         campaign.reviewSubmissionDeadline))
                 .from(campaign)
                 .where(campaign.brand.id.eq(brandId)
-                        .and(campaign.applyStartDate.loe(now))
-                        .and(campaign.reviewSubmissionDeadline.goe(now)))
-                .orderBy(campaign.title.asc())
+                        .and(campaign.applyStartDate.loe(now)))
+                .orderBy(campaign.applyStartDate.asc(), campaign.title.asc())
                 .fetch();
 
         return new BrandMyCampaignInfoListResponse(simpleResponses);


### PR DESCRIPTION


## Related issue 🛠

- closed #419 

## 작업 내용 💻

1. 리뷰 제출 마감일 where 조건을 제거하였습니다.
2. 지원시작 날짜 오름차순 정렬조건을 추가했습니다.

## 스크린샷 📷

- 종료된 캠페인도 정상적으로 조회 가능 

<img width="397" height="196" alt="image" src="https://github.com/user-attachments/assets/be48990f-c477-4f85-b6b0-dde134d85fa9" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **개선 사항**
  * 캠프인 목록 필터링 조건이 업데이트되었습니다.
  * 캠프인 목록의 정렬 순서가 변경되었습니다. 이제 신청 시작일을 기준으로 먼저 정렬된 후 제목 순서로 정렬됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->