### PR TITLE
[FEAT] #444 브랜드 명 기준 상품 검색 API 구현

### DIFF
--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -1,29 +1,34 @@
 package com.lokoko.domain.product.domain.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
 import com.lokoko.domain.product.api.dto.NewProductProjection;
 import com.lokoko.domain.product.api.dto.PopularProductProjection;
 import com.lokoko.domain.product.domain.entity.Product;
 import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
-import java.util.List;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Repository;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
 
-@Repository
 public interface ProductRepositoryCustom {
-    Slice<Product> searchByTokens(List<String> tokens, Pageable pageable);
+	Slice<Product> searchByTokens(List<String> tokens, Pageable pageable);
 
-    Slice<Product> findProductsByPopularityAndRating(MiddleCategory category, Pageable pageable);
+	Slice<Product> findProductsByPopularityAndRating(MiddleCategory category, Pageable pageable);
 
-    Slice<Product> findProductsByPopularityAndRating(MiddleCategory category, SubCategory subCategory,
-                                                     Pageable pageable);
+	Slice<Product> findProductsByPopularityAndRating(MiddleCategory category, SubCategory subCategory,
+		Pageable pageable);
 
-    Slice<PopularProductProjection> findPopularProductsWithDetails(MiddleCategory middleCategory,
-                                                                   Pageable pageable);
+	Slice<PopularProductProjection> findPopularProductsWithDetails(MiddleCategory middleCategory,
+		Pageable pageable);
 
-    Slice<NewProductProjection> findNewProductsWithDetails(
-            MiddleCategory category,
-            Pageable pageable
-    );
+	Slice<NewProductProjection> findNewProductsWithDetails(
+		MiddleCategory category,
+		Pageable pageable
+	);
+
+	Slice<ProductBrandInfoProjection> getProductsByBrandName(String productBrandName, Pageable pageable);
+
+	Long countByProductBrandName(String productBrandName);
 }

--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -28,7 +28,7 @@ public interface ProductRepositoryCustom {
 		Pageable pageable
 	);
 
-	Slice<ProductBrandInfoProjection> getProductsByBrandName(String productBrandName, Pageable pageable);
+	Slice<ProductBrandInfoProjection> findProductsByBrandName(String productBrandName, Pageable pageable);
 
 	Long countByProductBrandName(String productBrandName);
 }

--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -31,4 +31,8 @@ public interface ProductRepositoryCustom {
 	Slice<ProductBrandInfoProjection> findProductsByBrandName(String productBrandName, Pageable pageable);
 
 	Long countByProductBrandName(String productBrandName);
+
+	Slice<ProductBrandInfoProjection> findProductsOrderedByRating(Pageable pageable);
+
+	Long countAllProducts();
 }

--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -10,7 +10,7 @@ import com.lokoko.domain.product.api.dto.PopularProductProjection;
 import com.lokoko.domain.product.domain.entity.Product;
 import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
-import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
+import com.lokoko.domain.productBrand.api.dto.ProductBrandInfoProjection;
 
 public interface ProductRepositoryCustom {
 	Slice<Product> searchByTokens(List<String> tokens, Pageable pageable);

--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
@@ -396,4 +396,78 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 			.where(p.productBrand.brandName.eq(productBrandName))
 			.fetchOne();
 	}
+
+	@Override
+	public Slice<ProductBrandInfoProjection> findProductsOrderedByRating(Pageable pageable) {
+
+		QProductImage mainProductImage = new QProductImage("mainProductImage");
+		QProductImage anyProductImage = new QProductImage("anyProductImage");
+
+		NumberExpression<Integer> ratingValue = new CaseBuilder()
+			.when(r.rating.eq(Rating.ONE)).then(1)
+			.when(r.rating.eq(Rating.TWO)).then(2)
+			.when(r.rating.eq(Rating.THREE)).then(3)
+			.when(r.rating.eq(Rating.FOUR)).then(4)
+			.when(r.rating.eq(Rating.FIVE)).then(5)
+			.otherwise(0);
+
+		NumberExpression<Double> averageRatingExpression = ratingValue.avg();
+		NumberExpression<Long> reviewCountExpression = r.id.count();
+
+		var fallbackImageUrlSubquery = JPAExpressions
+			.select(anyProductImage.url.min())
+			.from(anyProductImage)
+			.where(anyProductImage.product.eq(p));
+
+		var imageUrlExpression = Expressions.stringTemplate(
+			"coalesce({0}, {1})",
+			mainProductImage.url,
+			fallbackImageUrlSubquery
+		);
+
+		List<ProductBrandInfoProjection> content = queryFactory
+			.select(Projections.constructor(
+				ProductBrandInfoProjection.class,
+				p.productBrand.brandName,
+				p.productName,
+				p.unit,
+				averageRatingExpression,
+				imageUrlExpression
+			))
+			.from(p)
+			.join(p.productBrand)
+			.leftJoin(r).on(r.product.eq(p))
+			.leftJoin(mainProductImage).on(mainProductImage.product.eq(p).and(mainProductImage.isMain.eq(true)))
+			.groupBy(
+				p.id,
+				p.productBrand.brandName,
+				p.productName,
+				p.unit,
+				mainProductImage.url
+			)
+			.orderBy(
+				averageRatingExpression.desc(),
+				reviewCountExpression.desc(),
+				p.createdAt.desc(),
+				p.id.desc()
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1L)
+			.fetch();
+
+		boolean hasNext = content.size() > pageable.getPageSize();
+		if (hasNext) {
+			content.remove(content.size() - 1);
+		}
+
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
+
+	@Override
+	public Long countAllProducts() {
+		return queryFactory
+			.select(p.count())
+			.from(p)
+			.fetchOne();
+	}
 }

--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
@@ -19,7 +19,7 @@ import com.lokoko.domain.product.domain.entity.QProduct;
 import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
 import com.lokoko.domain.product.domain.entity.enums.Tag;
-import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
+import com.lokoko.domain.productBrand.api.dto.ProductBrandInfoProjection;
 import com.lokoko.domain.productReview.domain.entity.QReview;
 import com.lokoko.domain.productReview.domain.entity.enums.Rating;
 import com.querydsl.core.BooleanBuilder;

--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
@@ -1,5 +1,14 @@
 package com.lokoko.domain.product.domain.repository;
 
+import static com.lokoko.domain.product.domain.entity.QProduct.*;
+import static com.lokoko.domain.productReview.domain.entity.QReview.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
 
 import com.lokoko.domain.like.domain.entity.QProductLike;
 import com.lokoko.domain.media.image.domain.entity.QProductImage;
@@ -10,6 +19,7 @@ import com.lokoko.domain.product.domain.entity.QProduct;
 import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
 import com.lokoko.domain.product.domain.entity.enums.Tag;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
 import com.lokoko.domain.productReview.domain.entity.QReview;
 import com.lokoko.domain.productReview.domain.entity.enums.Rating;
 import com.querydsl.core.BooleanBuilder;
