### PR TITLE
 [FEAT] #430 어드민 - 크리에이터 관련 RUD API 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -26,10 +26,10 @@ import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewStatus;
 import com.lokoko.domain.creatorCampaign.domain.entity.QCreatorCampaign;
 import com.lokoko.domain.media.image.domain.entity.QCampaignImage;
 import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
-import com.lokoko.domain.user.domain.entity.enums.ApprovedStatus;
 import com.lokoko.domain.user.api.dto.response.AdminCampaignInfoResponse;
 import com.lokoko.domain.user.api.dto.response.AdminCampaignListResponse;
 import com.lokoko.domain.user.domain.entity.User;
+import com.lokoko.domain.user.domain.entity.enums.ApprovedStatus;
 import com.lokoko.domain.user.domain.repository.UserRepository;
 import com.lokoko.global.common.response.PageableResponse;
 import com.querydsl.core.types.Projections;
@@ -462,7 +462,7 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
                 total
         );
 
-        return new AdminCampaignListResponse(campaignList, pageInfo);
+        return new AdminCampaignListResponse(campaignList, total, pageInfo);
     }
 
     private BooleanExpression createStatusCondition(ApprovedStatus status) {
@@ -472,8 +472,7 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
 
         return switch (status) {
             case PENDING -> campaign.campaignStatus.eq(CampaignStatus.WAITING_APPROVAL);
-            case APPROVED ->
-                    campaign.campaignStatus.in(CampaignStatus.getApprovedStatuses());
+            case APPROVED -> campaign.campaignStatus.in(CampaignStatus.getApprovedStatuses());
         };
     }
 }

--- a/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorInfo.java
+++ b/src/main/java/com/lokoko/domain/creator/api/dto/response/CreatorInfo.java
@@ -20,7 +20,7 @@ public record CreatorInfo(
         @Schema(requiredMode = REQUIRED, description = "크리에이터 닉네임", example = "jisoo_creator")
         String creatorNickname,
 
-        @Schema(requiredMode = NOT_REQUIRED, description = "프로필 이미지 URL", example = "https://s3.example.com/profile/creator-10.jpg")
+        @Schema(requiredMode = REQUIRED, description = "프로필 이미지 URL", example = "https://s3.example.com/profile/creator-10.jpg")
         String profileImageUrl,
 
         @Schema(description = "인스타그램 계정 링크", example = "https://www.instagram.com/_hyon.8x21?igsh=MWU4cTI5aw==")

--- a/src/main/java/com/lokoko/domain/creator/application/service/CreatorUpdateService.java
+++ b/src/main/java/com/lokoko/domain/creator/application/service/CreatorUpdateService.java
@@ -8,8 +8,6 @@ import com.lokoko.domain.creator.api.dto.request.CreatorProfileImageRequest;
 import com.lokoko.domain.creator.api.dto.request.CreatorSnsLinkRequest;
 import com.lokoko.domain.creator.api.dto.response.CreatorProfileImageResponse;
 import com.lokoko.domain.creator.domain.entity.Creator;
-import com.lokoko.domain.creator.domain.entity.enums.CreatorStatus;
-import com.lokoko.domain.creator.domain.entity.enums.CreatorType;
 import com.lokoko.domain.creator.exception.CreatorInstaLinkInvalidException;
 import com.lokoko.domain.creator.exception.CreatorTiktokLinkInvalidException;
 import com.lokoko.domain.creator.exception.SnsNotConnectedException;
@@ -24,8 +22,6 @@ import com.lokoko.global.utils.S3UrlParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Instant;
 
 @Service
 @RequiredArgsConstructor
@@ -181,12 +177,8 @@ public class CreatorUpdateService {
                 throw new CreatorTiktokLinkInvalidException();
             }
         }
