### PR TITLE
REFACTOR #465 : 상품 / 리뷰 수 반환 API 리팩토링

### DIFF
--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -31,4 +31,6 @@ public interface ProductRepositoryCustom {
 	Slice<ProductBrandInfoProjection> findProductsOrderedByRating(Pageable pageable);
 
 	Long countAllProducts();
+
+    int countProductsByBrandName(String brandName);
 }

--- a/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/product/domain/repository/ProductRepositoryImpl.java
@@ -9,13 +9,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
-import com.lokoko.domain.like.domain.entity.QProductLike;
 import com.lokoko.domain.media.image.domain.entity.QProductImage;
 import com.lokoko.domain.product.domain.entity.Product;
 import com.lokoko.domain.product.domain.entity.QProduct;
 import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
-import com.lokoko.domain.product.domain.entity.enums.Tag;
 import com.lokoko.domain.productBrand.api.dto.ProductBrandInfoProjection;
 import com.lokoko.domain.productReview.domain.entity.QReview;
 import com.lokoko.domain.productReview.domain.entity.enums.Rating;
@@ -444,4 +442,22 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 			.from(p)
 			.fetchOne();
 	}
+
+    @Override
+    public int countProductsByBrandName(String brandName) {
+        Long count = queryFactory
+                .select(p.count())
+                .from(p)
+                .where(brandNameCondition(brandName))
+                .fetchOne();
+
+        return count != null ? count.intValue() : 0;
+    }
+
+    private BooleanExpression brandNameCondition(String brandName) {
+        if (brandName == null || brandName.isBlank()) {
+            return null;
+        }
+        return p.productBrand.brandName.eq(brandName);
+    }
 }

--- a/src/main/java/com/lokoko/domain/productReview/application/service/ReviewReadService.java
+++ b/src/main/java/com/lokoko/domain/productReview/application/service/ReviewReadService.java
@@ -2,6 +2,7 @@ package com.lokoko.domain.productReview.application.service;
 
 import com.lokoko.domain.product.domain.entity.enums.MiddleCategory;
 import com.lokoko.domain.product.domain.entity.enums.SubCategory;
+import com.lokoko.domain.product.domain.repository.ProductRepository;
 import com.lokoko.domain.productReview.api.dto.response.BrandImageReviewListResponse;
 import com.lokoko.domain.productReview.api.dto.response.BrandVideoReviewListResponse;
 import com.lokoko.domain.productReview.api.dto.response.ProductAndReviewCountResponse;
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Service;
 public class ReviewReadService {
 
     private final ReviewRepository reviewRepository;
+    private final ProductRepository productRepository;
 
     private final ReviewCacheService reviewCacheService;
     private final KuromojiService kuromojiService;
@@ -119,7 +121,7 @@ public class ReviewReadService {
     }
 
     public ProductAndReviewCountResponse getProductAndReviewCount(String brandName) {
-        int productCount = reviewRepository.countProductsByBrandName(brandName);
+        int productCount = productRepository.countProductsByBrandName(brandName);
         int reviewCount = reviewRepository.countReviewsByBrandName(brandName);
 
         return ProductAndReviewCountResponse.of(brandName, productCount, reviewCount);

--- a/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryCustom.java
@@ -40,8 +40,6 @@ public interface ReviewRepositoryCustom {
 
     Slice<ImageReviewResponse> findImageReviewsByBrandName(String brandName, Pageable pageable);
 
-    int countProductsByBrandName(String brandName);
-
     int countReviewsByBrandName(String brandName);
 
     List<RatingCount> countByProductIdsAndRating(List<Long> productIds);

--- a/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
@@ -209,18 +209,6 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     }
 
     @Override
-    public int countProductsByBrandName(String brandName) {
-        Long count = queryFactory
-                .select(product.countDistinct())
-                .from(product)
-                .innerJoin(review).on(review.product.eq(product))
-                .where(brandNameCondition(brandName))
-                .fetchOne();
-
-        return count != null ? count.intValue() : 0;
-    }
-
-    @Override
     public int countReviewsByBrandName(String brandName) {
         Long count = queryFactory
                 .select(review.count())


### PR DESCRIPTION
## Related issue 🛠

- closed #463 

## 작업 내용 💻

- 상품 수 조회 메소드를 ReviewRepositoryCustom -> ProductRepositoryCustom 으로 이동하였습니다.
- 상품 수를 반환할 때는, 리뷰와의 join 이 불필요하므로 조인을 제거하였습니다. countDistinct() 도 불필요해졌으므로, count 로 수정하였습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 브랜드별 상품 개수 조회 기능의 내부 구조를 최적화했습니다. 상품 저장소에 브랜드별 카운팅 기능을 통합하여 데이터 조회 로직을 개선하고 시스템 아키텍처의 책임 분리를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->