@@ -18,15 +28,12 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
-import org.springframework.stereotype.Repository;
 
 /**
  * 1단계 : 완전 일치 검색 - 모든 토큰을 연결한 문자열로 검색한다. 2단계 : 모든 토큰 포함(AND 검색) - 각 토큰이 모두 포함된 경우 3단계 : 주요 토큰 포함 - 첫 번째 토큰(일반적으로 브랜드명)
@@ -37,278 +44,358 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
-    private final JPAQueryFactory queryFactory;
-    private final QProduct p = QProduct.product;
-    private final QReview r = QReview.review;
-    private final QProductImage productImage = QProductImage.productImage;
-    private final QProductLike productLike = QProductLike.productLike;
+	private final JPAQueryFactory queryFactory;
+	private final QProduct p = product;
+	private final QReview r = review;
+	private final QProductImage productImage = QProductImage.productImage;
+	private final QProductLike productLike = QProductLike.productLike;
 
-    /**
-     * 주어진 토큰 리스트를 기반으로 상품 검색 단계적으로 검색이 수행되고, 각 단계에서 결과가 존재하면 바로 반환
-     *
-     * @param tokens 형태소 분석기를 통해서 만들어진 검색어 토큰 리스트
-     * @return 검색 조건에 부합하는 Product List
-     */
+	/**
+	 * 주어진 토큰 리스트를 기반으로 상품 검색 단계적으로 검색이 수행되고, 각 단계에서 결과가 존재하면 바로 반환
+	 *
+	 * @param tokens 형태소 분석기를 통해서 만들어진 검색어 토큰 리스트
+	 * @return 검색 조건에 부합하는 Product List
+	 */
 