-
-        // (일시적 코드) 크리에이터가 SNS 링크 기입을 성공적으로 마친 뒤 크리에이터 상태를 바로 APPROVED로 변경
-        if (creator.getCreatorStatus() != CreatorStatus.APPROVED) {
-            creator.approve(Instant.now());
-            creator.changeCreatorType(CreatorType.NORMAL);
-        }
+        // SNS 링크 기입까지 마친 사용자의 최초 가입완료 시각 기록
+        creator.updateSignupCompleted();
     }
 
     private boolean isValidInstagramLink(String url) {

--- a/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
+++ b/src/main/java/com/lokoko/domain/creator/domain/entity/Creator.java
@@ -109,6 +109,9 @@ public class Creator {
     @Column
     private String instagramUserId;
 
+    @Column
+    private Instant signupCompletedAt;
+
     //최종 전화번호
     public String getCreatorPhoneNumber() {
         return countryCode + phoneNumber;
@@ -193,5 +196,12 @@ public class Creator {
 
     public void connectInsta(String instagramUserId) {
         this.instagramUserId = instagramUserId;
+    }
+
+    public void updateSignupCompleted() {
+        // null 일때만 now()로 업데이트 (최초 가입 완료 시각)
+        if (this.signupCompletedAt == null) {
+            this.signupCompletedAt = Instant.now();
+        }
     }
 }

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryCustom.java
@@ -2,9 +2,13 @@ package com.lokoko.domain.creatorCampaign.domain.repository;
 
 import com.lokoko.domain.brand.api.dto.request.ApplicantStatus;
 import com.lokoko.domain.brand.api.dto.response.CampaignApplicantListResponse;
+import com.lokoko.domain.user.api.dto.response.AdminCreatorListResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface CreatorCampaignRepositoryCustom {
 
     CampaignApplicantListResponse findCampaignApplicants(Long brandId, Long campaignId, Pageable pageable, ApplicantStatus status);
+
+    AdminCreatorListResponse findAdminCreators(Pageable pageable);
+
 }

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryCustom.java
@@ -9,6 +9,6 @@ public interface CreatorCampaignRepositoryCustom {
 
     CampaignApplicantListResponse findCampaignApplicants(Long brandId, Long campaignId, Pageable pageable, ApplicantStatus status);
 
-    AdminCreatorListResponse findAdminCreators(Pageable pageable);
+    AdminCreatorListResponse findCreatorsByAdmin(Pageable pageable);
 
 }

--- a/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/creatorCampaign/domain/repository/CreatorCampaignRepositoryImpl.java
@@ -134,7 +134,7 @@ public class CreatorCampaignRepositoryImpl implements CreatorCampaignRepositoryC
     }
 
     @Override
-    public AdminCreatorListResponse findAdminCreators(Pageable pageable) {
+    public AdminCreatorListResponse findCreatorsByAdmin(Pageable pageable) {
 
         StringExpression approveStatusExpr = new CaseBuilder()
                 .when(creator.creatorStatus.eq(CreatorStatus.APPROVED)).then("APPROVED")

--- a/src/main/java/com/lokoko/domain/user/api/AdminController.java
+++ b/src/main/java/com/lokoko/domain/user/api/AdminController.java
@@ -135,7 +135,7 @@ public class AdminController {
 
     // ACTIVE -> INACTIVE로 변경
     @Operation(summary = "어드민 크리에이터 삭제 - 복수 삭제 가능")
-    @PatchMapping("/creators")
+    @DeleteMapping("/creators")
     public ApiResponse<Void> inactivateCreators(
             @Parameter(hidden = true) @CurrentUser Long userId,
             @RequestBody @Valid DeleteCreatorsRequest request

--- a/src/main/java/com/lokoko/domain/user/api/AdminController.java
+++ b/src/main/java/com/lokoko/domain/user/api/AdminController.java
@@ -2,12 +2,15 @@ package com.lokoko.domain.user.api;
 
 import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
 import com.lokoko.domain.user.api.dto.request.ApproveCampaignIdsRequest;
-import com.lokoko.domain.user.domain.entity.enums.ApprovedStatus;
+import com.lokoko.domain.user.api.dto.request.ApproveCreatorsRequest;
 import com.lokoko.domain.user.api.dto.request.CampaignModifyRequest;
 import com.lokoko.domain.user.api.dto.request.DeleteCampaignIdsRequest;
+import com.lokoko.domain.user.api.dto.request.DeleteCreatorsRequest;
 import com.lokoko.domain.user.api.dto.response.AdminCampaignListResponse;
+import com.lokoko.domain.user.api.dto.response.AdminCreatorListResponse;
 import com.lokoko.domain.user.api.message.ResponseMessage;
 import com.lokoko.domain.user.application.usecase.AdminUsecase;
+import com.lokoko.domain.user.domain.entity.enums.ApprovedStatus;
 import com.lokoko.global.auth.annotation.CurrentUser;
 import com.lokoko.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -17,7 +20,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "ADMIN")
 @RestController
@@ -56,7 +67,7 @@ public class AdminController {
     @Operation(summary = "어드민 캠페인 신청 승인 - 복수 승인 가능")
     @PostMapping("/campaigns/approval")
     public ApiResponse<Void> approveCampaigns(@Parameter(hidden = true) @CurrentUser Long userId,
-                                              @RequestBody ApproveCampaignIdsRequest request) {
+                                              @RequestBody @Valid ApproveCampaignIdsRequest request) {
         adminUsecase.approveCampaigns(userId, request);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CAMPAIGN_APPROVAL_SUCCESS.getMessage());
     }
@@ -64,7 +75,7 @@ public class AdminController {
     @Operation(summary = "어드민 캠페인 삭제(soft delete) - 복수 삭제 가능")
     @DeleteMapping("/campaigns")
     public ApiResponse<Void> deleteCampaigns(@Parameter(hidden = true) @CurrentUser Long userId,
-                                             @RequestBody DeleteCampaignIdsRequest request){
+                                             @RequestBody @Valid DeleteCampaignIdsRequest request) {
         adminUsecase.deleteCampaigns(userId, request);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CAMPAIGN_DELETE_SUCCESS.getMessage());
     }
@@ -75,7 +86,7 @@ public class AdminController {
             @Parameter(hidden = true) @CurrentUser Long userId,
             @RequestParam(required = false) ApprovedStatus status,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size){
+            @RequestParam(defaultValue = "10") int size) {
 
         AdminCampaignListResponse response = adminUsecase.findAllCampaigns(userId, status, page, size);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CAMPAIGN_LIST_GET_SUCCESS.getMessage(), response);
@@ -86,7 +97,7 @@ public class AdminController {
     public ApiResponse<CampaignBasicResponse> getCampaignDetail(
             @Parameter(hidden = true) @CurrentUser Long userId,
             @PathVariable Long campaignId
-    ){
+    ) {
         CampaignBasicResponse response = adminUsecase.findCampaignDetail(userId, campaignId);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CAMPAIGN_DETAIL_GET_SUCCESS.getMessage(), response);
     }
@@ -97,8 +108,39 @@ public class AdminController {
             @Parameter(hidden = true) @CurrentUser Long userId,
             @PathVariable Long campaignId,
             @RequestBody @Valid CampaignModifyRequest request
-    ){
+    ) {
         adminUsecase.modifyCampaign(userId, campaignId, request);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CAMPAIGN_DETAIL_GET_SUCCESS.getMessage());
+    }
+
+    @Operation(summary = "어드민 - 전체 크리에이터 리스트 조회(페이지네이션)")
+    @GetMapping("/creators")
+    public ApiResponse<AdminCreatorListResponse> getAllCreators(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        AdminCreatorListResponse response = adminUsecase.findAllCreators(userId, page, size);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CREATOR_LIST_GET_SUCCESS.getMessage(), response);
+    }
+
+
+    @Operation(summary = "어드민 크리에이터 승인 - 복수 승인 가능")
+    @PostMapping("/creators/approval")
+    public ApiResponse<Void> approveCreators(@Parameter(hidden = true) @CurrentUser Long userId,
+                                             @RequestBody @Valid ApproveCreatorsRequest request) {
+        adminUsecase.approveCreators(userId, request);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CREATORS_APPROVAL_SUCCESS.getMessage());
+    }
+
+    // ACTIVE -> INACTIVE로 변경
+    @Operation(summary = "어드민 크리에이터 삭제 - 복수 삭제 가능")
+    @PatchMapping("/creators")
+    public ApiResponse<Void> inactivateCreators(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @RequestBody @Valid DeleteCreatorsRequest request
+    ) {
+        adminUsecase.deleteCreators(userId, request);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CREATORS_DELETE_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/lokoko/domain/user/api/dto/request/ApproveCampaignIdsRequest.java
+++ b/src/main/java/com/lokoko/domain/user/api/dto/request/ApproveCampaignIdsRequest.java
@@ -1,11 +1,11 @@
 package com.lokoko.domain.user.api.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
 public record ApproveCampaignIdsRequest(
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "승인할 캠페인 ID 목록", example = "[1, 2, 3]")
+        @NotEmpty(message = "한 개 이상의 ID는 필수입니다")
         List<Long> campaignIds
 ) {
 }

--- a/src/main/java/com/lokoko/domain/user/api/dto/request/ApproveCreatorsRequest.java
+++ b/src/main/java/com/lokoko/domain/user/api/dto/request/ApproveCreatorsRequest.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.user.api.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record ApproveCreatorsRequest(
+        @NotEmpty(message = "한 개 이상의 ID는 필수입니다")
+        List<Long> creatorIds
+) {
+}

--- a/src/main/java/com/lokoko/domain/user/api/dto/request/DeleteCampaignIdsRequest.java
+++ b/src/main/java/com/lokoko/domain/user/api/dto/request/DeleteCampaignIdsRequest.java
@@ -1,11 +1,11 @@
 package com.lokoko.domain.user.api.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
 public record DeleteCampaignIdsRequest(
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "삭제할 캠페인 ID 목록", example = "[1, 2, 3]")
+        @NotEmpty(message = "한 개 이상의 ID는 필수입니다")
         List<Long> campaignIds
 ) {
 }

--- a/src/main/java/com/lokoko/domain/user/api/dto/request/DeleteCreatorsRequest.java
+++ b/src/main/java/com/lokoko/domain/user/api/dto/request/DeleteCreatorsRequest.java
@@ -1,0 +1,11 @@
+package com.lokoko.domain.user.api.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record DeleteCreatorsRequest(
+        @NotEmpty(message = "한 개 이상의 ID는 필수입니다")
+        List<Long> creatorIds
+) {
+}

--- a/src/main/java/com/lokoko/domain/user/api/dto/response/AdminCampaignListResponse.java
+++ b/src/main/java/com/lokoko/domain/user/api/dto/response/AdminCampaignListResponse.java
@@ -5,10 +5,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record AdminCampaignListResponse(
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "캠페인 목록")
+        @Schema(requiredMode = REQUIRED, description = "캠페인 목록")
         List<AdminCampaignInfoResponse> campaigns,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "페이징 정보")
