### PR TITLE
[FEAT] #473 일반 사용자(Customer) 추가 정보 입력 API 구현 

### DIFF
--- a/src/main/java/com/lokoko/domain/customer/api/CustomerController.java
+++ b/src/main/java/com/lokoko/domain/customer/api/CustomerController.java
@@ -1,5 +1,6 @@
 package com.lokoko.domain.customer.api;
 
+import com.lokoko.domain.customer.api.dto.request.CustomerInfoRegisterRequest;
 import com.lokoko.domain.customer.api.dto.request.CustomerMyPageRequest;
 import com.lokoko.domain.customer.api.dto.request.CustomerProfileImageRequest;
 import com.lokoko.domain.customer.api.dto.response.CustomerMyPageResponse;
@@ -68,6 +69,17 @@ public class CustomerController {
 
         CustomerSnsConnectedResponse response = customerService.getCustomerSnsStatus(customer);
         return ApiResponse.success(HttpStatus.OK, ResponseMessage.CUSTOMER_GET_SNS_STATUS_SUCCESS.getMessage(), response);
+    }
+
+    @PostMapping("/info")
+    @Operation(summary = "Customer 대상 추가 정보 입력을 진행하는 API 입니다.")
+    public ApiResponse<Void> registerAdditionalInfo(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @RequestBody @Valid CustomerInfoRegisterRequest request){
+
+        customerService.registerAdditionalInfo(userId, request);
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CUSTOMER_ADDITIONAL_INFI_REGISTER_SUCCESS.getMessage());
+
     }
 
 }

--- a/src/main/java/com/lokoko/domain/customer/api/CustomerController.java
+++ b/src/main/java/com/lokoko/domain/customer/api/CustomerController.java
@@ -78,7 +78,7 @@ public class CustomerController {
             @RequestBody @Valid CustomerInfoRegisterRequest request){
 
         customerService.registerAdditionalInfo(userId, request);
-        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CUSTOMER_ADDITIONAL_INFI_REGISTER_SUCCESS.getMessage());
+        return ApiResponse.success(HttpStatus.OK, ResponseMessage.CUSTOMER_ADDITIONAL_INFO_REGISTER_SUCCESS.getMessage());
 
     }
 

--- a/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerInfoRegisterRequest.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerInfoRegisterRequest.java
@@ -1,0 +1,57 @@
+package com.lokoko.domain.customer.api.dto.request;
+
+import com.lokoko.domain.creator.domain.entity.enums.Gender;
+import com.lokoko.domain.creator.domain.entity.enums.SkinTone;
+import com.lokoko.domain.creator.domain.entity.enums.SkinType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CustomerInfoRegisterRequest(
+
+        @NotBlank(message = "커뮤니티 ID는 필수입니다")
+        @Size(min = 1, max = 15, message = "커뮤니티 ID는 1자 이상 15자 이하여야 합니다")
+        @Pattern(regexp = "^[a-z0-9._]+$",
+                message = "커뮤니티 ID는 영문(소문자), 숫자, 점(.), 언더바(_)만 사용 가능합니다")
+        String communityName,
+
+        @NotBlank(message = "생년월일은 필수입니다")
+        @Schema(description = "생년월일", example = "2002-08-21")
+        String birthDate,
+
+        @NotNull(message = "성별은 필수입니다")
+        @Schema(description = "성별", example = "MALE")
+        Gender gender,
+
+        @NotBlank(message = "이름은 필수입니다")
+        @Schema(description = "이름", example = "Jessica")
+        String firstName,
+
+        @NotBlank(message = "성은 필수입니다")
+        @Schema(description = "성", example = "Anderson")
+        String lastName,
+
+        @Schema(description = "국가", example = "US")
+        String country,
+
+        @NotBlank(message = "국가번호는 필수입니다")
+        @Schema(description = "국가번호 (선택, 최대 5자)", example = "+1")
+        @Size(max = 5)
+        String countryCode,
+
+        @NotBlank(message = "전화번호는 필수입니다")
+        @Schema(description = "전화번호 (선택, 최대 20자)", example = "01012345678")
+        @Size(max = 20)
+        String phoneNumber,
+
+        @NotNull(message = "피부 타입은 필수입니다")
+        @Schema(description = "피부 타입 (드롭다운 6개)", example = "COMBINATION")
+        SkinType skinType,
+
+        @NotNull(message = "피부 톤은 필수입니다")
+        @Schema(description = "피부 톤 (드롭다운 20개)", example = "SHADE_12")
+        SkinTone skinTone
+) {
+}

