### PR TITLE
[FIX] #451 : 어드민이 생성한 캠페인이 메인페이지에서 조회되지 않는 문제 수정 

### DIFF
--- a/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
+++ b/src/main/java/com/lokoko/domain/campaign/api/CampaignController.java
@@ -59,13 +59,12 @@ public class CampaignController {
     @Operation(summary = "메인페이지에서 캠페인 리스트 조회")
     @GetMapping
     public ApiResponse<MainPageCampaignListResponse> getCampaignsInMainPage(
-            @Parameter(hidden = true) @CurrentUser Long userId,
             @RequestParam LanguageFilter lang,
             @RequestParam CampaignProductTypeFilter category,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "6") int size) {
 
-        MainPageCampaignListResponse response = campaignReadService.getCampaignsInMainPage(userId, lang, category, page,
+        MainPageCampaignListResponse response = campaignReadService.getCampaignsInMainPage(lang, category, page,
                 size);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.MAIN_PAGE_CAMPAIGNS_GET_SUCCESS.getMessage(),
                 response);

--- a/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
+++ b/src/main/java/com/lokoko/domain/campaign/application/service/CampaignGetService.java
@@ -126,8 +126,8 @@ public class CampaignGetService {
         Hibernate.initialize(campaign.getEligibilityRequirements());
     }
 
-    public MainPageCampaignListResponse getCampaignsInMainPage(Long userId, LanguageFilter lang, CampaignProductTypeFilter category, int page, int size) {
-        return campaignRepository.findCampaignsInMainPage(userId, lang, category, PageRequest.of(page, size));
+    public MainPageCampaignListResponse getCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category, int page, int size) {
+        return campaignRepository.findCampaignsInMainPage(lang, category, PageRequest.of(page, size));
     }
 
     public MainPageUpcomingCampaignListResponse getUpcomingCampaignsInMainPage(LanguageFilter lang, CampaignProductTypeFilter category) {

--- a/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/campaign/domain/repository/CampaignRepositoryCustom.java
@@ -20,7 +20,7 @@ import org.springframework.data.domain.Pageable;
 public interface CampaignRepositoryCustom {
 
 
-    MainPageCampaignListResponse findCampaignsInMainPage(Long userId, LanguageFilter lang,
+    MainPageCampaignListResponse findCampaignsInMainPage(LanguageFilter lang,
                                                          CampaignProductTypeFilter category, Pageable pageable);
 
     MainPageUpcomingCampaignListResponse findUpcomingCampaignsInMainPage(LanguageFilter lang,


### PR DESCRIPTION
## Related issue 🛠

- closed #450 

## 작업 내용 💻

- 어드민이 만든 캠페인의 경우 brand 와 연관관계가 따로 존재하지 않습니다. 즉, brandName 만 가집니다.
그러한 이유로 .. 수정전 쿼리에서 campaign.brand.brandName 을 수행할때, campaign 과 brand 사이에 묵시적 inner join 이 발생하고, 
어드민이 만든 캠페인은 brand 와 연관관계가 없기 때문에 조인 결과가 반환되지 않았던 것입니다.

우리 도메인에서는
- 어드민이 만든 캠페인(brand 와 연관관계가 없고, brandName 필드만 자체적으로 가짐)
- 브랜드가 직접 만든 캠페인(brand 와 연관관계가 있음)
위 처럼 두가지 케이스가 존재하기 때문에,

brandName 을 반환하는 조건식을 따로 작성하여 문제를 해결하였습니다. 
즉, campaign.brand 가 null 이라면 , camapign.brandName 을 반환하고, 
null 이 아니라면 campaign.brand.brandName 을 반환하는 식으로요.


## 스크린샷 📷

로컬에서 어드민으로 캠페인 생성후, 메인페이지에 정상적으로 뜨는 것 확인했습니다.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 캠페인 브랜드명이 없을 때 표시되지 않는 문제를 개선했습니다.

* **리팩터링**
  * 메인 페이지 캠페인 조회 API가 간소화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->