+        @Schema(requiredMode = REQUIRED, description = "총 캠페인 개수")
+        Long totalCampaignCount,
+        @Schema(requiredMode = REQUIRED, description = "페이징 정보")
         PageableResponse pageInfo
 ) {
 }

--- a/src/main/java/com/lokoko/domain/user/api/dto/response/AdminCreator.java
+++ b/src/main/java/com/lokoko/domain/user/api/dto/response/AdminCreator.java
@@ -1,0 +1,29 @@
+package com.lokoko.domain.user.api.dto.response;
+
+import com.lokoko.domain.creator.api.dto.response.CreatorInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record AdminCreator(
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 기본 정보")
+        CreatorInfo creator,
+        @Schema(requiredMode = REQUIRED, description = "팔로워 수 정보")
+        FollowerCount followerCount,
+        @Schema(requiredMode = REQUIRED, description = "크리에이터가 참여한 총 캠페인 수", example = "10")
+        Integer participationCount,
+        @Schema(requiredMode = REQUIRED, description = "크리에이터가 가입 완료한 시간", example = "2025-09-27T12:45:01.455391")
+        Instant signupCompletedDate,
+        @Schema(requiredMode = REQUIRED, description = "승인 상태", example = "PENDING")
+        String approveStatus
+) {
+    public record FollowerCount(
+            @Schema(requiredMode = REQUIRED, description = "인스타그램 팔로워 수", example = "3859")
+            Integer instagramFollower,
+            @Schema(requiredMode = REQUIRED, description = "틱톡 팔로워 수", example = "110089")
+            Integer tiktokFollower
+    ) {
+    }
+}