--- a/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerInfoRegisterRequest.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerInfoRegisterRequest.java
@@ -37,12 +37,12 @@ public record CustomerInfoRegisterRequest(
         String country,
 
         @NotBlank(message = "국가번호는 필수입니다")
-        @Schema(description = "국가번호 (선택, 최대 5자)", example = "+1")
+        @Schema(description = "국가번호 (최대 5자)", example = "+1")
         @Size(max = 5)
         String countryCode,
 
         @NotBlank(message = "전화번호는 필수입니다")
-        @Schema(description = "전화번호 (선택, 최대 20자)", example = "01012345678")
+        @Schema(description = "전화번호 (최대 20자)", example = "01012345678")
         @Size(max = 20)
         String phoneNumber,
 

--- a/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerMyPageRequest.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/request/CustomerMyPageRequest.java
@@ -9,7 +9,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-import java.time.LocalDate;
 
 public record CustomerMyPageRequest(
 
@@ -22,7 +21,7 @@ public record CustomerMyPageRequest(
         String customerName,
 
         @Schema(description = "생년월일", example = "2002-08-21")
-        LocalDate birthDate,
+        String birthDate,
 
         @Schema(description = "성별", example = "MALE")
         Gender gender,

--- a/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerMyPageResponse.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerMyPageResponse.java
@@ -61,8 +61,8 @@ public record CustomerMyPageResponse(
         return new CustomerMyPageResponse(
                 user.getProfileImageUrl(),
                 user.getEmail(),
-                user.getFirstName(),
-                user.getLastName(),
+                customer.getFirstName(),
+                customer.getLastName(),
                 customer.getCustomerName(),
                 customer.getBirthDate(),
                 customer.getGender(),

--- a/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerMyPageResponse.java
+++ b/src/main/java/com/lokoko/domain/customer/api/dto/response/CustomerMyPageResponse.java
@@ -8,7 +8,6 @@ import com.lokoko.domain.customer.domain.entity.Customer;
 import com.lokoko.domain.user.domain.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDate;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
@@ -30,7 +29,7 @@ public record CustomerMyPageResponse(
         String userName,
 
         @Schema(description = "생년월일", example = "2002-08-21")
-        LocalDate birthDate,
+        String birthDate,
 
         @Schema(description = "성별", example = "MALE")
         Gender gender,
@@ -46,21 +45,6 @@ public record CustomerMyPageResponse(
 
         @Schema(description = "국가", example = "US")
         String country,
-
-        @Schema(description = "State (텍스트 최대 20자)", example = "CA")
-        String stateOrProvince,
-
-        @Schema(description = "City/Town (텍스트, 최대 20자)", example = "San Francisco")
-        String cityOrTown,
-
-        @Schema(description = "Address Line 1 (최대 100자)", example = "1234 Market St")
-        String addressLine1,
-
-        @Schema(description = "Address Line 2 (최대 100자)", example = "Apt 5B")
-        String addressLine2,
-
-        @Schema(description = "ZIP Code (최대 10자)", example = "94103")
-        String postalCode,
 
         @Schema(description = "피부 타입 (드롭다운 6개)", example = "COMBINATION")
         SkinType skinType,
@@ -86,11 +70,6 @@ public record CustomerMyPageResponse(
                 customer.getPhoneNumber(),
                 customer.getContentLanguage(),
                 customer.getCountry(),
-                customer.getStateOrProvince(),
-                customer.getCityOrTown(),
-                customer.getAddressLine1(),
-                customer.getAddressLine2(),
-                customer.getPostalCode(),
                 customer.getSkinType(),
                 customer.getSkinTone()
         );

--- a/src/main/java/com/lokoko/domain/customer/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/customer/api/message/ResponseMessage.java
@@ -13,7 +13,8 @@ public enum ResponseMessage {
     CUSTOMER_PROFILE_IMAGE_PRESIGNED_URL_SUCCESS("일반 유저 프로필 이미지 presigend url이 성공적으로 발급되었습니다."),
     CUSTOMER_GET_MYPAGE_INFO_SUCCESS("일반 유저 마이페이지 정보를 성공적으로 불러왔습니다."),
     CUSTOMER_UPDATE_MYPAGE_INFO_SUCCESS("일반 유저 마이페이지 정보를 성공적으로 수정했습니다."),
-    CUSTOMER_GET_SNS_STATUS_SUCCESS("일반 유저 SNS 연결 상태를 성공적으로 불러왔습니다");
+    CUSTOMER_GET_SNS_STATUS_SUCCESS("일반 유저 SNS 연결 상태를 성공적으로 불러왔습니다"),
+    CUSTOMER_ADDITIONAL_INFI_REGISTER_SUCCESS("일반 유저 추가 정보 입력에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/customer/api/message/ResponseMessage.java
+++ b/src/main/java/com/lokoko/domain/customer/api/message/ResponseMessage.java
@@ -14,7 +14,7 @@ public enum ResponseMessage {
     CUSTOMER_GET_MYPAGE_INFO_SUCCESS("일반 유저 마이페이지 정보를 성공적으로 불러왔습니다."),
     CUSTOMER_UPDATE_MYPAGE_INFO_SUCCESS("일반 유저 마이페이지 정보를 성공적으로 수정했습니다."),
     CUSTOMER_GET_SNS_STATUS_SUCCESS("일반 유저 SNS 연결 상태를 성공적으로 불러왔습니다"),
-    CUSTOMER_ADDITIONAL_INFI_REGISTER_SUCCESS("일반 유저 추가 정보 입력에 성공했습니다.");
+    CUSTOMER_ADDITIONAL_INFO_REGISTER_SUCCESS("일반 유저 추가 정보 입력에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
+++ b/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
@@ -133,8 +133,7 @@ public class CustomerService {
                 .orElseThrow(CustomerNotFoundException::new);
 
         // id 중복 검증
-        validateDuplicateId(request.communityName());
-
+        userService.checkUserIdAvailable(request.communityName(), customer.getId());
         registerAdditionalInfo(customer , request);
 
     }
@@ -154,12 +153,4 @@ public class CustomerService {
         customer.assignSkinType(request.skinType());
     }
 
-    private void validateDuplicateId(String communityName) {
-        boolean existsInCreator = creatorRepository.existsByCreatorNameIgnoreCase(communityName);
-        boolean existsInCustomer = customerRepository.existsByCustomerNameIgnoreCase(communityName);
-
-        if (existsInCreator || existsInCustomer) {
-            throw new UserIdAlreadyExistsException();
-        }
-    }
 }

--- a/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
+++ b/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
@@ -135,8 +135,23 @@ public class CustomerService {
         // id 중복 검증
         validateDuplicateId(request.communityName());
 
-        customer.registerAdditionalInfo(request);
+        registerAdditionalInfo(customer , request);
 
+    }
+
+    private void registerAdditionalInfo(Customer customer, CustomerInfoRegisterRequest request) {
+        customer.assignCustomerName(request.communityName());
+        customer.assignBirthDate(request.birthDate());
+        customer.assignGender(request.gender());
+        customer.assignFirstName(request.firstName());
+        customer.assignLastName(request.lastName());
+        if (request.country() != null){
+            customer.assignCountry(request.country());
+        }
+        customer.assignCountryCode(request.countryCode());
+        customer.assignPhoneNumber(request.phoneNumber());
+        customer.assignSkinTone(request.skinTone());
+        customer.assignSkinType(request.skinType());
     }
 
     private void validateDuplicateId(String communityName) {

--- a/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
+++ b/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
@@ -83,11 +83,11 @@ public class CustomerService {
         }
 
         if (request.firstName() != null) {
-            user.updateFirstName(request.firstName());
+            customer.assignFirstName(request.firstName());
         }
 
         if (request.lastName() != null) {
-            user.updateLastName(request.lastName());
+            customer.assignLastName(request.lastName());
         }
 
         if (request.countryCode() != null) {

--- a/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
+++ b/src/main/java/com/lokoko/domain/customer/application/CustomerService.java
@@ -1,6 +1,8 @@
 package com.lokoko.domain.customer.application;
 
 
+import com.lokoko.domain.creator.domain.repository.CreatorRepository;
+import com.lokoko.domain.customer.api.dto.request.CustomerInfoRegisterRequest;
 import com.lokoko.domain.customer.api.dto.request.CustomerMyPageRequest;
 import com.lokoko.domain.customer.api.dto.request.CustomerProfileImageRequest;
 import com.lokoko.domain.customer.api.dto.response.CustomerMyPageResponse;
@@ -15,7 +17,9 @@ import com.lokoko.domain.productReview.exception.ErrorMessage;
 import com.lokoko.domain.productReview.exception.InvalidMediaTypeException;
 import com.lokoko.domain.user.application.service.UserService;
 import com.lokoko.domain.user.domain.entity.User;
+import com.lokoko.domain.user.exception.UserIdAlreadyExistsException;
 import com.lokoko.global.utils.S3UrlParser;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +32,8 @@ public class CustomerService {
     private final CustomerRepository customerRepository;
     private final S3Service s3Service;
     private final UserService userService;
+
+    private final CreatorRepository creatorRepository;
 
     public CustomerProfileImageResponse createCustomerProfilePresignedUrl(Long customerId,
                                                                           CustomerProfileImageRequest request) {
@@ -100,26 +106,6 @@ public class CustomerService {
             customer.assignCountry(request.country());
         }
 
-        if (request.stateOrProvince() != null) {
-            customer.assignStateOrProvince(request.stateOrProvince());
-        }
-
-        if (request.cityOrTown() != null) {
-            customer.assignCityOrTown(request.cityOrTown());
-        }
-
-        if (request.addressLine1() != null) {
-            customer.assignAddressLine1(request.addressLine1());
-        }
-
-        if (request.addressLine2() != null) {
-            customer.assignAddressLine2(request.addressLine2());
-        }
-
-        if (request.postalCode() != null) {
-            customer.assignPostalCode(request.postalCode());
-        }
-
         if (request.skinType() != null) {
             customer.assignSkinType(request.skinType());
         }
@@ -139,4 +125,26 @@ public class CustomerService {
         );
     }
 
+
+    @Transactional
+    public void registerAdditionalInfo(Long userId, CustomerInfoRegisterRequest request) {
+
+        Customer customer = customerRepository.findById(userId)
+                .orElseThrow(CustomerNotFoundException::new);
+
+        // id 중복 검증
+        validateDuplicateId(request.communityName());
+
+        customer.registerAdditionalInfo(request);
+
+    }
+
+    private void validateDuplicateId(String communityName) {
+        boolean existsInCreator = creatorRepository.existsByCreatorNameIgnoreCase(communityName);
+        boolean existsInCustomer = customerRepository.existsByCustomerNameIgnoreCase(communityName);
+
+        if (existsInCreator || existsInCustomer) {
+            throw new UserIdAlreadyExistsException();
+        }
+    }
 }

--- a/src/main/java/com/lokoko/domain/customer/domain/entity/Customer.java
+++ b/src/main/java/com/lokoko/domain/customer/domain/entity/Customer.java
@@ -4,6 +4,7 @@ import com.lokoko.domain.creator.domain.entity.enums.ContentLanguage;
 import com.lokoko.domain.creator.domain.entity.enums.Gender;
 import com.lokoko.domain.creator.domain.entity.enums.SkinTone;
 import com.lokoko.domain.creator.domain.entity.enums.SkinType;
+import com.lokoko.domain.customer.api.dto.request.CustomerInfoRegisterRequest;
 import com.lokoko.domain.user.domain.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,7 +15,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,11 +41,17 @@ public class Customer {
     private String customerName;
 
     @Column
-    private LocalDate birthDate;
+    private String birthDate;
 
     @Enumerated(EnumType.STRING)
     @Column
     private Gender gender;
+
+    @Column
+    private String firstName;
+
+    @Column
+    private String lastName;
 
     @Column
     private String countryCode;
@@ -55,22 +61,6 @@ public class Customer {
 
     @Column
     private String country;
-
-    // 주/도/광역시 등
-    @Column
-    private String stateOrProvince;
-
-    @Column
-    private String cityOrTown;
-
-    @Column
-    private String addressLine1;
-
-    @Column
-    private String addressLine2;
-
-    @Column
-    private String postalCode;
 
     @Enumerated(EnumType.STRING)
     private SkinType skinType;
@@ -96,7 +86,7 @@ public class Customer {
         this.customerName = customerName;
     }
 
-    public void assignBirthDate(LocalDate birthDate) {
+    public void assignBirthDate(String birthDate) {
         this.birthDate = birthDate;
     }
 
@@ -114,26 +104,6 @@ public class Customer {
 
     public void assignCountry(String country) {
         this.country = country;
-    }
-
-    public void assignStateOrProvince(String stateOrProvince) {
-        this.stateOrProvince = stateOrProvince;
-    }
-
-    public void assignCityOrTown(String cityOrTown) {
-        this.cityOrTown = cityOrTown;
-    }
-
-    public void assignAddressLine1(String addressLine1) {
-        this.addressLine1 = addressLine1;
-    }
-
-    public void assignAddressLine2(String addressLine2) {
-        this.addressLine2 = addressLine2;
-    }
-
-    public void assignPostalCode(String postalCode) {
-        this.postalCode = postalCode;
     }
 
     public void assignSkinType(SkinType skinType) {
@@ -154,5 +124,28 @@ public class Customer {
 
     public void connectInsta(String instaUserId) {
         this.instaUserId = instaUserId;
+    }
+
+    public void assignFirstName(String firstName){
+        this.firstName = firstName;
+    }
+
+    public void assignLastName(String lastName){
+        this.lastName = lastName;
+    }
+
+    public void registerAdditionalInfo(CustomerInfoRegisterRequest request) {
+        assignCustomerName(request.communityName());
+        assignBirthDate(request.birthDate());
+        assignGender(request.gender());
+        assignFirstName(request.firstName());
+        assignLastName(request.lastName());
+        if (request.country() != null){
+            assignCountry(request.country());
+        }
+        assignCountryCode(request.countryCode());
+        assignPhoneNumber(request.phoneNumber());
+        assignSkinTone(request.skinTone());
+        assignSkinType(request.skinType());
     }
 }

--- a/src/main/java/com/lokoko/domain/customer/domain/entity/Customer.java
+++ b/src/main/java/com/lokoko/domain/customer/domain/entity/Customer.java
@@ -134,18 +134,5 @@ public class Customer {
         this.lastName = lastName;
     }
 
-    public void registerAdditionalInfo(CustomerInfoRegisterRequest request) {
-        assignCustomerName(request.communityName());
-        assignBirthDate(request.birthDate());
-        assignGender(request.gender());
-        assignFirstName(request.firstName());
-        assignLastName(request.lastName());
-        if (request.country() != null){
-            assignCountry(request.country());
-        }
-        assignCountryCode(request.countryCode());
-        assignPhoneNumber(request.phoneNumber());
-        assignSkinTone(request.skinTone());
-        assignSkinType(request.skinType());
-    }
+
 }

--- a/src/main/java/com/lokoko/domain/customer/domain/entity/Customer.java
+++ b/src/main/java/com/lokoko/domain/customer/domain/entity/Customer.java
@@ -4,7 +4,7 @@ import com.lokoko.domain.creator.domain.entity.enums.ContentLanguage;
 import com.lokoko.domain.creator.domain.entity.enums.Gender;
 import com.lokoko.domain.creator.domain.entity.enums.SkinTone;
 import com.lokoko.domain.creator.domain.entity.enums.SkinType;
-import com.lokoko.domain.customer.api.dto.request.CustomerInfoRegisterRequest;
+
 import com.lokoko.domain.user.domain.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewProductDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewProductDetailResponse.java
@@ -1,5 +1,6 @@
 package com.lokoko.domain.productReview.api.dto.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -34,7 +35,7 @@ public record ImageReviewProductDetailResponse(
         Boolean isLiked,
         @Schema(requiredMode = REQUIRED)
         Boolean isMine,
-        @Schema(requiredMode = REQUIRED)
+        @Schema(requiredMode = NOT_REQUIRED)
         String country
 ) {
 

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewProductDetailResponse.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/response/ImageReviewProductDetailResponse.java
@@ -33,7 +33,9 @@ public record ImageReviewProductDetailResponse(
         @Schema(requiredMode = REQUIRED)
         Boolean isLiked,
         @Schema(requiredMode = REQUIRED)
-        Boolean isMine
+        Boolean isMine,
+        @Schema(requiredMode = REQUIRED)
+        String country
 ) {
 
     public ImageReviewProductDetailResponse(Long reviewId, LocalDateTime writtenTime,
@@ -41,7 +43,7 @@ public record ImageReviewProductDetailResponse(
                                             String negativeComment, String profileImageUrl, String authorName,
                                             Long authorId, Double rating,
                                             Integer likeCount, List<String> images,
-                                            Boolean isLiked, Boolean isMine
+                                            Boolean isLiked, Boolean isMine, String country
     ) {
         this.reviewId = reviewId;
         this.writtenTime = writtenTime;
@@ -55,5 +57,6 @@ public record ImageReviewProductDetailResponse(
         this.images = images != null ? new ArrayList<>(images) : new ArrayList<>();
         this.isLiked = isLiked;
         this.isMine = isMine;
+        this.country = country;
     }
 }

--- a/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.lokoko.domain.productReview.api.dto.response.ImageReviewsProductDetai
 import com.lokoko.domain.productReview.api.dto.response.VideoReviewProductDetail;
 import com.lokoko.domain.productReview.api.dto.response.VideoReviewProductDetailResponse;
 import com.lokoko.domain.productReview.api.dto.response.VideoReviewResponse;
+import com.lokoko.domain.customer.domain.entity.QCustomer;
 import com.lokoko.domain.productReview.domain.entity.QReview;
 import com.lokoko.domain.user.domain.entity.enums.Role;
 import com.lokoko.domain.user.domain.repository.UserRepository;
@@ -46,6 +47,8 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     private final QReviewImage reviewImage = QReviewImage.reviewImage;
     private final QReviewLike reviewLike = QReviewLike.reviewLike;
     private final QReviewLikeCount reviewLikeCount = QReviewLikeCount.reviewLikeCount;
+
+    private final QCustomer customer = QCustomer.customer;
 
     private final UserRepository userRepository;
 
@@ -227,10 +230,12 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                         review.author.name,
                         review.author.id,
                         ratingAsInt,
-                        reviewImage.mediaFile.fileUrl
+                        reviewImage.mediaFile.fileUrl,
+                        customer.country
                 )
                 .from(review)
                 .join(review.product, product)
+                .leftJoin(customer).on(customer.id.eq(review.author.id))
                 .leftJoin(reviewImage).on(reviewImage.review.eq(review))
                 .where(review.id.in(reviewIds))
                 .orderBy(review.modifiedAt.desc())
@@ -242,6 +247,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             ImageReviewProductDetailResponse dto = map.computeIfAbsent(id, k -> {
                 boolean isMine = (userId != null && userId.equals(t.get(review.author.id)));
                 boolean isLiked = likedReviewIds.contains(k);
+              
                 return new ImageReviewProductDetailResponse(
                         k,
                         t.get(review.modifiedAt),
@@ -254,7 +260,8 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                         likeCounts.getOrDefault(k, 0L).intValue(),
                         new ArrayList<>(),
                         isLiked,
-                        isMine
+                        isMine,
+                        t.get(customer.country)
                 );
             });
             String img = t.get(reviewImage.mediaFile.fileUrl);


### PR DESCRIPTION
## Related issue 🛠

- closed #472 

코드 리뷰 주안점 
1. 크리에이터 추가 정보 입력 로직과 유사하게 구현.
2. Customer 테이블 정보 수정 

## 작업 내용 💻

### Customer 대상으로 구글 소셜 로그인 진행후 추가 정보입력을 진행하는 API 를 구현하였습니다.
----

### Customer 테이블의 일부 필드를 수정하였습니다.

1. birthDate 를 LocalDate -> String 으로 수정
- > Creator 테이블과 통일하기 위함입니다.

3. firstName, lastName 필드 추가
- > 추가 정보 입력 폼에서 firstName, lastName 을 입력할 수 있기 때문입니다.

4. 더 이상 필요하지 않은 필드 삭제
-> state or province 등 Customer 는 더 이상 해당 정보를 필요로 하지 않기 때문에 삭제하였습니다.

5. 제품 상세페이지 - 사진 리뷰 조회의 응답 DTO 에 국적 필드 추가 

## 스크린샷 📷

<img width="510" height="590" alt="image" src="https://github.com/user-attachments/assets/5f57d0c8-c98d-4a55-9055-e769e664e4f6" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 고객 추가 정보 입력용 POST API 추가(커뮤니티명, 생년월일(문자열), 성별, 성/이름 분리, 국가·국가코드, 전화번호, 피부 타입·톤 등)
  * 상품 이미지 리뷰 응답에 작성자 국가 정보 노출 추가
  * 추가 정보 등록 성공 응답 메시지 추가

* **개선 사항**
  * 프로필에서 주소 관련 필드 제거로 구조 단순화
  * 고객 이름·생년월일 처리 방식 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->