### PR TITLE
[FIX] #461 product-brand/products API 접근시 401 에러 발생하는 문제 해결 

### DIFF
--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -25,7 +25,7 @@ public class PermitUrlConfig {
                 "/api/reviews/brands/videos",
                 "/api/reviews/brands/images",
                 "/api/product-brand",
-//                "/api/product-brand/products",
+                "/api/product-brand/products",
                 "/api/reviews/brands/summary"
         };
     }

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -25,7 +25,7 @@ public class PermitUrlConfig {
                 "/api/reviews/brands/videos",
                 "/api/reviews/brands/images",
                 "/api/product-brand",
-                "/api/product-brand/products",
+//                "/api/product-brand/products",
                 "/api/reviews/brands/summary"
         };
     }

--- a/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/lokoko/global/config/PermitUrlConfig.java
@@ -25,6 +25,7 @@ public class PermitUrlConfig {
                 "/api/reviews/brands/videos",
                 "/api/reviews/brands/images",
                 "/api/product-brand",
+                "/api/product-brand/products",
                 "/api/reviews/brands/summary"
         };
     }


### PR DESCRIPTION
## Related issue 🛠

- closed #460

## 작업 내용 💻

- [ PermitUrlConfig 에 해당 엔드포인트를 추가하였습니다.] 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 상품 브랜드 제품 조회 API가 공개 접근으로 추가되어, 외부에서 해당 제품 목록을 조회할 수 있게 되었습니다. 접근 권한 설정이 명확해져 서비스 이용성과 접근성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->