-    @Override
-    public Slice<Product> searchByTokens(List<String> tokens, Pageable pageable) {
-        List<Product> allMatches;
-        if (tokens.isEmpty()) {
-            allMatches = List.of();
-        } else {
-            NumberExpression<Long> reviewCount = r.id.count();
-            NumberExpression<Integer> ratingValue = new CaseBuilder()
-                    .when(r.rating.eq(Rating.ONE)).then(1)
-                    .when(r.rating.eq(Rating.TWO)).then(2)
-                    .when(r.rating.eq(Rating.THREE)).then(3)
-                    .when(r.rating.eq(Rating.FOUR)).then(4)
-                    .when(r.rating.eq(Rating.FIVE)).then(5)
-                    .otherwise(0);
-            NumberExpression<Double> ratingAvgExpr = ratingValue.avg();
+	@Override
+	public Slice<Product> searchByTokens(List<String> tokens, Pageable pageable) {
+		List<Product> allMatches;
+		if (tokens.isEmpty()) {
+			allMatches = List.of();
+		} else {
+			NumberExpression<Long> reviewCount = r.id.count();
+			NumberExpression<Integer> ratingValue = new CaseBuilder()
+				.when(r.rating.eq(Rating.ONE)).then(1)
+				.when(r.rating.eq(Rating.TWO)).then(2)
+				.when(r.rating.eq(Rating.THREE)).then(3)
+				.when(r.rating.eq(Rating.FOUR)).then(4)
+				.when(r.rating.eq(Rating.FIVE)).then(5)
+				.otherwise(0);
+			NumberExpression<Double> ratingAvgExpr = ratingValue.avg();
 
-            BooleanBuilder finalCondition = buildSearchCondition(tokens);
+			BooleanBuilder finalCondition = buildSearchCondition(tokens);
 
-            allMatches = queryFactory
-                    .select(p)
-                    .from(p)
-                    .leftJoin(r).on(r.product.eq(p))
-                    .where(finalCondition)
-                    .groupBy(p.id)
-                    .orderBy(reviewCount.desc(), ratingAvgExpr.desc())
-                    .fetch();
-        }
+			allMatches = queryFactory
+				.select(p)
+				.from(p)
+				.leftJoin(r).on(r.product.eq(p))
+				.where(finalCondition)
+				.groupBy(p.id)
+				.orderBy(reviewCount.desc(), ratingAvgExpr.desc())
+				.fetch();
+		}
 
-        int offset = (int) pageable.getOffset();
-        int limit = pageable.getPageSize();
-        List<Product> content;
-        boolean hasNext = false;
+		int offset = (int)pageable.getOffset();
+		int limit = pageable.getPageSize();
+		List<Product> content;
+		boolean hasNext = false;
 
-        if (offset >= allMatches.size()) {
-            content = List.of();
-        } else {
-            int toIndex = Math.min(offset + limit, allMatches.size());
-            content = allMatches.subList(offset, toIndex);
-            hasNext = allMatches.size() > toIndex;
-        }
+		if (offset >= allMatches.size()) {
+			content = List.of();
+		} else {
+			int toIndex = Math.min(offset + limit, allMatches.size());
+			content = allMatches.subList(offset, toIndex);
+			hasNext = allMatches.size() > toIndex;
+		}
 
-        return new SliceImpl<>(content, pageable, hasNext);
-    }
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
 
-    /**
-     * 검색 토큰 리스트를 기반으로 단계적 검색 조건을 구성 1단계: 완전 일치 검색 2단계: 모든 토큰 포함 (AND 검색) 3단계: 주요 토큰 포함 (첫 번째 + 마지막 토큰) 4단계: 일부 토큰 포함
-     * (OR 검색)
-     */
-    private BooleanBuilder buildSearchCondition(List<String> tokens) {
+	/**
+	 * 검색 토큰 리스트를 기반으로 단계적 검색 조건을 구성 1단계: 완전 일치 검색 2단계: 모든 토큰 포함 (AND 검색) 3단계: 주요 토큰 포함 (첫 번째 + 마지막 토큰) 4단계: 일부 토큰 포함
+	 * (OR 검색)
+	 */
+	private BooleanBuilder buildSearchCondition(List<String> tokens) {
 
-        String fullKeyword = String.join("", tokens);
-        BooleanBuilder exactMatch = new BooleanBuilder()
-                .and(p.searchToken.containsIgnoreCase(fullKeyword));
+		String fullKeyword = String.join("", tokens);
+		BooleanBuilder exactMatch = new BooleanBuilder()
+			.and(p.searchToken.containsIgnoreCase(fullKeyword));
 
-        long exactMatchCount = queryFactory
-                .selectFrom(p)
-                .where(exactMatch)
-                .fetchCount();
+		long exactMatchCount = queryFactory
+			.selectFrom(p)
+			.where(exactMatch)
+			.fetchCount();
 
-        if (exactMatchCount > 0) {
-            return exactMatch;
-        }
+		if (exactMatchCount > 0) {
+			return exactMatch;
+		}
 
-        BooleanBuilder allTokensMatch = new BooleanBuilder();
-        tokens.forEach(token ->
-                allTokensMatch.and(p.searchToken.containsIgnoreCase(token))
-        );
+		BooleanBuilder allTokensMatch = new BooleanBuilder();
+		tokens.forEach(token ->
+			allTokensMatch.and(p.searchToken.containsIgnoreCase(token))
+		);
 
-        long allTokensCount = queryFactory
-                .selectFrom(p)
-                .where(allTokensMatch)
-                .fetchCount();
+		long allTokensCount = queryFactory
+			.selectFrom(p)
+			.where(allTokensMatch)
+			.fetchCount();
 
-        if (allTokensCount > 0) {
-            return allTokensMatch;
-        }
+		if (allTokensCount > 0) {
+			return allTokensMatch;
+		}
 
-        if (tokens.size() >= 3) {
-            BooleanBuilder majorTokensMatch = new BooleanBuilder()
-                    .and(p.searchToken.containsIgnoreCase(tokens.get(0)))
-                    .and(p.searchToken.containsIgnoreCase(tokens.get(tokens.size() - 1)));
+		if (tokens.size() >= 3) {
+			BooleanBuilder majorTokensMatch = new BooleanBuilder()
+				.and(p.searchToken.containsIgnoreCase(tokens.get(0)))
+				.and(p.searchToken.containsIgnoreCase(tokens.get(tokens.size() - 1)));
 
-            long majorTokensCount = queryFactory
-                    .selectFrom(p)
-                    .where(majorTokensMatch)
-                    .fetchCount();
+			long majorTokensCount = queryFactory
+				.selectFrom(p)
+				.where(majorTokensMatch)
+				.fetchCount();
 
-            if (majorTokensCount > 0) {
-                return majorTokensMatch;
-            }
-        }
+			if (majorTokensCount > 0) {
+				return majorTokensMatch;
+			}
+		}
 
-        BooleanBuilder anyTokenMatch = new BooleanBuilder();
-        tokens.forEach(token ->
-                anyTokenMatch.or(p.searchToken.containsIgnoreCase(token))
-        );
+		BooleanBuilder anyTokenMatch = new BooleanBuilder();
+		tokens.forEach(token ->
+			anyTokenMatch.or(p.searchToken.containsIgnoreCase(token))
+		);
 
-        return anyTokenMatch;
-    }
+		return anyTokenMatch;
+	}
 
-    @Override
-    public Slice<Product> findProductsByPopularityAndRating(
-            MiddleCategory category,
-            Pageable pageable
-    ) {
-        NumberExpression<Long> reviewCount = r.id.count();
-        NumberExpression<Integer> ratingValue = new CaseBuilder()
-                .when(r.rating.eq(Rating.ONE)).then(1)
-                .when(r.rating.eq(Rating.TWO)).then(2)
-                .when(r.rating.eq(Rating.THREE)).then(3)
-                .when(r.rating.eq(Rating.FOUR)).then(4)
-                .when(r.rating.eq(Rating.FIVE)).then(5)
-                .otherwise(0);
-        NumberExpression<Double> ratingAvg = ratingValue.avg();
-        List<Product> content = queryFactory
-                .select(p)
-                .from(p)
-                .leftJoin(r).on(r.product.eq(p))
-                .where(p.middleCategory.eq(category))
-                .groupBy(p.id)
-                .orderBy(
-                        reviewCount.desc(),
-                        ratingAvg.desc()
-                )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+	@Override
+	public Slice<Product> findProductsByPopularityAndRating(
+		MiddleCategory category,
+		Pageable pageable
+	) {
+		NumberExpression<Long> reviewCount = r.id.count();
+		NumberExpression<Integer> ratingValue = new CaseBuilder()
+			.when(r.rating.eq(Rating.ONE)).then(1)
+			.when(r.rating.eq(Rating.TWO)).then(2)
+			.when(r.rating.eq(Rating.THREE)).then(3)
+			.when(r.rating.eq(Rating.FOUR)).then(4)
+			.when(r.rating.eq(Rating.FIVE)).then(5)
+			.otherwise(0);
+		NumberExpression<Double> ratingAvg = ratingValue.avg();
+		List<Product> content = queryFactory
+			.select(p)
+			.from(p)
+			.leftJoin(r).on(r.product.eq(p))
+			.where(p.middleCategory.eq(category))
+			.groupBy(p.id)
+			.orderBy(
+				reviewCount.desc(),
+				ratingAvg.desc()
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
 
-        boolean hasNext = content.size() == pageable.getPageSize();
-        return new SliceImpl<>(content, pageable, hasNext);
-    }
+		boolean hasNext = content.size() == pageable.getPageSize();
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
 
-    @Override
-    public Slice<Product> findProductsByPopularityAndRating(
-            MiddleCategory category,
-            SubCategory subCategory,
-            Pageable pageable
-    ) {
-        NumberExpression<Long> reviewCount = r.id.count();
-        NumberExpression<Integer> ratingValue = new CaseBuilder()
-                .when(r.rating.eq(Rating.ONE)).then(1)
-                .when(r.rating.eq(Rating.TWO)).then(2)
-                .when(r.rating.eq(Rating.THREE)).then(3)
-                .when(r.rating.eq(Rating.FOUR)).then(4)
-                .when(r.rating.eq(Rating.FIVE)).then(5)
-                .otherwise(0);
-        NumberExpression<Double> ratingAvg = ratingValue.avg();
-        BooleanExpression where = p.middleCategory.eq(category);
-        if (subCategory != null) {
-            where = where.and(p.subCategory.eq(subCategory));
-        }
-        List<Product> content = queryFactory
-                .select(p)
-                .from(p)
-                .leftJoin(r).on(r.product.eq(p))
-                .where(where)
-                .groupBy(p.id)
-                .orderBy(reviewCount.desc(), ratingAvg.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+	@Override
+	public Slice<Product> findProductsByPopularityAndRating(
+		MiddleCategory category,
+		SubCategory subCategory,
+		Pageable pageable
+	) {
+		NumberExpression<Long> reviewCount = r.id.count();
+		NumberExpression<Integer> ratingValue = new CaseBuilder()
+			.when(r.rating.eq(Rating.ONE)).then(1)
+			.when(r.rating.eq(Rating.TWO)).then(2)
+			.when(r.rating.eq(Rating.THREE)).then(3)
+			.when(r.rating.eq(Rating.FOUR)).then(4)
+			.when(r.rating.eq(Rating.FIVE)).then(5)
+			.otherwise(0);
+		NumberExpression<Double> ratingAvg = ratingValue.avg();
+		BooleanExpression where = p.middleCategory.eq(category);
+		if (subCategory != null) {
+			where = where.and(p.subCategory.eq(subCategory));
+		}
+		List<Product> content = queryFactory
+			.select(p)
+			.from(p)
+			.leftJoin(r).on(r.product.eq(p))
+			.where(where)
+			.groupBy(p.id)
+			.orderBy(reviewCount.desc(), ratingAvg.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
 
-        boolean hasNext = content.size() == pageable.getPageSize();
-        return new SliceImpl<>(content, pageable, hasNext);
-    }
+		boolean hasNext = content.size() == pageable.getPageSize();
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
 
-    @Override
-    public Slice<PopularProductProjection> findPopularProductsWithDetails(
-            MiddleCategory category,
-            Pageable pageable) {
+	@Override
+	public Slice<PopularProductProjection> findPopularProductsWithDetails(
+		MiddleCategory category,
+		Pageable pageable) {
 
-        NumberExpression<Integer> ratingValue = new CaseBuilder()
-                .when(r.rating.eq(Rating.ONE)).then(1)
-                .when(r.rating.eq(Rating.TWO)).then(2)
-                .when(r.rating.eq(Rating.THREE)).then(3)
-                .when(r.rating.eq(Rating.FOUR)).then(4)
-                .when(r.rating.eq(Rating.FIVE)).then(5)
-                .otherwise(0);
+		NumberExpression<Integer> ratingValue = new CaseBuilder()
+			.when(r.rating.eq(Rating.ONE)).then(1)
+			.when(r.rating.eq(Rating.TWO)).then(2)
+			.when(r.rating.eq(Rating.THREE)).then(3)
+			.when(r.rating.eq(Rating.FOUR)).then(4)
+			.when(r.rating.eq(Rating.FIVE)).then(5)
+			.otherwise(0);
 
-        JPAQuery<PopularProductProjection> query = queryFactory
-                .select(Projections.constructor(PopularProductProjection.class,
-                        p.id,
-                        p.productName,
-                        p.productBrand.brandName,
-                        p.unit,
-                        r.id.count(),
-                        ratingValue.avg(),
-                        productImage.url,
-                        Expressions.FALSE  // 또는 Expressions.asBoolean(false)
-                ))
-                .from(p)
-                .leftJoin(r).on(r.product.eq(p))
-                .leftJoin(productImage).on(productImage.product.eq(p).and(productImage.isMain.eq(true)));
+		JPAQuery<PopularProductProjection> query = queryFactory
+			.select(Projections.constructor(PopularProductProjection.class,
+				p.id,
+				p.productName,
+				p.productBrand.brandName,
+				p.unit,
+				r.id.count(),
+				ratingValue.avg(),
+				productImage.url,
+				Expressions.FALSE  // 또는 Expressions.asBoolean(false)
+			))
+			.from(p)
+			.leftJoin(r).on(r.product.eq(p))
+			.leftJoin(productImage).on(productImage.product.eq(p).and(productImage.isMain.eq(true)));
 
-        List<PopularProductProjection> content = query
-                .where(p.middleCategory.eq(category))
-                .groupBy(p.id, p.productName, p.productBrand.brandName, p.unit, productImage.url)
-                .orderBy(r.id.count().desc(), ratingValue.avg().desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
+		List<PopularProductProjection> content = query
+			.where(p.middleCategory.eq(category))
+			.groupBy(p.id, p.productName, p.productBrand.brandName, p.unit, productImage.url)
+			.orderBy(r.id.count().desc(), ratingValue.avg().desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
 
-        boolean hasNext = content.size() > pageable.getPageSize();
-        if (hasNext) {
-            content.remove(content.size() - 1);
-        }
+		boolean hasNext = content.size() > pageable.getPageSize();
+		if (hasNext) {
+			content.remove(content.size() - 1);
+		}
 
-        return new SliceImpl<>(content, pageable, hasNext);
-    }
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
 
-    @Override
-    public Slice<NewProductProjection> findNewProductsWithDetails(
-            MiddleCategory category,
-            Pageable pageable) {
+	@Override
+	public Slice<NewProductProjection> findNewProductsWithDetails(
+		MiddleCategory category,
+		Pageable pageable) {
 
-        NumberExpression<Integer> ratingValue = new CaseBuilder()
-                .when(r.rating.eq(Rating.ONE)).then(1)
-                .when(r.rating.eq(Rating.TWO)).then(2)
-                .when(r.rating.eq(Rating.THREE)).then(3)
-                .when(r.rating.eq(Rating.FOUR)).then(4)
-                .when(r.rating.eq(Rating.FIVE)).then(5)
-                .otherwise(0);
+		NumberExpression<Integer> ratingValue = new CaseBuilder()
+			.when(r.rating.eq(Rating.ONE)).then(1)
+			.when(r.rating.eq(Rating.TWO)).then(2)
+			.when(r.rating.eq(Rating.THREE)).then(3)
+			.when(r.rating.eq(Rating.FOUR)).then(4)
+			.when(r.rating.eq(Rating.FIVE)).then(5)
+			.otherwise(0);
 
-        JPAQuery<NewProductProjection> query = queryFactory
-                .select(Projections.constructor(NewProductProjection.class,
-                        p.id,
-                        p.productName,
-                        p.productBrand.brandName,
-                        p.unit,
-                        r.id.count(),
-                        ratingValue.avg(),
-                        productImage.url,
-                        Expressions.FALSE,
-                        p.createdAt
-                ))
-                .from(p)
-                .leftJoin(r).on(r.product.eq(p))
-                .leftJoin(productImage).on(productImage.product.eq(p).and(productImage.isMain.eq(true)));
+		JPAQuery<NewProductProjection> query = queryFactory
+			.select(Projections.constructor(NewProductProjection.class,
+				p.id,
+				p.productName,
+				p.productBrand.brandName,
+				p.unit,
+				r.id.count(),
+				ratingValue.avg(),
+				productImage.url,
+				Expressions.FALSE,
+				p.createdAt
+			))
+			.from(p)
+			.leftJoin(r).on(r.product.eq(p))
+			.leftJoin(productImage).on(productImage.product.eq(p).and(productImage.isMain.eq(true)));
 
-        List<NewProductProjection> content = query
-                .where(
-                        p.middleCategory.eq(category)
-                                .and(p.tag.eq(Tag.NEW))
-                )
-                .groupBy(p.id, p.productName, p.productBrand.brandName, p.unit, productImage.url, p.createdAt)
-                .orderBy(
-                        r.id.count().desc(), //  리뷰 수
-                        ratingValue.avg().desc(), // 별점
-                        p.createdAt.desc()
-                )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
+		List<NewProductProjection> content = query
+			.where(
+				p.middleCategory.eq(category)
+					.and(p.tag.eq(Tag.NEW))
+			)
+			.groupBy(p.id, p.productName, p.productBrand.brandName, p.unit, productImage.url, p.createdAt)
+			.orderBy(
+				r.id.count().desc(), //  리뷰 수
+				ratingValue.avg().desc(), // 별점
+				p.createdAt.desc()
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
 
-        boolean hasNext = content.size() > pageable.getPageSize();
-        if (hasNext) {
-            content.remove(content.size() - 1);
-        }
+		boolean hasNext = content.size() > pageable.getPageSize();
+		if (hasNext) {
+			content.remove(content.size() - 1);
+		}
 
-        return new SliceImpl<>(content, pageable, hasNext);
-    }
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
+
+	@Override
+	public Slice<ProductBrandInfoProjection> getProductsByBrandName(String productBrandName, Pageable pageable) {
+
+		QProductImage mainProductImage = new QProductImage("mainProductImage");
+		QProductImage anyProductImage = new QProductImage("anyProductImage");
+
+		NumberExpression<Integer> ratingValue = new CaseBuilder()
+			.when(r.rating.eq(Rating.ONE)).then(1)
+			.when(r.rating.eq(Rating.TWO)).then(2)
+			.when(r.rating.eq(Rating.THREE)).then(3)
+			.when(r.rating.eq(Rating.FOUR)).then(4)
+			.when(r.rating.eq(Rating.FIVE)).then(5)
+			.otherwise(0);
+
+		NumberExpression<Double> averageRatingExpression = ratingValue.avg().coalesce(0.0);
+		NumberExpression<Long> reviewCountExpression = r.id.count();
+
+		var fallbackImageUrlSubquery = JPAExpressions
+			.select(anyProductImage.url.min())
+			.from(anyProductImage)
+			.where(anyProductImage.product.eq(p));
+
+		var imageUrlExpression = Expressions.stringTemplate(
+			"coalesce({0}, {1})",
+			mainProductImage.url,
+			fallbackImageUrlSubquery
+		);
+
+		List<ProductBrandInfoProjection> content = queryFactory
+			.select(Projections.constructor(
+				ProductBrandInfoProjection.class,
+				p.productBrand.brandName,
+				p.productName,
+				p.unit,
+				averageRatingExpression,
+				imageUrlExpression
+			))
+			.from(p)
+			.join(p.productBrand)
+			.leftJoin(r).on(r.product.eq(p))
+			.leftJoin(mainProductImage).on(
+				mainProductImage.product.eq(p)
+					.and(mainProductImage.isMain.eq(true))
+			)
+			.where(p.productBrand.brandName.eq(productBrandName))
+			.groupBy(
+				p.id,
+				p.productBrand.brandName,
+				p.productName,
+				p.unit,
+				mainProductImage.url
+			)
+			.orderBy(
+				averageRatingExpression.desc(),
+				reviewCountExpression.desc(),
+				p.createdAt.desc(),
+				p.id.desc()
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1L)
+			.fetch();
+
+		boolean hasNext = content.size() > pageable.getPageSize();
+		if (hasNext) {
+			content.remove(content.size() - 1);
+		}
+
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
+
+	@Override
+	public Long countByProductBrandName(String productBrandName) {
+		return queryFactory
+			.select(product.count())
+			.from(product)
+			.join(product.productBrand)
+			.where(product.productBrand.brandName.eq(productBrandName))
+			.fetchOne();
+	}
 }

--- a/src/main/java/com/lokoko/domain/productBrand/api/ProductBrandController.java
+++ b/src/main/java/com/lokoko/domain/productBrand/api/ProductBrandController.java
@@ -1,22 +1,26 @@
 package com.lokoko.domain.productBrand.api;
 
-import com.lokoko.domain.productBrand.api.dto.message.ResponseMessage;
-import com.lokoko.domain.productBrand.api.dto.response.ProductBrandNameListResponse;
-import com.lokoko.domain.productBrand.application.mapper.ProductBrandMapper;
-import com.lokoko.domain.productBrand.application.service.ProductBrandGetService;
-import com.lokoko.domain.productBrand.domain.entity.ProductBrand;
-import com.lokoko.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import com.lokoko.domain.productBrand.api.dto.message.ResponseMessage;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoListResponse;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandNameListResponse;
+import com.lokoko.domain.productBrand.application.mapper.ProductBrandMapper;
+import com.lokoko.domain.productBrand.application.service.ProductBrandGetService;
+import com.lokoko.domain.productBrand.application.usecase.ProductBrandUsecase;
+import com.lokoko.domain.productBrand.domain.entity.ProductBrand;
+import com.lokoko.global.common.response.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "PRODUCT BRAND")
 @RestController
@@ -24,17 +28,31 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProductBrandController {
 
-    private final ProductBrandGetService productBrandGetService;
-    private final ProductBrandMapper productBrandMapper;
+	private final ProductBrandGetService productBrandGetService;
+	private final ProductBrandUsecase productBrandUsecase;
+	private final ProductBrandMapper productBrandMapper;
 
-    @Operation(summary = "상품 브랜드 이름 리스트 조회 (전체 / A~Z / 0)")
-    @GetMapping
-    public ApiResponse<ProductBrandNameListResponse> getProductBrandNames(
-            @RequestParam(required = false) String startsWith
-    ) {
-        List<ProductBrand> brands = productBrandGetService.getBrandNames(startsWith);
-        ProductBrandNameListResponse response = productBrandMapper.toBrandNameListResponse(brands);
+	@Operation(summary = "상품 브랜드 이름 리스트 조회 (전체 / A~Z / 0)")
+	@GetMapping
+	public ApiResponse<ProductBrandNameListResponse> getProductBrandNames(
+		@RequestParam(required = false) String startsWith
+	) {
+		List<ProductBrand> brands = productBrandGetService.getBrandNames(startsWith);
+		ProductBrandNameListResponse response = productBrandMapper.toBrandNameListResponse(brands);
 
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.PRODUCT_BRAND_GET_SUCCESS.getMessage(), response);
-    }
+		return ApiResponse.success(HttpStatus.OK, ResponseMessage.PRODUCT_BRAND_GET_SUCCESS.getMessage(), response);
+	}
+
+	@Operation(summary = "브랜드 이름으로 상품 목록 조회 (페이지네이션, 별점 높은 순)")
+	@GetMapping("/products")
+	public ApiResponse<ProductBrandInfoListResponse> getProductsByBrandName(
+		@RequestParam @NotBlank String productBrandName,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "12") int size
+	) {
+		ProductBrandInfoListResponse response = productBrandUsecase.getProductsByBrandName(productBrandName, page,
+			size);
+
+		return ApiResponse.success(HttpStatus.OK, ResponseMessage.PRODUCT_LIST_FETCH_SUCCESS.getMessage(), response);
+	}
 }

--- a/src/main/java/com/lokoko/domain/productBrand/api/ProductBrandController.java
+++ b/src/main/java/com/lokoko/domain/productBrand/api/ProductBrandController.java
@@ -37,7 +37,7 @@ public class ProductBrandController {
 	@Operation(summary = "브랜드 이름으로 상품 목록 조회 (페이지네이션, 별점 높은 순)")
 	@GetMapping("/products")
 	public ApiResponse<ProductBrandInfoListResponse> getProductsByBrandName(
-		@RequestParam String productBrandName,
+		@RequestParam(required = false) String productBrandName,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "12") int size
 	) {

--- a/src/main/java/com/lokoko/domain/productBrand/api/ProductBrandController.java
+++ b/src/main/java/com/lokoko/domain/productBrand/api/ProductBrandController.java
@@ -14,7 +14,6 @@ import com.lokoko.global.common.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "PRODUCT BRAND")
@@ -38,7 +37,7 @@ public class ProductBrandController {
 	@Operation(summary = "브랜드 이름으로 상품 목록 조회 (페이지네이션, 별점 높은 순)")
 	@GetMapping("/products")
 	public ApiResponse<ProductBrandInfoListResponse> getProductsByBrandName(
-		@RequestParam @NotBlank String productBrandName,
+		@RequestParam String productBrandName,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "12") int size
 	) {

--- a/src/main/java/com/lokoko/domain/productBrand/api/ProductBrandController.java
+++ b/src/main/java/com/lokoko/domain/productBrand/api/ProductBrandController.java
@@ -1,7 +1,5 @@
 package com.lokoko.domain.productBrand.api;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,10 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.lokoko.domain.productBrand.api.dto.message.ResponseMessage;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoListResponse;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandNameListResponse;
-import com.lokoko.domain.productBrand.application.mapper.ProductBrandMapper;
-import com.lokoko.domain.productBrand.application.service.ProductBrandGetService;
 import com.lokoko.domain.productBrand.application.usecase.ProductBrandUsecase;
-import com.lokoko.domain.productBrand.domain.entity.ProductBrand;
 import com.lokoko.global.common.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,17 +23,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductBrandController {
 
-	private final ProductBrandGetService productBrandGetService;
 	private final ProductBrandUsecase productBrandUsecase;
-	private final ProductBrandMapper productBrandMapper;
 
 	@Operation(summary = "상품 브랜드 이름 리스트 조회 (전체 / A~Z / 0)")
 	@GetMapping
 	public ApiResponse<ProductBrandNameListResponse> getProductBrandNames(
 		@RequestParam(required = false) String startsWith
 	) {
-		List<ProductBrand> brands = productBrandGetService.getBrandNames(startsWith);
-		ProductBrandNameListResponse response = productBrandMapper.toBrandNameListResponse(brands);
+		ProductBrandNameListResponse response = productBrandUsecase.getBrandNames(startsWith);
 
 		return ApiResponse.success(HttpStatus.OK, ResponseMessage.PRODUCT_BRAND_GET_SUCCESS.getMessage(), response);
 	}

--- a/src/main/java/com/lokoko/domain/productBrand/api/dto/ProductBrandInfoProjection.java
+++ b/src/main/java/com/lokoko/domain/productBrand/api/dto/ProductBrandInfoProjection.java
@@ -1,4 +1,4 @@
-package com.lokoko.domain.productBrand.api.dto.response;
+package com.lokoko.domain.productBrand.api.dto;
 
 public record ProductBrandInfoProjection(
 	String productBrandName,

--- a/src/main/java/com/lokoko/domain/productBrand/api/dto/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/productBrand/api/dto/message/ResponseMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ResponseMessage {
-    PRODUCT_BRAND_GET_SUCCESS("상품 브랜드 조회에 성공했습니다.");
+	PRODUCT_BRAND_GET_SUCCESS("상품 브랜드 조회에 성공했습니다."),
+	PRODUCT_LIST_FETCH_SUCCESS("브랜드 이름으로 상품 목록 조회에 성공했습니다.");
 
-    private final String message;
+	private final String message;
 }

--- a/src/main/java/com/lokoko/domain/productBrand/api/dto/response/ProductBrandInfoListResponse.java
+++ b/src/main/java/com/lokoko/domain/productBrand/api/dto/response/ProductBrandInfoListResponse.java
@@ -1,0 +1,21 @@
+package com.lokoko.domain.productBrand.api.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import java.util.List;
+
+import com.lokoko.global.common.response.PageableResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ProductBrandInfoListResponse(
+
+	@Schema(requiredMode = REQUIRED, description = "상품 목록")
+	List<ProductBrandInfoResponse> products,
+
+	@Schema(requiredMode = REQUIRED, description = "페이지 정보")
+	PageableResponse pageInfo
+) {
+}

--- a/src/main/java/com/lokoko/domain/productBrand/api/dto/response/ProductBrandInfoProjection.java
+++ b/src/main/java/com/lokoko/domain/productBrand/api/dto/response/ProductBrandInfoProjection.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.productBrand.api.dto.response;
+
+public record ProductBrandInfoProjection(
+	String productBrandName,
+	String productName,
+	String unit,
+	Double averageRating,
+	String imageUrl
+) {
+}

--- a/src/main/java/com/lokoko/domain/productBrand/api/dto/response/ProductBrandInfoResponse.java
+++ b/src/main/java/com/lokoko/domain/productBrand/api/dto/response/ProductBrandInfoResponse.java
@@ -1,0 +1,27 @@
+package com.lokoko.domain.productBrand.api.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ProductBrandInfoResponse(
+
+	@Schema(requiredMode = REQUIRED, description = "상품 브랜드명")
+	String productBrandName,
+
+	@Schema(requiredMode = REQUIRED, description = "상품명")
+	String productName,
+
+	@Schema(requiredMode = REQUIRED, description = "용량")
+	String unit,
+
+	@Schema(requiredMode = REQUIRED, description = "평균 별점")
+	Double rating,
+
+	@Schema(requiredMode = REQUIRED, description = "대표 이미지 URL")
+	String imageUrl
+) {
+}
+

--- a/src/main/java/com/lokoko/domain/productBrand/application/mapper/ProductBrandMapper.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/mapper/ProductBrandMapper.java
@@ -5,8 +5,8 @@ import java.util.List;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
+import com.lokoko.domain.productBrand.api.dto.ProductBrandInfoProjection;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoListResponse;
-import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoResponse;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandName;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandNameListResponse;

--- a/src/main/java/com/lokoko/domain/productBrand/application/mapper/ProductBrandMapper.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/mapper/ProductBrandMapper.java
@@ -1,27 +1,65 @@
 package com.lokoko.domain.productBrand.application.mapper;
 
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoListResponse;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoResponse;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandName;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandNameListResponse;
 import com.lokoko.domain.productBrand.domain.entity.ProductBrand;
-import org.springframework.stereotype.Component;
-
-import java.util.List;
+import com.lokoko.global.common.response.PageableResponse;
+import com.lokoko.global.utils.RatingConverter;
 
 @Component
 public class ProductBrandMapper {
 
-    public ProductBrandNameListResponse toBrandNameListResponse(List<ProductBrand> brands) {
-        return ProductBrandNameListResponse.builder()
-                .brandNames(brands.stream()
-                        .map(this::toBrandName)
-                        .toList())
-                .build();
-    }
+	public ProductBrandNameListResponse toBrandNameListResponse(List<ProductBrand> brands) {
+		return ProductBrandNameListResponse.builder()
+			.brandNames(brands.stream()
+				.map(this::toBrandName)
+				.toList())
+			.build();
+	}
 
-    private ProductBrandName toBrandName(ProductBrand productBrand) {
-        return ProductBrandName.builder()
-                .productBrandId(productBrand.getId())
-                .productBrandName(productBrand.getBrandName())
-                .build();
-    }
+	private ProductBrandName toBrandName(ProductBrand productBrand) {
+		return ProductBrandName.builder()
+			.productBrandId(productBrand.getId())
+			.productBrandName(productBrand.getBrandName())
+			.build();
+	}
+
+	public ProductBrandInfoResponse toProductBrandInfoResponse(ProductBrandInfoProjection productBrandInfoProjection) {
+		double displayRating = RatingConverter.toDisplayRating(productBrandInfoProjection.averageRating());
+
+		return ProductBrandInfoResponse.builder()
+			.productBrandName(productBrandInfoProjection.productBrandName())
+			.productName(productBrandInfoProjection.productName())
+			.unit(productBrandInfoProjection.unit())
+			.rating(displayRating)
+			.imageUrl(productBrandInfoProjection.imageUrl())
+			.build();
+	}
+
+	public ProductBrandInfoListResponse toProductBrandInfoList(
+		Slice<ProductBrandInfoProjection> slice,
+		List<ProductBrandInfoResponse> products,
+		long totalElements
+	) {
+		PageableResponse pageInfo = PageableResponse.of(
+			slice.getNumber(),
+			slice.getSize(),
+			slice.getNumberOfElements(),
+			slice.isLast(),
+			totalElements
+		);
+
+		return ProductBrandInfoListResponse.builder()
+			.products(products)
+			.pageInfo(pageInfo)
+			.build();
+	}
 }

--- a/src/main/java/com/lokoko/domain/productBrand/application/service/ProductBrandGetService.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/service/ProductBrandGetService.java
@@ -47,7 +47,7 @@ public class ProductBrandGetService {
 	public Slice<ProductBrandInfoProjection> getProductsByBrandName(String productBrandName, int page, int size) {
 		Pageable pageable = PageRequest.of(page, size);
 
-		return productRepository.getProductsByBrandName(productBrandName, pageable);
+		return productRepository.findProductsByBrandName(productBrandName, pageable);
 	}
 
 	public Long countProductsByBrandName(String productBrandName) {

--- a/src/main/java/com/lokoko/domain/productBrand/application/service/ProductBrandGetService.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/service/ProductBrandGetService.java
@@ -1,39 +1,58 @@
 package com.lokoko.domain.productBrand.application.service;
 
-import com.lokoko.domain.productBrand.domain.entity.ProductBrand;
-import com.lokoko.domain.productBrand.domain.repository.ProductBrandRepository;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import com.lokoko.domain.product.domain.repository.ProductRepository;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
+import com.lokoko.domain.productBrand.domain.entity.ProductBrand;
+import com.lokoko.domain.productBrand.domain.repository.ProductBrandRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProductBrandGetService {
 
-    private final ProductBrandRepository productBrandRepository;
+	private final ProductBrandRepository productBrandRepository;
+	private final ProductRepository productRepository;
 
-    public List<ProductBrand> getBrandNames(String startsWith) {
+	public List<ProductBrand> getBrandNames(String startsWith) {
 
-        Sort sort = Sort.by(Sort.Direction.ASC, "brandName");
+		Sort sort = Sort.by(Sort.Direction.ASC, "brandName");
 
-        // 파라미터 없으면 전체
-        if (startsWith == null || startsWith.isBlank()) {
-            return productBrandRepository.findAll(sort);
-        }
+		// 파라미터 없으면 전체
+		if (startsWith == null || startsWith.isBlank()) {
+			return productBrandRepository.findAll(sort);
+		}
 
-        String firstChar = startsWith.trim();
+		String firstChar = startsWith.trim();
 
-        // 혹시 알파벳 여러 글자 들어온 경우
-        String prefix = firstChar.substring(0, 1).toUpperCase();
+		// 혹시 알파벳 여러 글자 들어온 경우
+		String prefix = firstChar.substring(0, 1).toUpperCase();
 
-        if (firstChar.equals("0")) {
-            return productBrandRepository.findAllStartsWithDigit();
-        }
-        return productBrandRepository.findByBrandNameStartingWithIgnoreCase(prefix, sort);
-    }
+		if (firstChar.equals("0")) {
+			return productBrandRepository.findAllStartsWithDigit();
+		}
+		return productBrandRepository.findByBrandNameStartingWithIgnoreCase(prefix, sort);
+	}
+
+	public Slice<ProductBrandInfoProjection> getProductsByBrandName(String productBrandName, int page, int size) {
+		Pageable pageable = PageRequest.of(page, size);
+
+		return productRepository.getProductsByBrandName(productBrandName, pageable);
+	}
+
+	public Long countProductsByBrandName(String productBrandName) {
+
+		return productRepository.countByProductBrandName(productBrandName);
+	}
 }
 

--- a/src/main/java/com/lokoko/domain/productBrand/application/service/ProductBrandGetService.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/service/ProductBrandGetService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.lokoko.domain.product.domain.repository.ProductRepository;
-import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
+import com.lokoko.domain.productBrand.api.dto.ProductBrandInfoProjection;
 import com.lokoko.domain.productBrand.domain.entity.ProductBrand;
 import com.lokoko.domain.productBrand.domain.repository.ProductBrandRepository;
 

--- a/src/main/java/com/lokoko/domain/productBrand/application/service/ProductBrandGetService.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/service/ProductBrandGetService.java
@@ -47,12 +47,21 @@ public class ProductBrandGetService {
 	public Slice<ProductBrandInfoProjection> getProductsByBrandName(String productBrandName, int page, int size) {
 		Pageable pageable = PageRequest.of(page, size);
 
+		/*
+		 * TODO: 추후 캐싱 추가
+		 */
+		if (productBrandName == null || productBrandName.isBlank()) {
+			return productRepository.findProductsOrderedByRating(pageable);
+		}
 		return productRepository.findProductsByBrandName(productBrandName, pageable);
 	}
 
 	public Long countProductsByBrandName(String productBrandName) {
-
+		if (productBrandName == null || productBrandName.isBlank()) {
+			return productRepository.countAllProducts();
+		}
 		return productRepository.countByProductBrandName(productBrandName);
 	}
+
 }
 

--- a/src/main/java/com/lokoko/domain/productBrand/application/usecase/ProductBrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/usecase/ProductBrandUsecase.java
@@ -1,0 +1,38 @@
+package com.lokoko.domain.productBrand.application.usecase;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoListResponse;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoResponse;
+import com.lokoko.domain.productBrand.application.mapper.ProductBrandMapper;
+import com.lokoko.domain.productBrand.application.service.ProductBrandGetService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductBrandUsecase {
+
+	private final ProductBrandGetService productBrandGetService;
+
+	private ProductBrandMapper productBrandMapper;
+
+	@Transactional(readOnly = true)
+	public ProductBrandInfoListResponse getProductsByBrandName(String productBrandName, int page, int size) {
+		Slice<ProductBrandInfoProjection> slice =
+			productBrandGetService.getProductsByBrandName(productBrandName, page, size);
+
+		Long totalElements = productBrandGetService.countProductsByBrandName(productBrandName);
+
+		List<ProductBrandInfoResponse> products = slice.getContent().stream()
+			.map(productBrandMapper::toProductBrandInfoResponse)
+			.toList();
+
+		return productBrandMapper.toProductBrandInfoList(slice, products, totalElements);
+	}
+}

--- a/src/main/java/com/lokoko/domain/productBrand/application/usecase/ProductBrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/usecase/ProductBrandUsecase.java
@@ -6,8 +6,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.lokoko.domain.productBrand.api.dto.ProductBrandInfoProjection;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoListResponse;
-import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoResponse;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandNameListResponse;
 import com.lokoko.domain.productBrand.application.mapper.ProductBrandMapper;

--- a/src/main/java/com/lokoko/domain/productBrand/application/usecase/ProductBrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/usecase/ProductBrandUsecase.java
@@ -9,8 +9,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoListResponse;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoProjection;
 import com.lokoko.domain.productBrand.api.dto.response.ProductBrandInfoResponse;
+import com.lokoko.domain.productBrand.api.dto.response.ProductBrandNameListResponse;
 import com.lokoko.domain.productBrand.application.mapper.ProductBrandMapper;
 import com.lokoko.domain.productBrand.application.service.ProductBrandGetService;
+import com.lokoko.domain.productBrand.domain.entity.ProductBrand;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,7 +22,13 @@ public class ProductBrandUsecase {
 
 	private final ProductBrandGetService productBrandGetService;
 
-	private ProductBrandMapper productBrandMapper;
+	private final ProductBrandMapper productBrandMapper;
+
+	@Transactional(readOnly = true)
+	public ProductBrandNameListResponse getBrandNames(String startsWith) {
+		List<ProductBrand> brands = productBrandGetService.getBrandNames(startsWith);
+		return productBrandMapper.toBrandNameListResponse(brands);
+	}
 
 	@Transactional(readOnly = true)
 	public ProductBrandInfoListResponse getProductsByBrandName(String productBrandName, int page, int size) {

--- a/src/main/java/com/lokoko/domain/productBrand/application/usecase/ProductBrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/productBrand/application/usecase/ProductBrandUsecase.java
@@ -32,9 +32,9 @@ public class ProductBrandUsecase {
 
 	@Transactional(readOnly = true)
 	public ProductBrandInfoListResponse getProductsByBrandName(String productBrandName, int page, int size) {
-		Slice<ProductBrandInfoProjection> slice =
-			productBrandGetService.getProductsByBrandName(productBrandName, page, size);
 
+		Slice<ProductBrandInfoProjection> slice = productBrandGetService.getProductsByBrandName(productBrandName, page,
+			size);
 		Long totalElements = productBrandGetService.countProductsByBrandName(productBrandName);
 
 		List<ProductBrandInfoResponse> products = slice.getContent().stream()

--- a/src/main/java/com/lokoko/global/utils/RatingConverter.java
+++ b/src/main/java/com/lokoko/global/utils/RatingConverter.java
@@ -1,25 +1,27 @@
 package com.lokoko.global.utils;
 
-import com.lokoko.domain.productReview.domain.entity.enums.Rating;
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 
-@Converter(autoApply = true)
-public class RatingConverter implements AttributeConverter<Rating, Integer> {
+public final class RatingConverter {
 
-    @Override
-    public Integer convertToDatabaseColumn(Rating rating) {
-        if (rating == null) {
-            return null;
-        }
-        return rating.getValue();
-    }
+	private static final int DEFAULT_SCALE = 1;
+	private static final RoundingMode DEFAULT_ROUNDING_MODE = RoundingMode.HALF_UP;
 
-    @Override
-    public Rating convertToEntityAttribute(Integer dbData) {
-        if (dbData == null) {
-            return null;
-        }
-        return Rating.fromValue(dbData);
-    }
+	private RatingConverter() {
+	}
+
+	public static double toDisplayRating(Double averageRating) {
+		return toDisplayRating(averageRating, DEFAULT_SCALE, DEFAULT_ROUNDING_MODE);
+	}
+
+	public static double toDisplayRating(Double averageRating, int scale, RoundingMode roundingMode) {
+		if (averageRating == null) {
+			return 0.0;
+		}
+
+		return BigDecimal.valueOf(averageRating)
+			.setScale(scale, roundingMode)
+			.doubleValue();
+	}
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #437 

## 작업 내용 💻

- [x] 기존에 있던 상품 브랜드 이름 리스트 조회 API 유스케이스 적용
- [x] 별점 반올림 유틸 메서드 분리 (계산 로직 관련해서는 어제 가볍게 얘기한대로 다같이 말해보면 좋을거같아요. 별도 필드 추가, 계산 공통 로직 분리 등등)
- [x] 브랜드 이름으로 상품 검색 API 구현 

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 정렬은 기획 의도에 따라서 별점 높은 순으로 하였고, 별점이 같을시 리뷰가 많은 순으로 정렬했습니다
- 리뷰가 없는 상품에 경우에는 0점으로 계산되도록 하였습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 브랜드별 상품 목록 조회용 공개 API 추가(브랜드명·페이지네이션 지원)
  * 브랜드별 상품 응답 포맷 및 개별 상품 정보 DTO 추가

* **개선 사항**
  * 브랜드 기반 상품 조회 성능 및 페이징/정렬 개선
  * 인기·신상품 조회와 평점 기반 정렬 기능 확대
  * 검색(토큰 기반) 결과 페이징 일관성 강화
  * 평점 표기 방식 통일 및 소수점 처리 개선
  * 상품 이미지 우선순위 선택 로직 보강

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->