--- a/src/main/java/com/lokoko/domain/user/api/dto/response/AdminCreatorListResponse.java
+++ b/src/main/java/com/lokoko/domain/user/api/dto/response/AdminCreatorListResponse.java
@@ -1,0 +1,18 @@
+package com.lokoko.domain.user.api.dto.response;
+
+import com.lokoko.global.common.response.PageableResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record AdminCreatorListResponse(
+        @Schema(requiredMode = REQUIRED, description = "전체 크리에이터 목록")
+        List<AdminCreator> creators,
+        @Schema(requiredMode = REQUIRED, description = "총 크리에이터 수")
+        Long totalCreatorCount,
+        @Schema(requiredMode = REQUIRED, description = "페이징 정보")
+        PageableResponse pageInfo
+) {
+}

--- a/src/main/java/com/lokoko/domain/user/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/user/api/message/ResponseMessage.java
@@ -13,6 +13,11 @@ public enum ResponseMessage {
     ADMIN_CAMPAIGN_LIST_GET_SUCCESS("어드민 캠페인 리스트 조회에 성공했습니다."),
     ADMIN_CAMPAIGN_DETAIL_GET_SUCCESS("어드민 캠페인 단건 정보 조회에 성공했습니다."),
     ADMIN_CAMPAIGN_MODIFY_SUCCESS("어드민 캠페인 수정에 성공했습니다."),
+    ADMIN_CREATOR_LIST_GET_SUCCESS("어드민 크리에이터 리스트 조회에 성공했습니다."),
+    ADMIN_CREATORS_APPROVAL_SUCCESS("어드민 크리에이터 복수 승인에 성공했습니다."),
+    ADMIN_CREATORS_DELETE_SUCCESS("어드민 크리에이터 복수 삭제에 성공했습니다."),
+
+
 
     USER_ID_CHECK_SUCCESS("사용 가능한 ID입니다.");
 

--- a/src/main/java/com/lokoko/domain/user/application/service/AdminCreatorGetService.java
+++ b/src/main/java/com/lokoko/domain/user/application/service/AdminCreatorGetService.java
@@ -1,0 +1,20 @@
+package com.lokoko.domain.user.application.service;
+
+import com.lokoko.domain.creatorCampaign.domain.repository.CreatorCampaignRepository;
+import com.lokoko.domain.user.api.dto.response.AdminCreatorListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminCreatorGetService {
+
+    private final CreatorCampaignRepository creatorCampaignRepository;
+
+    public AdminCreatorListResponse findAllCreators(int page, int size) {
+        return creatorCampaignRepository.findAdminCreators(PageRequest.of(page, size));
+    }
+}

--- a/src/main/java/com/lokoko/domain/user/application/service/AdminCreatorGetService.java
+++ b/src/main/java/com/lokoko/domain/user/application/service/AdminCreatorGetService.java
@@ -15,6 +15,6 @@ public class AdminCreatorGetService {
     private final CreatorCampaignRepository creatorCampaignRepository;
 
     public AdminCreatorListResponse findAllCreators(int page, int size) {
-        return creatorCampaignRepository.findAdminCreators(PageRequest.of(page, size));
+        return creatorCampaignRepository.findCreatorsByAdmin(PageRequest.of(page, size));
     }
 }

--- a/src/main/java/com/lokoko/domain/user/application/service/AdminCreatorUpdateService.java
+++ b/src/main/java/com/lokoko/domain/user/application/service/AdminCreatorUpdateService.java
@@ -4,10 +4,16 @@ import com.lokoko.domain.creator.application.service.CreatorGetService;
 import com.lokoko.domain.creator.application.service.CreatorSaveService;
 import com.lokoko.domain.creator.domain.entity.Creator;
 import com.lokoko.domain.creator.domain.entity.enums.CreatorStatus;
-import java.time.Instant;
+import com.lokoko.domain.creator.exception.NotCreatorRoleException;
+import com.lokoko.domain.user.domain.entity.User;
+import com.lokoko.domain.user.domain.entity.enums.Role;
+import com.lokoko.domain.user.domain.entity.enums.UserStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +22,8 @@ public class AdminCreatorUpdateService {
     private final CreatorGetService creatorGetService;
 
     private final CreatorSaveService creatorSaveService;
+    private final UserGetService userGetService;
+    private final UserSaveService userSaveService;
 
     @Transactional
     public void approveById(Long userId, Instant now) {
@@ -27,5 +35,46 @@ public class AdminCreatorUpdateService {
 
         creator.approve(now);
         creatorSaveService.save(creator);
+    }
+
+
+    @Transactional
+    public void approveCreators(List<Long> creatorIds, Instant now) {
+        creatorIds.stream()
+                .distinct()
+                .forEach(id -> {
+                    Creator creator = creatorGetService.findByUserId(id);
+
+                    // 이미 승인된 경우는 패스
+                    if (creator.getCreatorStatus() == CreatorStatus.APPROVED) {
+                        return;
+                    }
+
+                    // NOT_APPROVED → APPROVED
+                    creator.approve(now);
+                    creatorSaveService.save(creator);
+                });
+    }
+
+    @Transactional
+    public void deleteCreators(List<Long> creatorIds) {
+
+        creatorIds.stream()
+                .distinct()
+                .forEach(id -> {
+                    User user = userGetService.findUserById(id);
+
+                    if (user.getRole() != Role.CREATOR) {
+                        throw new NotCreatorRoleException();
+                    }
+
+                    // 이미 비활성화면 패스
+                    if (user.getStatus() == UserStatus.INACTIVE) {
+                        return;
+                    }
+
+                    user.updateStatus(UserStatus.INACTIVE);
+                    userSaveService.save(user);
+                });
     }
 }

--- a/src/main/java/com/lokoko/domain/user/application/service/AdminCreatorUpdateService.java
+++ b/src/main/java/com/lokoko/domain/user/application/service/AdminCreatorUpdateService.java
@@ -52,7 +52,6 @@ public class AdminCreatorUpdateService {
 
                     // NOT_APPROVED → APPROVED
                     creator.approve(now);
-                    creatorSaveService.save(creator);
                 });
     }
 
