### PR TITLE
[FEAT] #442 브랜드 명 기준 리뷰 검색 API 구현 / 어드민 캠페인 생성 API 위치 이전 / ReviewLikeCount 엔티티 생성

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/api/BrandController.java
+++ b/src/main/java/com/lokoko/domain/brand/api/BrandController.java
@@ -279,22 +279,6 @@ public class BrandController {
     }
 
 
-    /**
-     * 어드민용 캠페인 발행 API 추후 삭제 예정
-     */
-    @Operation(summary = "캠페인 생성 - 발행",
-            description = "브랜드 마이페이지 - 브랜드가 캠페인을 발행 상태로 생성하는 API 입니다.")
-    @PostMapping("/my/campaigns/publish/admin")
-    public ApiResponse<CampaignBasicResponse> createAndPublishCampaignForAdmin(
-            @Parameter(hidden = true) @CurrentUser Long adminId,
-            @Valid @RequestBody CampaignPublishRequest publishRequest) {
-
-        CampaignBasicResponse response = campaignService.createAndPublishCampaignForAdmin(adminId, publishRequest);
-
-        return ApiResponse.success(HttpStatus.OK,
-                ResponseMessage.CAMPAIGN_PUBLISH_SUCCESS.getMessage(), response);
-    }
-
     @Operation(summary = "브랜드 대시보드 캠페인 리스트 조회")
     @GetMapping("/dashboard/campaigns")
     public ApiResponse<BrandDashboardCampaignListResponse> getBrandDashboardCampaigns(

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/request/AdminCampaignCreateRequest.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/request/AdminCampaignCreateRequest.java
@@ -1,0 +1,59 @@
+package com.lokoko.domain.campaign.api.dto.request;
+
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public record AdminCampaignCreateRequest(
+        String brandName,
+        String campaignTitle,
+        CampaignLanguage language,
+        CampaignType campaignType,
+        CampaignProductType campaignProductType,
+        @Size(max = 5, message = "상단 이미지는 최대 5개까지 가능합니다")
+        List<CampaignImageRequest> thumbnailImages,
+        @Size(max = 15, message = "하단 이미지는 최대 15개까지 가능합니다")
+        List<CampaignImageRequest> detailImages,
+        Instant applyStartDate,
+        Instant applyDeadline,
+        Instant creatorAnnouncementDate,
+        Instant reviewSubmissionDeadline,
+        Integer recruitmentNumber,
+        List<String> participationRewards,
+        List<String> deliverableRequirements,
+        List<String> eligibilityRequirements,
+        ContentType firstContentType,
+        ContentType secondContentType
+) {
+    public static AdminCampaignCreateRequest convertPublishToCreateRequest(AdminCampaignCreateRequest publishRequest) {
+        return new AdminCampaignCreateRequest(
+                publishRequest.brandName,
+                publishRequest.campaignTitle(),
+                publishRequest.language(),
+                publishRequest.campaignType(),
+                publishRequest.campaignProductType(),
+                safeList(publishRequest.thumbnailImages()),
+                safeList(publishRequest.detailImages()),
+                publishRequest.applyStartDate(),
+                publishRequest.applyDeadline(),
+                publishRequest.creatorAnnouncementDate(),
+                publishRequest.reviewSubmissionDeadline(),
+                publishRequest.recruitmentNumber(),
+                safeList(publishRequest.participationRewards()),
+                safeList(publishRequest.deliverableRequirements()),
+                safeList(publishRequest.eligibilityRequirements()),
+                publishRequest.firstContentType(),
+                publishRequest.secondContentType()
+        );
+    }
+
+    private static <T> List<T> safeList(List<T> original) {
+        return original != null ? new ArrayList<>(original) : new ArrayList<>();
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/AdminCampaignBasicResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/AdminCampaignBasicResponse.java
@@ -1,0 +1,96 @@
+package com.lokoko.domain.campaign.api.dto.response;
+
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+import java.util.List;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+public record AdminCampaignBasicResponse(
+
+        @Schema(requiredMode = REQUIRED, description = "브랜드 이름", example = "LOCOCO")
+        String brandName,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 id", example = "1")
+        Long campaignId,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 제목", example = "나는야 캠페인")
+        String campaignTitle,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 진행 언어", example = "ENG")
+        CampaignLanguage language,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 종류", example = "GIVEAWAY")
+        CampaignType campaignType,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 상품 카테고리", example = "SKINCARE")
+        CampaignProductType campaignProductType,
+
+        @Schema(requiredMode = REQUIRED, description = "상단 이미지 리스트")
+        List<CampaignImageResponse> thumbnailImages,
+
+        @Schema(requiredMode = REQUIRED, description = "하단 이미지 리스트")
+        List<CampaignImageResponse> detailImages,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 지원 시작 일시", example = "2025-09-17T시7:32:08.995Z")
+        Instant applyStartDate,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 지원 마감 일", example = "2025-09-17T시7:32:08.995Z")
+        Instant applyDeadline,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 발표 일시", example = "2025-09-17T07:32:08.995Z")
+        Instant creatorAnnouncementDate,
+
+        @Schema(requiredMode = REQUIRED, description = "리뷰 제출 마감일", example = "2025-09-17T07:32:08.995Z")
+        Instant reviewSubmissionDeadline,
+
+        @Schema(requiredMode = REQUIRED, description = "모집 인원 수 ", example = "20")
+        Integer recruitmentNumber,
+
+        @Schema(requiredMode = REQUIRED, description = "캠페인 참여 보상 리스트")
+        List<String> participationRewards,
+
+        @Schema(requiredMode = REQUIRED, description = "컨텐츠 제출 요구사항 리스트")
+        List<String> deliverableRequirements,
+
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 자격 요건 리스트")
+        List<String> eligibilityRequirements,
+
+        @Schema(requiredMode = REQUIRED, description = "첫 번째 제출 컨텐츠", example = "INSTA_REELS")
+        ContentType firstContentType,
+
+        @Schema(requiredMode = REQUIRED, description = "두 번째 제출 컨텐츠", example = "TIKTOK_VIDEO")
+        ContentType secondContentType
+) {
+
+    public static AdminCampaignBasicResponse of(Campaign campaign, List<CampaignImageResponse> thumbnailImages,
+                                           List<CampaignImageResponse> detailImages) {
+        return new AdminCampaignBasicResponse(
+                campaign.getBrandName(),
+                campaign.getId(),
+                campaign.getTitle(),
+                campaign.getLanguage(),
+                campaign.getCampaignType(),
+                campaign.getCampaignProductType(),
+                thumbnailImages,
+                detailImages,
+                campaign.getApplyStartDate(),
+                campaign.getApplyDeadline(),
+                campaign.getCreatorAnnouncementDate(),
+                campaign.getReviewSubmissionDeadline(),
+                campaign.getRecruitmentNumber(),
+                campaign.getParticipationRewards(),
+                campaign.getDeliverableRequirements(),
+                campaign.getEligibilityRequirements(),
+                campaign.getFirstContentPlatform(),
+                campaign.getSecondContentPlatform()
+
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/dto/response/CampaignBasicResponse.java
@@ -33,16 +33,16 @@ public record CampaignBasicResponse(
         @Schema(requiredMode = REQUIRED, description = "하단 이미지 리스트")
         List<CampaignImageResponse> detailImages,
 
-        @Schema(requiredMode = REQUIRED, description = "크리에이터 지원 시작 일시", example = "2025-09-17T시7:32:08.995Z")
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 지원 시작 일시", example = "2024-12-15T23:59:59Z")
         Instant applyStartDate,
 
-        @Schema(requiredMode = REQUIRED, description = "크리에이터 지원 마감 일", example = "2025-09-17T시7:32:08.995Z")
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 지원 마감 일", example = "2024-12-15T23:59:59Z")
         Instant applyDeadline,
 
-        @Schema(requiredMode = REQUIRED, description = "크리에이터 발표 일시", example = "2025-09-17T07:32:08.995Z")
+        @Schema(requiredMode = REQUIRED, description = "크리에이터 발표 일시", example = "2024-12-15T23:59:59Z")
         Instant creatorAnnouncementDate,
 
-        @Schema(requiredMode = REQUIRED, description = "리뷰 제출 마감일", example = "2025-09-17T07:32:08.995Z")
+        @Schema(requiredMode = REQUIRED, description = "리뷰 제출 마감일", example = "2024-12-15T23:59:59Z")
         Instant reviewSubmissionDeadline,
 
         @Schema(requiredMode = REQUIRED, description = "모집 인원 수 ", example = "20")

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -6,12 +6,7 @@ import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignInfoListResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandMyCampaignListResponse;
 import com.lokoko.domain.brand.api.dto.response.CampaignApplicantListResponse;
 import com.lokoko.domain.brand.domain.entity.Brand;
-import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
-import com.lokoko.domain.campaign.api.dto.response.CampaignDetailResponse;
-import com.lokoko.domain.campaign.api.dto.response.CampaignImageResponse;
-import com.lokoko.domain.campaign.api.dto.response.CampaignParticipatedResponse;
-import com.lokoko.domain.campaign.api.dto.response.MainPageCampaignListResponse;
-import com.lokoko.domain.campaign.api.dto.response.MainPageUpcomingCampaignListResponse;
+import com.lokoko.domain.campaign.api.dto.response.*;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignDetailPageStatus;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductTypeFilter;
@@ -221,7 +216,7 @@ public class CampaignGetService {
         return campaignRepository.findBrandDashboardCampaigns(brandId, PageRequest.of(page, size));
     }
 
-    public CampaignBasicResponse getCampaignDetailForAdmin(Long campaignId) {
+    public AdminCampaignBasicResponse getCampaignDetailForAdmin(Long campaignId) {
         Campaign campaign  = campaignRepository.findById(campaignId)
                 .orElseThrow(CampaignNotFoundException::new);
 
@@ -230,6 +225,6 @@ public class CampaignGetService {
         List<CampaignImageResponse> thumbnailImages = campaignImageRepository.findThumbnailImagesByCampaignId(campaignId);
         List<CampaignImageResponse> detailImages = campaignImageRepository.findDetailImagesByCampaignId(campaignId);
 
-        return CampaignBasicResponse.of(campaign, thumbnailImages, detailImages);
+        return AdminCampaignBasicResponse.of(campaign, thumbnailImages, detailImages);
     }
 }

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignService.java
@@ -117,6 +117,8 @@ public class CampaignService {
         validatePublishableCampaign(actionType, campaign);
 
         Campaign savedCampaign = campaignRepository.save(campaign);
+        savedCampaign.assignBrandName(savedCampaign.getBrand().getBrandName());
+
         List<CampaignImage> savedImages = saveImages(createRequest, savedCampaign);
 
         return buildCampaignCreateResponse(savedCampaign, savedImages);

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -206,60 +206,6 @@ public class Campaign extends BaseEntity {
         }
     }
 
-    public void updateCampaignForAdmin(AdminCampaignCreateRequest request) {
-
-        if (request.brandName() != null) {
-            this.brandName = request.brandName();
-        }
-        if (request.campaignTitle() != null) {
-            this.title = request.campaignTitle();
-        }
-        if (request.language() != null) {
-            this.language = request.language();
-        }
-        if (request.campaignType() != null) {
-            this.campaignType = request.campaignType();
-        }
-        if (request.campaignProductType() != null) {
-            this.campaignProductType = request.campaignProductType();
-        }
-        if (request.applyStartDate() != null) {
-            this.applyStartDate = request.applyStartDate();
-        }
-        if (request.applyDeadline() != null) {
-            this.applyDeadline = request.applyDeadline();
-        }
-        if (request.creatorAnnouncementDate() != null) {
-            this.creatorAnnouncementDate = request.creatorAnnouncementDate();
-        }
-        if (request.reviewSubmissionDeadline() != null) {
-            this.reviewSubmissionDeadline = request.reviewSubmissionDeadline();
-        }
-        if (request.recruitmentNumber() != null) {
-            this.recruitmentNumber = request.recruitmentNumber();
-        }
-
-        if (request.participationRewards() != null) {
-            this.participationRewards.clear();
-            this.participationRewards.addAll(request.participationRewards());
-        }
-        if (request.deliverableRequirements() != null) {
-            this.deliverableRequirements.clear();
-            this.deliverableRequirements.addAll(request.deliverableRequirements());
-        }
-        if (request.eligibilityRequirements() != null) {
-            this.eligibilityRequirements.clear();
-            this.eligibilityRequirements.addAll(request.eligibilityRequirements());
-        }
-        if (request.firstContentType() != null) {
-            this.firstContentPlatform = request.firstContentType();
-        }
-        if (request.secondContentType() != null) {
-            this.secondContentPlatform = request.secondContentType();
-        }
-    }
-
-    // to be refactored...
     public void updateCampaign(CampaignModifyRequest request) {
 
         if (request.campaignTitle() != null) {

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -133,6 +133,9 @@ public class Campaign extends BaseEntity {
     @Column(nullable = false)
     private Integer deleted = 0;
 
+    public void assignBrandName(String brandName) {
+        this.brandName = brandName;
+    }
     /**
      * 캠페인 지원자 수 증가 메소드
      */
@@ -207,7 +210,9 @@ public class Campaign extends BaseEntity {
     }
 
     public void updateCampaign(CampaignModifyRequest request) {
-
+        if (request.brandName() != null) {
+            this.brandName = request.brandName();
+        }
         if (request.campaignTitle() != null) {
             this.title = request.campaignTitle();
         }

--- a/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/entity/Campaign.java
@@ -3,6 +3,7 @@ package com.lokoko.domain.campaign.domain.entity;
 import static jakarta.persistence.FetchType.LAZY;
 
 import com.lokoko.domain.brand.domain.entity.Brand;
+import com.lokoko.domain.campaign.api.dto.request.AdminCampaignCreateRequest;
 import com.lokoko.domain.campaign.api.dto.request.CampaignCreateRequest;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
 import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
@@ -41,6 +42,8 @@ public class Campaign extends BaseEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "brand_id")
     private Brand brand;
+
+    private String brandName;
 
     private String title;
 
@@ -203,6 +206,59 @@ public class Campaign extends BaseEntity {
         }
     }
 
+    public void updateCampaignForAdmin(AdminCampaignCreateRequest request) {
+
+        if (request.brandName() != null) {
+            this.brandName = request.brandName();
+        }
+        if (request.campaignTitle() != null) {
+            this.title = request.campaignTitle();
+        }
+        if (request.language() != null) {
+            this.language = request.language();
+        }
+        if (request.campaignType() != null) {
+            this.campaignType = request.campaignType();
+        }
+        if (request.campaignProductType() != null) {
+            this.campaignProductType = request.campaignProductType();
+        }
+        if (request.applyStartDate() != null) {
+            this.applyStartDate = request.applyStartDate();
+        }
+        if (request.applyDeadline() != null) {
+            this.applyDeadline = request.applyDeadline();
+        }
+        if (request.creatorAnnouncementDate() != null) {
+            this.creatorAnnouncementDate = request.creatorAnnouncementDate();
+        }
+        if (request.reviewSubmissionDeadline() != null) {
+            this.reviewSubmissionDeadline = request.reviewSubmissionDeadline();
+        }
+        if (request.recruitmentNumber() != null) {
+            this.recruitmentNumber = request.recruitmentNumber();
+        }
+
+        if (request.participationRewards() != null) {
+            this.participationRewards.clear();
+            this.participationRewards.addAll(request.participationRewards());
+        }
+        if (request.deliverableRequirements() != null) {
+            this.deliverableRequirements.clear();
+            this.deliverableRequirements.addAll(request.deliverableRequirements());
+        }
+        if (request.eligibilityRequirements() != null) {
+            this.eligibilityRequirements.clear();
+            this.eligibilityRequirements.addAll(request.eligibilityRequirements());
+        }
+        if (request.firstContentType() != null) {
+            this.firstContentPlatform = request.firstContentType();
+        }
+        if (request.secondContentType() != null) {
+            this.secondContentPlatform = request.secondContentType();
+        }
+    }
+
     // to be refactored...
     public void updateCampaign(CampaignModifyRequest request) {
 
@@ -270,6 +326,12 @@ public class Campaign extends BaseEntity {
         }
     }
 
+    public void validatePublishableForAdmin() {
+        if (isDraftForAdmin()) {
+            throw new DraftNotFilledException();
+        }
+    }
+
     /**
      * 임시 저장 여부 반환 필수 필드 중 하나라도 비어있으면 임시저장으로 간주.
      *
@@ -293,10 +355,56 @@ public class Campaign extends BaseEntity {
         ).anyMatch(condition -> condition);
     }
 
+    /**
+     * 어드민 생성 캠페인의 임시 저장 여부 반환.
+     * Brand 연관관계 대신 brandName 필드를 검증한다.
+     *
+     * @return 임시저장 여부
+     */
+    public boolean isDraftForAdmin() {
+        return Stream.of(
+                this.brandName == null || this.brandName.isBlank(),
+                this.title == null || this.title.isBlank(),
+                this.language == null,
+                this.campaignType == null,
+                this.campaignProductType == null,
+                this.applyStartDate == null,
+                this.applyDeadline == null,
+                this.creatorAnnouncementDate == null,
+                this.reviewSubmissionDeadline == null,
+                this.recruitmentNumber == null,
+                this.participationRewards == null || this.participationRewards.isEmpty(),
+                this.deliverableRequirements == null || this.deliverableRequirements.isEmpty(),
+                this.firstContentPlatform == null
+        ).anyMatch(condition -> condition);
+    }
+
     public static Campaign createCampaign(CampaignCreateRequest request, Brand brand) {
 
         return Campaign.builder()
                 .brand(brand)
+                .title(request.campaignTitle())
+                .language(request.language())
+                .campaignType(request.campaignType())
+                .campaignStatus(CampaignStatus.DRAFT) // DRAFT 가 기본값
+                .campaignProductType(request.campaignProductType())
+                .applyStartDate(request.applyStartDate())
+                .applyDeadline(request.applyDeadline())
+                .creatorAnnouncementDate(request.creatorAnnouncementDate())
+                .reviewSubmissionDeadline(request.reviewSubmissionDeadline())
+                .recruitmentNumber(request.recruitmentNumber())
+                .participationRewards(request.participationRewards())
+                .deliverableRequirements(request.deliverableRequirements())
+                .eligibilityRequirements(request.eligibilityRequirements())
+                .firstContentPlatform(request.firstContentType())
+                .secondContentPlatform(request.secondContentType())
+                .build();
+    }
+
+    public static Campaign createCampaignForAdmin(AdminCampaignCreateRequest request) {
+
+        return Campaign.builder()
+                .brandName(request.brandName())
                 .title(request.campaignTitle())
                 .language(request.language())
                 .campaignType(request.campaignType())

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -424,10 +424,13 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
 
         BooleanExpression statusCondition = createStatusCondition(status);
 
+        StringExpression brandNameExpression = campaign.brandName
+                .coalesce(campaign.brand.brandName);
+
         List<AdminCampaignInfoResponse> campaignList = queryFactory
                 .select(Projections.constructor(AdminCampaignInfoResponse.class,
                         campaign.id,
-                        campaign.brand.brandName,
+                        brandNameExpression,
                         campaign.title,
                         Projections.constructor(AdminCampaignInfoResponse.RecruitmentStatus.class,
                                 campaign.recruitmentNumber,

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryImpl.java
@@ -424,8 +424,10 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
 
         BooleanExpression statusCondition = createStatusCondition(status);
 
-        StringExpression brandNameExpression = campaign.brandName
-                .coalesce(campaign.brand.brandName);
+        StringExpression brandNameExpression = new CaseBuilder()
+                .when(campaign.brand.isNull())
+                .then(campaign.brandName)
+                .otherwise(campaign.brand.brandName);
 
         List<AdminCampaignInfoResponse> campaignList = queryFactory
                 .select(Projections.constructor(AdminCampaignInfoResponse.class,
@@ -440,6 +442,7 @@ public class CampaignRepositoryImpl implements CampaignRepositoryCustom {
                         approvedStatus
                 ))
                 .from(campaign)
+                .leftJoin(campaign.brand)
                 .where(statusCondition, campaign.campaignStatus.ne(CampaignStatus.DRAFT))
                 .orderBy(campaign.publishedAt.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/com/lokoko/domain/like/application/service/ReviewLikeService.java
+++ b/src/main/java/com/lokoko/domain/like/application/service/ReviewLikeService.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ReviewLikeService {
     private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
@@ -29,6 +28,7 @@ public class ReviewLikeService {
     private final ApplicationEventPublisher eventPublisher;
 
     @DistributedLock(key = "'like:review:' + #reviewId + ':user:' + #userId")
+    @Transactional
     public long toggleReviewLike(Long reviewId, Long userId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(ReviewNotFoundException::new);

--- a/src/main/java/com/lokoko/domain/like/domain/entity/ReviewLikeCount.java
+++ b/src/main/java/com/lokoko/domain/like/domain/entity/ReviewLikeCount.java
@@ -17,12 +17,11 @@ public class ReviewLikeCount {
 
     private Long reviewId;
 
-    private Long likeCount;
+    private long likeCount;
 
-    public static ReviewLikeCount init(Long reviewId, Long likeCount) {
+    public static ReviewLikeCount init(Long reviewId) {
         return ReviewLikeCount.builder()
                 .reviewId(reviewId)
-                .likeCount(likeCount)
                 .build();
     }
 

--- a/src/main/java/com/lokoko/domain/like/domain/entity/ReviewLikeCount.java
+++ b/src/main/java/com/lokoko/domain/like/domain/entity/ReviewLikeCount.java
@@ -1,0 +1,29 @@
+package com.lokoko.domain.like.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReviewLikeCount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_like_count_id")
+    private Long id;
+
+    private Long reviewId;
+
+    private Long likeCount;
+
+    public static ReviewLikeCount init(Long reviewId, Long likeCount) {
+        return ReviewLikeCount.builder()
+                .reviewId(reviewId)
+                .likeCount(likeCount)
+                .build();
+    }
+
+}

--- a/src/main/java/com/lokoko/domain/like/domain/repository/ReviewLikeCountRepository.java
+++ b/src/main/java/com/lokoko/domain/like/domain/repository/ReviewLikeCountRepository.java
@@ -1,0 +1,27 @@
+package com.lokoko.domain.like.domain.repository;
+
+import com.lokoko.domain.like.domain.entity.ReviewLikeCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ReviewLikeCountRepository extends JpaRepository<ReviewLikeCount, Long> {
+
+    // 좋아요 수 증가
+    @Query(value = "UPDATE review_like_count SET like_count = like_count + 1 " +
+                   "WHERE review_id = :reviewId",
+            nativeQuery = true
+    )
+    @Modifying
+    int increase(@Param("reviewId") Long reviewId);
+
+    // 좋아요 수 감소
+    @Query(value = "UPDATE review_like_count SET like_count = like_count -1 " +
+                   "WHERE review_id = :reviewId",
+            nativeQuery = true
+    )
+    @Modifying
+    int decrease(@Param("reviewId") Long reviewId);
+
+}

--- a/src/main/java/com/lokoko/domain/like/domain/repository/ReviewLikeCountRepository.java
+++ b/src/main/java/com/lokoko/domain/like/domain/repository/ReviewLikeCountRepository.java
@@ -17,8 +17,8 @@ public interface ReviewLikeCountRepository extends JpaRepository<ReviewLikeCount
     int increase(@Param("reviewId") Long reviewId);
 
     // 좋아요 수 감소
-    @Query(value = "UPDATE review_like_count SET like_count = like_count -1 " +
-                   "WHERE review_id = :reviewId",
+    @Query(value = "UPDATE review_like_count SET like_count = CASE WHEN like_count > 0 THEN like_count -1 " +
+                   "ELSE 0 END WHERE review_id = :reviewId",
             nativeQuery = true
     )
     @Modifying

--- a/src/main/java/com/lokoko/domain/media/image/domain/repository/ReviewImageRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/media/image/domain/repository/ReviewImageRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.lokoko.domain.media.image.domain.repository;
 
-import com.lokoko.domain.like.domain.entity.QReviewLike;
+import com.lokoko.domain.like.domain.entity.QReviewLikeCount;
 import com.lokoko.domain.media.image.domain.entity.QReviewImage;
 import com.lokoko.domain.product.domain.entity.QProduct;
 import com.lokoko.domain.productReview.api.dto.response.MainImageReview;
@@ -8,10 +8,9 @@ import com.lokoko.domain.productReview.domain.entity.QReview;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,7 +20,7 @@ public class ReviewImageRepositoryImpl implements ReviewImageRepositoryCustom {
     private static final QReviewImage reviewImage = QReviewImage.reviewImage;
     private static final QReview review = QReview.review;
     private static final QProduct product = QProduct.product;
-    private static final QReviewLike reviewLike = QReviewLike.reviewLike;
+    private static final QReviewLikeCount reviewLikeCount = QReviewLikeCount.reviewLikeCount;
 
     @Override
     public List<MainImageReview> findMainImageReviewSorted() {
@@ -31,7 +30,7 @@ public class ReviewImageRepositoryImpl implements ReviewImageRepositoryCustom {
                         product.id,
                         product.productBrand.brandName,
                         product.productName,
-                        reviewLike.count().intValue(),
+                        reviewLikeCount.likeCount.coalesce(0L),
                         // 일단 여기서 rank 0, service에서 추가
                         Expressions.constant(0),
                         reviewImage.mediaFile.fileUrl
@@ -39,11 +38,9 @@ public class ReviewImageRepositoryImpl implements ReviewImageRepositoryCustom {
                 .from(reviewImage)
                 .join(reviewImage.review, review)
                 .join(review.product, product)
-                .leftJoin(reviewLike).on(reviewLike.review.eq(review))
+                .leftJoin(reviewLikeCount).on(reviewLikeCount.reviewId.eq(review.id))
                 .where(reviewImage.displayOrder.eq(0))
-                .groupBy(review.id, product.id, product.productBrand.brandName, product.productName, review.rating,
-                        reviewImage.mediaFile.fileUrl)
-                .orderBy(reviewLike.count().desc(), review.rating.desc())
+                .orderBy(reviewLikeCount.likeCount.desc())
                 .limit(4)
                 .fetch();
     }

--- a/src/main/java/com/lokoko/domain/media/video/domain/repository/ReviewVideoRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/media/video/domain/repository/ReviewVideoRepositoryImpl.java
@@ -1,6 +1,9 @@
 package com.lokoko.domain.media.video.domain.repository;
 
 
+import static com.lokoko.domain.like.domain.entity.QReviewLike.reviewLike;
+
+import com.lokoko.domain.like.domain.entity.QReviewLikeCount;
 import com.lokoko.domain.media.video.domain.entity.QReviewVideo;
 import com.lokoko.domain.product.domain.entity.QProduct;
 import com.lokoko.domain.productReview.api.dto.response.MainVideoReview;
@@ -8,12 +11,9 @@ import com.lokoko.domain.productReview.domain.entity.QReview;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-
-import static com.lokoko.domain.like.domain.entity.QReviewLike.reviewLike;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,6 +22,7 @@ public class ReviewVideoRepositoryImpl implements ReviewVideoRepositoryCustom {
     private static final QReviewVideo reviewVideo = QReviewVideo.reviewVideo;
     private static final QReview review = QReview.review;
     private static final QProduct product = QProduct.product;
+    private static final QReviewLikeCount reviewLikeCount = QReviewLikeCount.reviewLikeCount;
 
 
     @Override
@@ -40,11 +41,9 @@ public class ReviewVideoRepositoryImpl implements ReviewVideoRepositoryCustom {
                 .from(reviewVideo)
                 .join(reviewVideo.review, review)
                 .join(review.product, product)
-                .leftJoin(reviewLike).on(reviewLike.review.eq(review))
+                .leftJoin(reviewLikeCount).on(reviewLikeCount.reviewId.eq(review.id))
                 .where(reviewVideo.displayOrder.eq(0))
-                .groupBy(review.id, product.id, product.productBrand.brandName, product.productName, review.rating,
-                        reviewVideo.mediaFile.fileUrl)
-                .orderBy(reviewLike.count().desc(), review.rating.desc())
+                .orderBy(reviewLikeCount.likeCount.desc())
                 .limit(4)
                 .fetch();
     }

--- a/src/main/java/com/lokoko/domain/productReview/api/ReviewController.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/ReviewController.java
@@ -6,6 +6,9 @@ import com.lokoko.domain.media.api.dto.request.MediaPresignedUrlRequest;
 import com.lokoko.domain.media.api.dto.response.MediaPresignedUrlResponse;
 import com.lokoko.domain.productReview.api.dto.request.ReviewReceiptRequest;
 import com.lokoko.domain.productReview.api.dto.request.ReviewRequest;
+import com.lokoko.domain.productReview.api.dto.response.BrandImageReviewListResponse;
+import com.lokoko.domain.productReview.api.dto.response.BrandVideoReviewListResponse;
+import com.lokoko.domain.productReview.api.dto.response.ProductAndReviewCountResponse;
 import com.lokoko.domain.productReview.api.dto.response.ImageReviewDetailResponse;
 import com.lokoko.domain.productReview.api.dto.response.ImageReviewsProductDetailResponse;
 import com.lokoko.domain.productReview.api.dto.response.MainImageReviewResponse;
@@ -142,5 +145,39 @@ public class ReviewController {
                                           @PathVariable Long reviewId) {
         reviewService.deleteReview(userId, reviewId);
         return ApiResponse.success(HttpStatus.OK, REVIEW_DELETE_SUCCESS.getMessage());
+    }
+
+    @Operation(summary = "브랜드명 기준 영상 리뷰 검색 (brandName 없으면 전체 조회)")
+    @GetMapping("/brands/videos")
+    public ApiResponse<BrandVideoReviewListResponse> searchVideoReviewsByBrandName(
+            @RequestParam(required = false) String brandName,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "8") int size
+    ) {
+        BrandVideoReviewListResponse response = reviewReadService.searchVideoReviewsByBrandName(brandName, page, size);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_VIDEO_REVIEW_SEARCH_SUCCESS.getMessage(),
+                response);
+    }
+
+    @Operation(summary = "브랜드명 기준 사진 리뷰 검색 (brandName 없으면 전체 조회)")
+    @GetMapping("/brands/images")
+    public ApiResponse<BrandImageReviewListResponse> searchImageReviewsByBrandName(
+            @RequestParam(required = false) String brandName,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "8") int size
+    ) {
+        BrandImageReviewListResponse response = reviewReadService.searchImageReviewsByBrandName(brandName, page, size);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_IMAGE_REVIEW_SEARCH_SUCCESS.getMessage(),
+                response);
+    }
+
+    @Operation(summary = "브랜드명 기준 상품 수 및 리뷰 수 조회 (brandName 없으면 전체 조회)")
+    @GetMapping("/brands/summary")
+    public ApiResponse<ProductAndReviewCountResponse> getProductAndReviewCount(
+            @RequestParam(required = false) String brandName
+    ) {
+        ProductAndReviewCountResponse response = reviewReadService.getProductAndReviewCount(brandName);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.BRAND_REVIEW_SUMMARY_SUCCESS.getMessage(),
+                response);
     }
 }

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/BrandImageReviewListResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/BrandImageReviewListResponse.java
@@ -1,0 +1,25 @@
+package com.lokoko.domain.productReview.api.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.lokoko.global.common.response.PageableResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record BrandImageReviewListResponse(
+        @Schema(requiredMode = REQUIRED)
+        String brandName,
+        @Schema(requiredMode = REQUIRED)
+        List<ImageReviewResponse> reviews,
+        @Schema(requiredMode = REQUIRED)
+        PageableResponse pageInfo
+) {
+    public static BrandImageReviewListResponse from(String brandName, Slice<ImageReviewResponse> reviews) {
+        return new BrandImageReviewListResponse(
+                brandName,
+                reviews.getContent(),
+                PageableResponse.of(reviews)
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/BrandVideoReviewListResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/BrandVideoReviewListResponse.java
@@ -1,0 +1,27 @@
+package com.lokoko.domain.productReview.api.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.lokoko.global.common.response.PageableResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+@Builder
+public record BrandVideoReviewListResponse(
+        @Schema(requiredMode = REQUIRED)
+        String brandName,
+        @Schema(requiredMode = REQUIRED)
+        List<VideoReviewResponse> reviews,
+        @Schema(requiredMode = REQUIRED)
+        PageableResponse pageInfo
+) {
+    public static BrandVideoReviewListResponse from(String brandName, Slice<VideoReviewResponse> reviews) {
+        return new BrandVideoReviewListResponse(
+                brandName,
+                reviews.getContent(),
+                PageableResponse.of(reviews)
+        );
+    }
+}

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewResponse.java
@@ -12,7 +12,7 @@ public record ImageReviewResponse(
         @Schema(requiredMode = REQUIRED)
         String productName,
         @Schema(requiredMode = REQUIRED)
-        Integer likeCount,
+        Long likeCount,
         @Schema(requiredMode = REQUIRED)
         String url
 ) {

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/MainImageReview.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/MainImageReview.java
@@ -14,7 +14,7 @@ public record MainImageReview(
         @Schema(requiredMode = REQUIRED)
         String productName,
         @Schema(requiredMode = REQUIRED)
-        Integer likeCount,
+        Long likeCount,
         @Schema(requiredMode = REQUIRED)
         Integer rank,
         @Schema(requiredMode = REQUIRED)

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/MainVideoReview.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/MainVideoReview.java
@@ -14,7 +14,7 @@ public record MainVideoReview(
         @Schema(requiredMode = REQUIRED)
         String productName,
         @Schema(requiredMode = REQUIRED)
-        Integer likeCount,
+        Long likeCount,
         @Schema(requiredMode = REQUIRED)
         Integer rank,
         @Schema(requiredMode = REQUIRED)

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/ProductAndReviewCountResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/ProductAndReviewCountResponse.java
@@ -1,0 +1,18 @@
+package com.lokoko.domain.productReview.api.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ProductAndReviewCountResponse(
+        @Schema(description = "브랜드명 (null이면 전체 조회)")
+        String brandName,
+        @Schema(requiredMode = REQUIRED, description = "해당 브랜드의 상품 수")
+        int productCount,
+        @Schema(requiredMode = REQUIRED, description = "해당 브랜드의 전체 리뷰 수")
+        int reviewCount
+) {
+    public static ProductAndReviewCountResponse of(String brandName, int productCount, int reviewCount) {
+        return new ProductAndReviewCountResponse(brandName, productCount, reviewCount);
+    }
+}

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/VideoReviewResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/VideoReviewResponse.java
@@ -12,7 +12,7 @@ public record VideoReviewResponse(
         @Schema(requiredMode = REQUIRED)
         String productName,
         @Schema(requiredMode = REQUIRED)
-        Integer likeCount,
+        Long likeCount,
         @Schema(requiredMode = REQUIRED)
         String url
 ) {

--- a/src/main/java/com/lokoko/domain/productReview/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/message/ResponseMessage.java
@@ -15,7 +15,10 @@ public enum ResponseMessage {
     MAIN_REVIEW_VIDEO_SUCCESS("메인페이지 상세 리뷰 비디오 조회에 성공했습니다."),
     VIDEO_REVIEW_DETAIL_SUCCESS("영상 리뷰 상세 조회에 성공했습니다."),
     IMAGE_REVIEW_DETAIL_SUCCESS("사진 리뷰 상세 조회에 성공했습니다."),
-    REVIEW_DELETE_SUCCESS("리뷰가 성공적으로 삭제되었습니다.");
+    REVIEW_DELETE_SUCCESS("리뷰가 성공적으로 삭제되었습니다."),
+    BRAND_VIDEO_REVIEW_SEARCH_SUCCESS("브랜드명 기준 영상 리뷰 검색에 성공했습니다."),
+    BRAND_IMAGE_REVIEW_SEARCH_SUCCESS("브랜드명 기준 사진 리뷰 검색에 성공했습니다."),
+    BRAND_REVIEW_SUMMARY_SUCCESS("브랜드명 기준 상품 수 및 리뷰 수 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/productReview/application/service/ReviewReadService.java
+++ b/src/main/java/com/lokoko/domain/productReview/application/service/ReviewReadService.java
@@ -2,6 +2,9 @@ package com.lokoko.domain.productReview.application.service;
 
 import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
+import com.lokoko.domain.productReview.api.dto.response.BrandImageReviewListResponse;
+import com.lokoko.domain.productReview.api.dto.response.BrandVideoReviewListResponse;
+import com.lokoko.domain.productReview.api.dto.response.ProductAndReviewCountResponse;
 import com.lokoko.domain.productReview.api.dto.response.ImageReviewListResponse;
 import com.lokoko.domain.productReview.api.dto.response.ImageReviewResponse;
 import com.lokoko.domain.productReview.api.dto.response.ImageReviewsProductDetailResponse;
@@ -97,6 +100,29 @@ public class ReviewReadService {
                 pageable);
 
         return KeywordImageReviewListResponse.from(keyword, imageReviews);
+    }
+
+    public BrandVideoReviewListResponse searchVideoReviewsByBrandName(String brandName, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<VideoReviewResponse> videoReviews = reviewRepository.findVideoReviewsByBrandName(brandName, pageable);
+
+        return BrandVideoReviewListResponse.from(brandName, videoReviews);
+    }
+
+    public BrandImageReviewListResponse searchImageReviewsByBrandName(String brandName, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<ImageReviewResponse> imageReviews = reviewRepository.findImageReviewsByBrandName(brandName, pageable);
+
+        return BrandImageReviewListResponse.from(brandName, imageReviews);
+    }
+
+    public ProductAndReviewCountResponse getProductAndReviewCount(String brandName) {
+        int productCount = reviewRepository.countProductsByBrandName(brandName);
+        int reviewCount = reviewRepository.countReviewsByBrandName(brandName);
+
+        return ProductAndReviewCountResponse.of(brandName, productCount, reviewCount);
     }
 
     public ImageReviewsProductDetailResponse getImageReviewsInProductDetail(Long productId, int page,

--- a/src/main/java/com/lokoko/domain/productReview/application/service/ReviewService.java
+++ b/src/main/java/com/lokoko/domain/productReview/application/service/ReviewService.java
@@ -175,7 +175,7 @@ public class ReviewService {
         saveMediaFiles(mediaUrls, review);
 
         // ReviewLikeCount init
-        reviewLikeCountRepository.save(ReviewLikeCount.init(savedReview.getId(), 0L));
+        reviewLikeCountRepository.save(ReviewLikeCount.init(savedReview.getId()));
 
         eventPublisher.publishEvent(new PopularProductsCacheEvictEvent(product.getMiddleCategory()));
         eventPublisher.publishEvent(new PopularReviewsCacheEvictEvent());

--- a/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryCustom.java
@@ -36,6 +36,14 @@ public interface ReviewRepositoryCustom {
 
     Slice<ImageReviewResponse> findImageReviewsByKeyword(List<String> tokens, Pageable pageable);
 
+    Slice<VideoReviewResponse> findVideoReviewsByBrandName(String brandName, Pageable pageable);
+
+    Slice<ImageReviewResponse> findImageReviewsByBrandName(String brandName, Pageable pageable);
+
+    int countProductsByBrandName(String brandName);
+
+    int countReviewsByBrandName(String brandName);
+
     List<RatingCount> countByProductIdsAndRating(List<Long> productIds);
 
     VideoReviewProductDetailResponse findVideoReviewsByProductId(Long productId);

--- a/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.lokoko.domain.productReview.domain.repository;
 
 import com.lokoko.domain.like.domain.entity.QReviewLike;
+import com.lokoko.domain.like.domain.entity.QReviewLikeCount;
 import com.lokoko.domain.media.image.domain.entity.QReviewImage;
 import com.lokoko.domain.media.video.domain.entity.QReviewVideo;
 import com.lokoko.domain.product.domain.entity.QProduct;
@@ -50,6 +51,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     private final QReviewImage reviewImage = QReviewImage.reviewImage;
     private final QProductOption productOption = QProductOption.productOption;
     private final QReviewLike reviewLike = QReviewLike.reviewLike;
+    private final QReviewLikeCount reviewLikeCount = QReviewLikeCount.reviewLikeCount;
 
     private final UserRepository userRepository;
 
@@ -155,6 +157,86 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     public Slice<ImageReviewResponse> findImageReviewsByKeyword(List<String> tokens, Pageable pageable) {
         List<ImageReviewResponse> content = getImageReviewsByKeyword(tokens, pageable);
         return createSlice(content, pageable);
+    }
+
+    @Override
+    public Slice<VideoReviewResponse> findVideoReviewsByBrandName(String brandName, Pageable pageable) {
+        List<VideoReviewResponse> content = queryFactory
+                .select(Projections.constructor(VideoReviewResponse.class,
+                        review.id,
+                        product.productBrand.brandName,
+                        product.productName,
+                        reviewLikeCount.likeCount.coalesce(0L),
+                        reviewVideo.mediaFile.fileUrl
+                ))
+                .from(reviewVideo)
+                .innerJoin(reviewVideo.review, review)
+                .innerJoin(review.product, product)
+                .leftJoin(reviewLikeCount).on(reviewLikeCount.reviewId.eq(review.id))
+                .where(brandNameCondition(brandName))
+                .orderBy(reviewLikeCount.likeCount.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        return createSlice(content, pageable);
+    }
+
+    @Override
+    public Slice<ImageReviewResponse> findImageReviewsByBrandName(String brandName, Pageable pageable) {
+        List<ImageReviewResponse> content = queryFactory
+                .select(Projections.constructor(ImageReviewResponse.class,
+                        review.id,
+                        product.productBrand.brandName,
+                        product.productName,
+                        reviewLikeCount.likeCount.coalesce(0L),
+                        reviewImage.mediaFile.fileUrl
+                ))
+                .from(reviewImage)
+                .innerJoin(reviewImage.review, review)
+                .innerJoin(review.product, product)
+                .leftJoin(reviewLikeCount).on(reviewLikeCount.reviewId.eq(review.id))
+                .where(
+                        brandNameCondition(brandName),
+                        reviewImage.isMain.eq(true)
+                )
+                .orderBy(reviewLikeCount.likeCount.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        return createSlice(content, pageable);
+    }
+
+    @Override
+    public int countProductsByBrandName(String brandName) {
+        Long count = queryFactory
+                .select(product.countDistinct())
+                .from(product)
+                .innerJoin(review).on(review.product.eq(product))
+                .where(brandNameCondition(brandName))
+                .fetchOne();
+
+        return count != null ? count.intValue() : 0;
+    }
+
+    @Override
+    public int countReviewsByBrandName(String brandName) {
+        Long count = queryFactory
+                .select(review.count())
+                .from(review)
+                .innerJoin(review.product, product)
+                .where(brandNameCondition(brandName))
+                .fetchOne();
+
+        return count != null ? count.intValue() : 0;
+    }
+
+    private BooleanExpression brandNameCondition(String brandName) {
+        if (brandName == null || brandName.isBlank()) {
+            return null;
+        }
+        return product.productBrand.brandName.eq(brandName);
     }
 
     private List<VideoReviewResponse> getVideoReviewsByKeyword(List<String> tokens, Pageable pageable) {

--- a/src/main/java/com/lokoko/domain/user/api/AdminController.java
+++ b/src/main/java/com/lokoko/domain/user/api/AdminController.java
@@ -1,5 +1,7 @@
 package com.lokoko.domain.user.api;
 
+import com.lokoko.domain.campaign.api.dto.request.AdminCampaignCreateRequest;
+import com.lokoko.domain.campaign.api.dto.response.AdminCampaignBasicResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
 import com.lokoko.domain.media.api.dto.request.ProductImagePresignedUrlRequest;
 import com.lokoko.domain.media.api.dto.response.ProductImageResponse;
@@ -101,11 +103,11 @@ public class AdminController {
 
     @Operation(summary = "발행한 캠페인 정보 단건 조회(수정 페이지 진입 시 정보 반환 용)")
     @GetMapping("/campaigns/{campaignId}")
-    public ApiResponse<CampaignBasicResponse> getCampaignDetail(
+    public ApiResponse<AdminCampaignBasicResponse> getCampaignDetail(
             @Parameter(hidden = true) @CurrentUser Long userId,
             @PathVariable Long campaignId
     ) {
-        CampaignBasicResponse response = adminUsecase.findCampaignDetail(userId, campaignId);
+        AdminCampaignBasicResponse response = adminUsecase.findCampaignDetail(userId, campaignId);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CAMPAIGN_DETAIL_GET_SUCCESS.getMessage(), response);
     }
 
@@ -118,6 +120,17 @@ public class AdminController {
     ) {
         adminUsecase.modifyCampaign(userId, campaignId, request);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CAMPAIGN_MODIFY_SUCCESS.getMessage());
+    }
+
+    @Operation(summary = "어드민 - 캠페인 생성")
+    @PostMapping("/campaigns")
+    public ApiResponse<CampaignBasicResponse> createCampaignForAdmin(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @RequestBody @Valid AdminCampaignCreateRequest request
+    ) {
+
+        CampaignBasicResponse response = adminUsecase.publishCampaign(userId, request);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.ADMIN_CAMPAIGN_CREATE_SUCCESS.getMessage(), response);
     }
 
     @Operation(summary = "어드민 - 전체 크리에이터 리스트 조회(페이지네이션)")

--- a/src/main/java/com/lokoko/domain/user/api/dto/request/CampaignModifyRequest.java
+++ b/src/main/java/com/lokoko/domain/user/api/dto/request/CampaignModifyRequest.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.List;
 
 public record CampaignModifyRequest(
+        String brandName,
         String campaignTitle,
         CampaignLanguage language,
         CampaignType campaignType,

--- a/src/main/java/com/lokoko/domain/user/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/user/api/message/ResponseMessage.java
@@ -13,6 +13,7 @@ public enum ResponseMessage {
     ADMIN_CAMPAIGN_LIST_GET_SUCCESS("어드민 캠페인 리스트 조회에 성공했습니다."),
     ADMIN_CAMPAIGN_DETAIL_GET_SUCCESS("어드민 캠페인 단건 정보 조회에 성공했습니다."),
     ADMIN_CAMPAIGN_MODIFY_SUCCESS("어드민 캠페인 수정에 성공했습니다."),
+    ADMIN_CAMPAIGN_CREATE_SUCCESS("어드민 캠페인 생성에 성공했습니다."),
     ADMIN_CREATOR_LIST_GET_SUCCESS("어드민 크리에이터 리스트 조회에 성공했습니다."),
     ADMIN_CREATORS_APPROVAL_SUCCESS("어드민 크리에이터 복수 승인에 성공했습니다."),
     ADMIN_CREATORS_DELETE_SUCCESS("어드민 크리에이터 복수 삭제에 성공했습니다."),

--- a/src/main/java/com/lokoko/domain/user/application/usecase/AdminUsecase.java
+++ b/src/main/java/com/lokoko/domain/user/application/usecase/AdminUsecase.java
@@ -1,7 +1,11 @@
 package com.lokoko.domain.user.application.usecase;
 
+import com.lokoko.domain.campaign.api.dto.request.AdminCampaignCreateRequest;
+import com.lokoko.domain.campaign.api.dto.response.AdminCampaignBasicResponse;
 import com.lokoko.domain.campaign.api.dto.response.CampaignBasicResponse;
 import com.lokoko.domain.campaign.application.service.CampaignGetService;
+import com.lokoko.domain.campaign.application.service.CampaignService;
+import com.lokoko.domain.campaign.domain.entity.enums.ActionType;
 import com.lokoko.domain.campaign.domain.repository.CampaignRepository;
 import com.lokoko.domain.media.api.dto.request.ProductImagePresignedUrlRequest;
 import com.lokoko.domain.media.api.dto.response.ProductImageResponse;
@@ -43,6 +47,7 @@ public class AdminUsecase {
 
     private final UserGetService userGetService;
     private final CampaignGetService campaignGetService;
+    private final CampaignService campaignService;
 
     private final AdminCreatorGetService adminCreatorGetService;
     private final AdminCampaignUpdateService adminCampaignUpdateService;
@@ -96,7 +101,7 @@ public class AdminUsecase {
         return campaignRepository.findAllCampaignsByAdmin(status, PageRequest.of(page, size));
     }
 
-    public CampaignBasicResponse findCampaignDetail(Long userId, Long campaignId) {
+    public AdminCampaignBasicResponse findCampaignDetail(Long userId, Long campaignId) {
         validateIsAdmin(userId);
         return campaignGetService.getCampaignDetailForAdmin(campaignId);
     }
@@ -145,4 +150,11 @@ public class AdminUsecase {
                 .mediaUrl(urls)
                 .build();
     }
+
+    public CampaignBasicResponse publishCampaign(Long userId, AdminCampaignCreateRequest request) {
+        validateIsAdmin(userId);
+        AdminCampaignCreateRequest createRequest = AdminCampaignCreateRequest.convertPublishToCreateRequest(request);
+        return campaignService.createCampaignWithActionForAdmin(ActionType.PUBLISH, createRequest);
+    }
+
 }

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -22,6 +22,8 @@ public class PermitUrlConfig {
                 "/api/products/details/{productId}/youtube",
                 "/api/campaigns/upcoming",
                 "/api/admin/login",
+                "/api/reviews/brands/videos",
+                "/api/reviews/brands/images",
                 "/api/product-brand"
         };
     }
@@ -90,7 +92,7 @@ public class PermitUrlConfig {
                 "/api/campaignReviews/{campaignId}/second",
                 "/api/campaignReviews/my/participation",
                 "/api/campaignReviews/my/participation/{campaignId}",
-                "/api/creator/profile/campaigns",
+                "/api/creator/profile/campaigns"
         };
     }
 

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -24,7 +24,8 @@ public class PermitUrlConfig {
                 "/api/admin/login",
                 "/api/reviews/brands/videos",
                 "/api/reviews/brands/images",
-                "/api/product-brand"
+                "/api/product-brand",
+                "/api/reviews/brands/summary"
         };
     }
 


### PR DESCRIPTION
## Related issue 🛠

- closed #441 

## 작업 내용 💻

1. 브랜드 명 기준 리뷰 검색 api 를 구현하였습니다.
  1.1 브랜드 명 기준 영상 리뷰 검색 api 구현
  1.2 브랜드 명 기준 사진 리뷰 검색 api 구현
  1.3 상품 검색 결과 수 / 리뷰 검색 결과 수 반환 api 구현 

참고로, 1.3 api 는 아래 그림에서 필요한 api 입니다.
<img width="700" height="72" alt="image" src="https://github.com/user-attachments/assets/9b26f3a2-b3d9-425b-8dc4-eb6b9b324fd1" />


2. 어드민 캠페인 생성 API 의 위치를 brandController 에서 adminController 로 이전하였습니다.

3. 조회 쿼리 성능향상을 위해 ReviewLikeCount 엔티티를 생성하였습니다.

4. Campaign 테이블에 brandName 칼럼추가
brandName 칼럼이 추가 된 것은, 어드민이 직접 캠페인을 발행하는 경우 때문입니다.
  

## 스크린샷 📷

1. 브랜드 명 기준 영상 리뷰 검색 결과

<img width="979" height="430" alt="image" src="https://github.com/user-attachments/assets/b40811f3-b08e-4c9b-ae01-989bb17f5d52" />

2. 브랜드 명 기준 사진 리뷰 검색 결과
<img width="907" height="443" alt="image" src="https://github.com/user-attachments/assets/54f6e317-8f11-46c4-89e9-7792b351293f" />

3. 상품 검색 결과 수 / 리뷰 검색 결과 수 반환 
<img width="622" height="209" alt="image" src="https://github.com/user-attachments/assets/79cdb794-0815-4c93-b486-ef976c74ae9b" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 브랜드명 기준 영상/사진 리뷰 검색 API 및 브랜드별 상품·리뷰 개수 조회 API 추가
  * 관리자용 캠페인 생성 API(관리자 전용 생성/게시 흐름) 추가

* **개선 사항**
  * 리뷰 좋아요의 영구 집계 도입 및 리뷰 생성 시 초기 집계 엔트리 생성으로 정렬 신뢰도 향상
  * 관리자용 캠페인 요청/응답 구조 및 관리자 전용 상세 응답 개선

* **변경/제거**
  * 관리자 전용 게시(publish) 엔드포인트 제거

* **호환성**
  * 리뷰 응답의 likeCount 타입 Integer → Long 변경

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->