### PR TITLE
[REFACTOR] #453 상품리뷰 도메인 리팩토링

### DIFF
--- a/src/main/java/com/lokoko/domain/media/video/domain/repository/ReviewVideoRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/media/video/domain/repository/ReviewVideoRepositoryImpl.java
@@ -1,8 +1,5 @@
 package com.lokoko.domain.media.video.domain.repository;
 
-
-import static com.lokoko.domain.like.domain.entity.QReviewLike.reviewLike;
-
 import com.lokoko.domain.like.domain.entity.QReviewLikeCount;
 import com.lokoko.domain.media.video.domain.entity.QReviewVideo;
 import com.lokoko.domain.product.domain.entity.QProduct;
@@ -33,7 +30,7 @@ public class ReviewVideoRepositoryImpl implements ReviewVideoRepositoryCustom {
                         product.id,
                         product.productBrand.brandName,
                         product.productName,
-                        reviewLike.count().intValue(),
+                        reviewLikeCount.likeCount.coalesce(0L),
                         // 일단 여기서 rank 0, service에서 추가
                         Expressions.constant(0),
                         reviewVideo.mediaFile.fileUrl

--- a/src/main/java/com/lokoko/domain/productReview/api/ReviewController.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/ReviewController.java
@@ -1,7 +1,5 @@
 package com.lokoko.domain.productReview.api;
 
-import static com.lokoko.domain.productReview.api.message.ResponseMessage.REVIEW_DELETE_SUCCESS;
-
 import com.lokoko.domain.media.api.dto.request.MediaPresignedUrlRequest;
 import com.lokoko.domain.media.api.dto.response.MediaPresignedUrlResponse;
 import com.lokoko.domain.productReview.api.dto.request.ReviewReceiptRequest;
@@ -123,18 +121,16 @@ public class ReviewController {
 
     @Operation(summary = "영상 리뷰 상세 조회 (가장 마지막 뎁스)")
     @GetMapping("/details/{reviewId}/video")
-    public ApiResponse<VideoReviewDetailResponse> getVideoReviewDetails(@PathVariable Long reviewId,
-                                                                        @Parameter(hidden = true) @CurrentUser Long userId) {
-        VideoReviewDetailResponse response = reviewDetailsService.getVideoReviewDetails(reviewId, userId);
+    public ApiResponse<VideoReviewDetailResponse> getVideoReviewDetails(@PathVariable Long reviewId) {
+        VideoReviewDetailResponse response = reviewDetailsService.getVideoReviewDetails(reviewId);
 
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.VIDEO_REVIEW_DETAIL_SUCCESS.getMessage(), response);
     }
 
     @Operation(summary = "사진 리뷰 상세 조회 (가장 마지막 뎁스")
     @GetMapping("/details/{reviewId}/image")
-    public ApiResponse<ImageReviewDetailResponse> getImageReviewDetails(@PathVariable Long reviewId,
-                                                                        @Parameter(hidden = true) @CurrentUser Long userId) {
-        ImageReviewDetailResponse response = reviewDetailsService.getImageReviewDetails(reviewId, userId);
+    public ApiResponse<ImageReviewDetailResponse> getImageReviewDetails(@PathVariable Long reviewId) {
+        ImageReviewDetailResponse response = reviewDetailsService.getImageReviewDetails(reviewId);
 
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.IMAGE_REVIEW_DETAIL_SUCCESS.getMessage(), response);
     }
@@ -144,7 +140,7 @@ public class ReviewController {
     public ApiResponse<Void> deleteReview(@Parameter(hidden = true) @CurrentUser Long userId,
                                           @PathVariable Long reviewId) {
         reviewService.deleteReview(userId, reviewId);
-        return ApiResponse.success(HttpStatus.OK, REVIEW_DELETE_SUCCESS.getMessage());
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.REVIEW_DELETE_SUCCESS.getMessage());
     }
 
     @Operation(summary = "브랜드명 기준 영상 리뷰 검색 (brandName 없으면 전체 조회)")

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewDetailResponse.java
@@ -18,8 +18,6 @@ public record ImageReviewDetailResponse(
         @Schema(requiredMode = REQUIRED)
         LocalDateTime writtenTime,
         @Schema(requiredMode = REQUIRED)
-        Boolean receiptUploaded,
-        @Schema(requiredMode = REQUIRED)
         String positiveComment,
         @Schema(requiredMode = REQUIRED)
         String negativeComment,
@@ -29,7 +27,6 @@ public record ImageReviewDetailResponse(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "0.0")
         @Schema(requiredMode = REQUIRED)
         Double rating,
-        String option,
         @Schema(requiredMode = REQUIRED)
         Long likeCount,
         @Schema(requiredMode = REQUIRED)
@@ -40,16 +37,12 @@ public record ImageReviewDetailResponse(
         String productName,
         @Schema(requiredMode = REQUIRED)
         String productImageUrl,
-        String receiptImageUrl,
-        @Schema(requiredMode = REQUIRED)
-        Boolean isLiked,
         @Schema(requiredMode = REQUIRED)
         Long productId
 
 ) {
     public static ImageReviewDetailResponse from(Review review, List<ReviewImage> reviewImages,
-                                                 long totalLikes, String receiptImage, ProductImage productImage,
-                                                 Boolean isLiked) {
+                                                 long totalLikes, ProductImage productImage) {
         Product product = review.getProduct();
         User author = review.getAuthor();
 
@@ -57,27 +50,19 @@ public record ImageReviewDetailResponse(
                 .map(reviewImage -> reviewImage.getMediaFile().getFileUrl())
                 .toList();
 
-        String optionName = review.getProductOption() != null
-                ? review.getProductOption().getOptionName()
-                : null;
-
         return new ImageReviewDetailResponse(
                 review.getId(),
                 review.getModifiedAt(),
-                review.isReceiptUploaded(),
                 review.getPositiveContent(),
                 review.getNegativeContent(),
                 author.getName(),
                 author.getProfileImageUrl(),
                 (double) review.getRating().getValue(),
-                optionName,
                 totalLikes,
                 images,
                 product.getProductBrand().getBrandName(),
                 product.getProductName(),
                 productImage.getUrl(),
-                receiptImage,
-                isLiked,
                 product.getId()
         );
     }

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewProductDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewProductDetailResponse.java
@@ -14,8 +14,6 @@ public record ImageReviewProductDetailResponse(
         @Schema(requiredMode = REQUIRED)
         LocalDateTime writtenTime,
         @Schema(requiredMode = REQUIRED)
-        Boolean receiptUploaded,
-        @Schema(requiredMode = REQUIRED)
         String positiveComment,
         @Schema(requiredMode = REQUIRED)
         String negativeComment,
@@ -29,8 +27,6 @@ public record ImageReviewProductDetailResponse(
         @Schema(requiredMode = REQUIRED)
         Double rating,
         @Schema(requiredMode = REQUIRED)
-        String option,
-        @Schema(requiredMode = REQUIRED)
         Integer likeCount,
         @Schema(requiredMode = REQUIRED)
         List<String> images,
@@ -41,22 +37,20 @@ public record ImageReviewProductDetailResponse(
 ) {
 
     public ImageReviewProductDetailResponse(Long reviewId, LocalDateTime writtenTime,
-                                            Boolean receiptUploaded, String positiveComment,
+                                             String positiveComment,
                                             String negativeComment, String profileImageUrl, String authorName,
-                                            Long authorId, Double rating, String option,
+                                            Long authorId, Double rating,
                                             Integer likeCount, List<String> images,
                                             Boolean isLiked, Boolean isMine
     ) {
         this.reviewId = reviewId;
         this.writtenTime = writtenTime;
-        this.receiptUploaded = receiptUploaded;
         this.positiveComment = positiveComment;
         this.negativeComment = negativeComment;
         this.profileImageUrl = profileImageUrl;
         this.authorName = authorName;
         this.authorId = authorId;
         this.rating = rating;
-        this.option = option;
         this.likeCount = likeCount;
         this.images = images != null ? new ArrayList<>(images) : new ArrayList<>();
         this.isLiked = isLiked;

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/VideoReviewDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/VideoReviewDetailResponse.java
@@ -32,22 +32,15 @@ public record VideoReviewDetailResponse(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "0.0")
         @Schema(requiredMode = REQUIRED)
         Double rating,
-        String option,
         @Schema(requiredMode = REQUIRED)
         LocalDateTime uploadAt,
         @Schema(requiredMode = REQUIRED)
         String productImageUrl,
-        String receiptImageUrl,
-        @Schema(requiredMode = REQUIRED)
-        Boolean receiptUploaded,
-        @Schema(requiredMode = REQUIRED)
-        Boolean isLiked,
         @Schema(requiredMode = REQUIRED)
         Long productId
 ) {
     public static VideoReviewDetailResponse from(Review review, List<ReviewVideo> reviewVideos, long likeCount,
-                                                 String receiptImageUrl, ProductImage productImage,
-                                                 Boolean isLiked) {
+                                                 ProductImage productImage) {
         List<String> videoUrls = reviewVideos.stream()
                 .map(rv -> rv.getMediaFile().getFileUrl())
                 .toList();
@@ -56,10 +49,6 @@ public record VideoReviewDetailResponse(
                 .map(ReviewVideo::getCreatedAt)
                 .max(LocalDateTime::compareTo)
                 .orElse(review.getCreatedAt());
-
-        String optionName = review.getProductOption() != null
-                ? review.getProductOption().getOptionName()
-                : null;
 
         return new VideoReviewDetailResponse(
                 review.getId(),
@@ -72,12 +61,8 @@ public record VideoReviewDetailResponse(
                 review.getAuthor().getProfileImageUrl(),
                 review.getAuthor().getName(),
                 (double) review.getRating().getValue(),
-                optionName,
                 uploadAt,
                 productImage.getUrl(),
-                receiptImageUrl,
-                review.isReceiptUploaded(),
-                isLiked,
                 review.getProduct().getId()
         );
     }

--- a/src/main/java/com/lokoko/domain/productReview/application/service/ReviewService.java
+++ b/src/main/java/com/lokoko/domain/productReview/application/service/ReviewService.java
@@ -67,8 +67,8 @@ public class ReviewService {
     private static final int MAX_VIDEO_REVIEW_COUNT = 1;
     private static final int MAX_IMAGE_REVIEW_COUNT = 5;
 
-    private static final String VIDEO_URL = "video/";
-    private static final String IMAGE_URL = "image/";
+    private static final String VIDEO_URL_PREFIX = "video/";
+    private static final String IMAGE_URL_PREFIX = "image/";
 
     public ReviewReceiptResponse createReceiptPresignedUrl(Long userId,
                                                            ReviewReceiptRequest request) {
@@ -78,7 +78,7 @@ public class ReviewService {
         String mediaType = request.mediaType();
 
         // "image/"로 시작하는지, 슬래시가 포함되어 있는지 검사
-        if (!(mediaType.startsWith(IMAGE_URL)) || !mediaType.contains("/")) {
+        if (!(mediaType.startsWith(IMAGE_URL_PREFIX)) || !mediaType.contains("/")) {
             throw new InvalidMediaTypeException(ErrorMessage.INVALID_MEDIA_TYPE_FORMAT);
         }
 
@@ -101,8 +101,8 @@ public class ReviewService {
 
         List<String> mediaTypes = request.mediaType();
 
-        boolean hasVideo = mediaTypes.stream().anyMatch(type -> type.startsWith(VIDEO_URL));
-        boolean hasImage = mediaTypes.stream().anyMatch(type -> type.startsWith(IMAGE_URL));
+        boolean hasVideo = mediaTypes.stream().anyMatch(type -> type.startsWith(VIDEO_URL_PREFIX));
+        boolean hasImage = mediaTypes.stream().anyMatch(type -> type.startsWith(IMAGE_URL_PREFIX));
 
         validateMediaTypeAndSize(hasVideo, hasImage, mediaTypes);
 
@@ -189,7 +189,7 @@ public class ReviewService {
             int order = 0;
             for (String url : mediaUrls) {
                 MediaFile mediaFile = S3UrlParser.parsePresignedUrl(url);
-                if (url.contains(VIDEO_URL)) {
+                if (url.contains(VIDEO_URL_PREFIX)) {
                     ReviewVideo rv = ReviewVideo.createReviewVideo(mediaFile, order++, review);
                     reviewVideoRepository.save(rv);
                 } else {

--- a/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
@@ -399,7 +399,6 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         Long totalCount = queryFactory
                 .select(review.id.countDistinct())
                 .from(review)
-                .leftJoin(review.productOption, productOption)
                 .join(review.product, product)
                 .where(product.id.eq(productId))
                 .fetchOne();
@@ -454,18 +453,15 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                 .select(
                         review.id,
                         review.modifiedAt,
-                        review.receiptUploaded,
                         review.positiveContent,
                         review.negativeContent,
                         review.author.profileImageUrl,
                         review.author.name,
                         review.author.id,
                         ratingAsInt,
-                        productOption.optionName,
                         reviewImage.mediaFile.fileUrl
                 )
                 .from(review)
-                .leftJoin(review.productOption, productOption)
                 .join(review.product, product)
                 .leftJoin(reviewImage).on(reviewImage.review.eq(review))
                 .where(review.id.in(reviewIds))
@@ -481,14 +477,12 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                 return new ImageReviewProductDetailResponse(
                         k,
                         t.get(review.modifiedAt),
-                        t.get(review.receiptUploaded),
                         t.get(review.positiveContent),
                         t.get(review.negativeContent),
                         t.get(review.author.profileImageUrl),
                         t.get(review.author.name),
                         t.get(review.author.id),
                         t.get(ratingAsInt).doubleValue(),
-                        t.get(productOption.optionName),
                         likeCounts.getOrDefault(k, 0L).intValue(),
                         new ArrayList<>(),
                         isLiked,

--- a/src/main/java/com/lokoko/domain/productReview/mapper/ReviewMapper.java
+++ b/src/main/java/com/lokoko/domain/productReview/mapper/ReviewMapper.java
@@ -2,7 +2,6 @@ package com.lokoko.domain.productReview.mapper;
 
 import com.lokoko.domain.media.api.dto.response.MediaPresignedUrlResponse;
 import com.lokoko.domain.product.domain.entity.Product;
-import com.lokoko.domain.product.domain.entity.ProductOption;
 import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
 import com.lokoko.domain.productReview.api.dto.request.ReviewRequest;
@@ -90,20 +89,18 @@ public interface ReviewMapper {
      * @param request 리뷰 작성 요청 DTO
      * @param user    리뷰 작성자 (유저)
      * @param product 리뷰 대상 상품
-     * @param option  선택된 옵션 (nullable 가능)
      * @return Review 엔티티
      */
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "author", source = "user")
     @Mapping(target = "product", source = "product")
-    @Mapping(target = "productOption", source = "option")
     @Mapping(target = "rating", expression = "java(com.lokoko.domain.productReview.domain.entity.enums.Rating.fromValue(request.rating()))")
     @Mapping(target = "positiveContent", source = "request.positiveComment")
     @Mapping(target = "negativeContent", source = "request.negativeComment")
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "modifiedAt", ignore = true)
     @Mapping(target = "receiptUploaded", ignore = true)
-    Review toReview(ReviewRequest request, User user, Product product, @Nullable ProductOption option);
+    Review toReview(ReviewRequest request, User user, Product product);
 
 
     @Mapping(target = "rank", source = "ranking")


### PR DESCRIPTION
## Related issue 🛠

- closed #452 

## 작업 내용 💻

리뷰 도메인에서 리팩토링을 진행했습니다. 

- 리뷰 서비스 계층의 메서드 리팩토링을 진행했습니다. 
상수 추출, public method -> private method 순으로 배치, 검증로직 메서드 추출 등

- 더 이상 사용하지 않는 필드와 그것을 가공하는 로직을 제거하였습니다.
상품 옵션 반환, 영수증 이미지 저장, 영수증 업로드 여부 반환 등..

이번 PR 에서의 변경으로 인해 영향 받는 부분은 아래와 같습니다.
/api/reviews/video
/api/reviews/image
/api/reviews/details/{reviewId}/video
/api/reviews/details/{reviewId}/image
/api/reviews/details/video
/api/reviews/details/image
/api/reviews/{productId}

위 API 모두 정상 동작 테스트 완료하였습니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 리뷰 삭제 기능이 추가되었습니다. 삭제 시 권한 검사 및 연관 데이터 정리가 수행됩니다.

* **리팩토링**
  * 리뷰 상세 응답에서 영수증, 옵션명, 좋아요 여부 등 일부 필드가 제거되어 응답이 간결해졌습니다.
  * 리뷰 상세 조회가 사용자 컨텍스트 없이 동작하도록 단순화되었습니다.
  * 미디어(이미지/비디오) 검증 및 저장 흐름이 개선되고 캐시 무효화 이벤트 발행이 중앙화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->