@@ -74,7 +73,6 @@ public class AdminCreatorUpdateService {
                     }
 
                     user.updateStatus(UserStatus.INACTIVE);
-                    userSaveService.save(user);
                 });
     }
 }

--- a/src/main/java/com/lokoko/domain/user/application/usecase/AdminUsecase.java
+++ b/src/main/java/com/lokoko/domain/user/application/usecase/AdminUsecase.java
@@ -4,18 +4,27 @@ import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
 import com.lokoko.domain.campaign.application.service.CampaignGetService;
 import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
 import com.lokoko.domain.user.api.dto.request.ApproveCampaignIdsRequest;
-import com.lokoko.domain.user.domain.entity.enums.ApprovedStatus;
+import com.lokoko.domain.user.api.dto.request.ApproveCreatorsRequest;
 import com.lokoko.domain.user.api.dto.request.CampaignModifyRequest;
 import com.lokoko.domain.user.api.dto.request.DeleteCampaignIdsRequest;
+import com.lokoko.domain.user.api.dto.request.DeleteCreatorsRequest;
 import com.lokoko.domain.user.api.dto.response.AdminCampaignListResponse;
-import com.lokoko.domain.user.application.service.*;
+import com.lokoko.domain.user.api.dto.response.AdminCreatorListResponse;
+import com.lokoko.domain.user.application.service.AdminCampaignDeleteService;
+import com.lokoko.domain.user.application.service.AdminCampaignUpdateService;
+import com.lokoko.domain.user.application.service.AdminCreatorGetService;
+import com.lokoko.domain.user.application.service.AdminCreatorUpdateService;
+import com.lokoko.domain.user.application.service.AdminReviewDeleteService;
+import com.lokoko.domain.user.application.service.UserGetService;
 import com.lokoko.domain.user.domain.entity.User;
+import com.lokoko.domain.user.domain.entity.enums.ApprovedStatus;
 import com.lokoko.global.utils.AdminValidator;
-import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +33,7 @@ public class AdminUsecase {
     private final UserGetService userGetService;
     private final CampaignGetService campaignGetService;
 
+    private final AdminCreatorGetService adminCreatorGetService;
     private final AdminCampaignUpdateService adminCampaignUpdateService;
     private final AdminCreatorUpdateService adminCreatorUpdateService;
     private final AdminReviewDeleteService adminReviewDeleteService;
@@ -69,7 +79,7 @@ public class AdminUsecase {
 
     public AdminCampaignListResponse findAllCampaigns(Long userId, ApprovedStatus status, int page, int size) {
         validateIsAdmin(userId);
-        return campaignRepository.findAllCampaignsByAdmin(status, PageRequest.of(page,size));
+        return campaignRepository.findAllCampaignsByAdmin(status, PageRequest.of(page, size));
     }
 
     public CampaignBasicResponse findCampaignDetail(Long userId, Long campaignId) {
@@ -82,4 +92,22 @@ public class AdminUsecase {
         validateIsAdmin(userId);
         adminCampaignUpdateService.modifyCampaign(campaignId, request);
     }
+
+    public AdminCreatorListResponse findAllCreators(Long userId, int page, int size) {
+        validateIsAdmin(userId);
+        return adminCreatorGetService.findAllCreators(page, size);
+    }
+
+    @Transactional
+    public void approveCreators(Long userId, ApproveCreatorsRequest request) {
+        validateIsAdmin(userId);
+        adminCreatorUpdateService.approveCreators(request.creatorIds(), Instant.now());
+    }
+
+    @Transactional
+    public void deleteCreators(Long userId, DeleteCreatorsRequest request) {
+        validateIsAdmin(userId);
+        adminCreatorUpdateService.deleteCreators(request.creatorIds());
+    }
+
 }

--- a/src/main/java/com/lokoko/domain/user/domain/entity/User.java
+++ b/src/main/java/com/lokoko/domain/user/domain/entity/User.java
@@ -144,4 +144,8 @@ public class User extends BaseEntity {
     public void updateRole(Role role) {
         this.role = role;
     }
+
+    public void updateStatus(UserStatus status) {
+        this.status = status;
+    }
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #429 

## 작업 내용 💻

- [x] 유저 리스트 조회 (페이지네이션)
- [x] 유저 승인
- [x] 유저 삭제

1) 유저 리스트 조회
-> ACTIVE 이면서 크리에이터 회원가입이 완료된 순서대로 내림차순 정렬로 구현했습니다. (동일 시간이라면 이름으로 오름차순 정렬)
-> CreatorStatus에서 APPROVED 는 승인됨(APPROVED)로 NOT_APPROVED는 대기중(PENDING)으로 내려보내줍니다.

2) 승인 
테스트 케이스는 다음과 같습니다.
-> 해당 ID 리스트에 유효하지 않은 크리에이터 아이디가 있는 경우
-> 이미 APPROVED된 상태인 Creator를 계속해서 APPROVED 하는 경우 ( APPROVED 상태가 유지됨)

3) 삭제
테스트 케이스는 다음과 같습니다.
-> 해당 ID 리스트에 유효하지 않은 크리에이터 아이디가 있는 경우
-> INACTIVE로 변경한 뒤 전체 조회에서 해당 크리에이터가 뜨는지 확인

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢
- 유저 삭제 부분은 실제로 서버 상으론 DELETE의 개념이 아니라서 HTTP 메서드를 PATCH로 만들긴 했는데, 이게 옳은 선택인지는 잘 모르겠습니다. 클라이언트에게 혼동을 줄 수도 있을 것 같아서요. 어떻게 생각하시는지 자유롭게 의견 주시면 감사하겠습니다.
- 추후 해야 할 일은 다음과 같습니다.  DB Creator에 SignupCompletedAt 필드 추가하기 -> 현재 이미 회원가입이 완료된 Creator들 중에서는 APPROVED 된 Creator들에 한해서만 승인 시각을 SignupCompletedAt 필드에 넣어주기. (NOT_APPROVED는 아님. 정상적인 회원가입이 안된 상태이기 때문)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 관리자가 크리에이터 목록을 조회할 수 있습니다
- 여러 크리에이터를 한 번에 승인할 수 있습니다
- 여러 크리에이터를 한 번에 비활성화(삭제)할 수 있습니다

## 개선사항
- 캠페인 목록에 전체 개수(total) 정보가 추가되었습니다
- API 요청 입력값에 런타임 검증(NotEmpty) 적용으로 유효성 강화
- 크리에이터의 가입 완료 시간(signup completed) 기록이 추가되었습니다

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->