### PR TITLE
[FIX] #476 제품 상세페이지 - 사진 리뷰 조회에서 Creator 의 country 가 null 로 반환되는 문제 해결 

### DIFF
--- a/src/main/java/com/lokoko/domain/productReview/api/dto/request/ReviewRequest.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/request/ReviewRequest.java
@@ -1,12 +1,15 @@
 package com.lokoko.domain.productReview.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record ReviewRequest(
         @NotNull
+        @Min(1) @Max(5)
         @Schema(description = "별점 (1~5)", example = "5")
         Integer rating,
 

--- a/src/main/java/com/lokoko/domain/productReview/api/dto/request/ReviewRequest.java
+++ b/src/main/java/com/lokoko/domain/productReview/api/dto/request/ReviewRequest.java
@@ -1,15 +1,26 @@
 package com.lokoko.domain.productReview.api.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record ReviewRequest(
-        Long productOptionId,
-        @NotNull Integer rating,
-        @NotNull @Size(min = 15, max = 1500) String positiveComment,
-        @NotNull @Size(min = 15, max = 1500) String negativeComment,
-        List<String> mediaUrl,
-        List<String> receiptUrl
+        @NotNull
+        @Schema(description = "별점 (1~5)", example = "5")
+        Integer rating,
+
+        @NotNull
+        @Size(min = 15, max = 1500)
+        @Schema(description = "긍정적인 리뷰 내용 (15자 이상 1500자 이하)", example = "This product is amazing and works great on my skin!")
+        String positiveComment,
+
+        @NotNull
+        @Size(min = 15, max = 1500)
+        @Schema(description = "부정적인 리뷰 내용 (15자 이상 1500자 이하)", example = "The packaging could be improved for better usability.")
+        String negativeComment,
+
+        @Schema(description = "리뷰 이미지 URL 목록", example = "[\"https://example.com/image1.jpg\"]")
+        List<String> mediaUrl
 ) {
 }

--- a/src/main/java/com/lokoko/domain/productReview/application/service/ReviewService.java
+++ b/src/main/java/com/lokoko/domain/productReview/application/service/ReviewService.java
@@ -26,10 +26,7 @@ import com.lokoko.domain.productReview.api.dto.response.ReviewReceiptResponse;
 import com.lokoko.domain.productReview.api.dto.response.ReviewResponse;
 import com.lokoko.domain.productReview.domain.entity.Review;
 import com.lokoko.domain.productReview.domain.repository.ReviewRepository;
-import com.lokoko.domain.productReview.exception.ErrorMessage;
-import com.lokoko.domain.productReview.exception.InvalidMediaTypeException;
-import com.lokoko.domain.productReview.exception.ReviewNotFoundException;
-import com.lokoko.domain.productReview.exception.ReviewPermissionException;
+import com.lokoko.domain.productReview.exception.*;
 import com.lokoko.domain.productReview.mapper.ReviewMapper;
 import com.lokoko.domain.user.domain.entity.User;
 import com.lokoko.domain.user.domain.entity.enums.Role;
@@ -39,7 +36,6 @@ import com.lokoko.global.common.annotation.DistributedLock;
 import com.lokoko.global.utils.S3UrlParser;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,9 +53,7 @@ public class ReviewService {
     private final ReviewLikeRepository reviewLikeRepository;
     private final ReviewLikeCountRepository reviewLikeCountRepository;
 
-
     private final S3Service s3Service;
-    private final ApplicationEventPublisher eventPublisher;
     private final ReviewMapper reviewMapper;
 
     private static final int MAX_VIDEO_REVIEW_COUNT = 1;
@@ -121,6 +115,8 @@ public class ReviewService {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
+        validateCreateReviewPermission(user);
+
         // 미디어 검증 (동영상 1개 이하, 이미지 5개 이하, 혼용 불가)
         validateMediaFiles(request.mediaUrl());
 
@@ -153,6 +149,12 @@ public class ReviewService {
 
         deleteAllReferenceOfReview(review);
         reviewRepository.delete(review);
+    }
+
+    private static void validateCreateReviewPermission(User user) {
+        if (user.getRole() != Role.CUSTOMER || user.getRole() != Role.CREATOR){
+            throw new ReviewCreatePermissionDeniedException();
+        }
     }
 
     private static void validateMediaTypeAndSize(boolean hasVideo, boolean hasImage, List<String> mediaTypes) {

--- a/src/main/java/com/lokoko/domain/productReview/application/service/ReviewService.java
+++ b/src/main/java/com/lokoko/domain/productReview/application/service/ReviewService.java
@@ -152,7 +152,7 @@ public class ReviewService {
     }
 
     private static void validateCreateReviewPermission(User user) {
-        if (user.getRole() != Role.CUSTOMER || user.getRole() != Role.CREATOR){
+        if (user.getRole() != Role.CUSTOMER && user.getRole() != Role.CREATOR){
             throw new ReviewCreatePermissionDeniedException();
         }
     }

--- a/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/lokoko/domain/productReview/domain/repository/ReviewRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.lokoko.domain.productReview.api.dto.response.ImageReviewsProductDetai
 import com.lokoko.domain.productReview.api.dto.response.VideoReviewProductDetail;
 import com.lokoko.domain.productReview.api.dto.response.VideoReviewProductDetailResponse;
 import com.lokoko.domain.productReview.api.dto.response.VideoReviewResponse;
+import com.lokoko.domain.creator.domain.entity.QCreator;
 import com.lokoko.domain.customer.domain.entity.QCustomer;
 import com.lokoko.domain.productReview.domain.entity.QReview;
 import com.lokoko.domain.user.domain.entity.enums.Role;
@@ -49,6 +50,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     private final QReviewLikeCount reviewLikeCount = QReviewLikeCount.reviewLikeCount;
 
     private final QCustomer customer = QCustomer.customer;
+    private final QCreator creator = QCreator.creator;
 
     private final UserRepository userRepository;
 
@@ -231,11 +233,12 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                         review.author.id,
                         ratingAsInt,
                         reviewImage.mediaFile.fileUrl,
-                        customer.country
+                        customer.country.coalesce(creator.country)
                 )
                 .from(review)
                 .join(review.product, product)
                 .leftJoin(customer).on(customer.id.eq(review.author.id))
+                .leftJoin(creator).on(creator.id.eq(review.author.id))
                 .leftJoin(reviewImage).on(reviewImage.review.eq(review))
                 .where(review.id.in(reviewIds))
                 .orderBy(review.modifiedAt.desc())
@@ -261,7 +264,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                         new ArrayList<>(),
                         isLiked,
                         isMine,
-                        t.get(customer.country)
+                        t.get(customer.country.coalesce(creator.country))
                 );
             });
             String img = t.get(reviewImage.mediaFile.fileUrl);

--- a/src/main/java/com/lokoko/domain/productReview/exception/ErrorMessage.java
+++ b/src/main/java/com/lokoko/domain/productReview/exception/ErrorMessage.java
@@ -21,7 +21,8 @@ public enum ErrorMessage {
     REVIEW_VIDEO_NOT_FOUND("존재하지 않는 리뷰 영상입니다."),
     RECEIPT_IMAGE_NOT_FOUND("존재하지 않는 영수증 입니다"),
     PRODUCT_IMAGE_NOT_FOUND("제품 이미지가 존재하지 않습니다"),
-    REVIEW_DELETE_FORBIDDEN("본인이 작성한 리뷰만 삭제할 수 있습니다");
+    REVIEW_DELETE_FORBIDDEN("본인이 작성한 리뷰만 삭제할 수 있습니다"),
+    REVIEW_CREATE_PERMISSION_DENIED("리뷰를 작성할 수 있는 권한을 가지고 있지 않습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/lokoko/domain/productReview/exception/ReviewCreatePermissionDeniedException.java
+++ b/src/main/java/com/lokoko/domain/productReview/exception/ReviewCreatePermissionDeniedException.java
@@ -1,0 +1,10 @@
+package com.lokoko.domain.productReview.exception;
+
+import com.lokoko.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class ReviewCreatePermissionDeniedException extends BaseException {
+    public ReviewCreatePermissionDeniedException() {
+        super(HttpStatus.FORBIDDEN, ErrorMessage.REVIEW_CREATE_PERMISSION_DENIED.getMessage());
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #475 

## 작업 내용 💻

- [리뷰 작성을 Customer 만 진행할 수 있다고 가정했기 때문에 발생한 문제였습니다. customer, creator 를 모두 조인하여 coalesce 처리를 통해 country 가 null 로 반환되는 경우가 존재하지 않도록 설정하였습니다. ]
 
- [리뷰 작성을 Customer , Creator 외의 사용자가 진행하면 예외를 반환하도록 하였습니다. ] 

## 스크린샷 📷

-

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 리뷰에 별점 입력 및 리뷰 이미지 URL 지원 추가
  * 작성자 지역 정보 보강으로 리뷰 위치 표시 개선

* **버그 수정**
  * 리뷰 유효성 검사 강화: 별점 범위(1–5) 및 긍정/부정 의견 길이(15–1500자) 적용
  * 권한 없는 사용자의 리뷰 작성 시 명확한 거부 응답 제공
  * 제품 옵션 ID 및 영수증 URL 관련 필드 제거로 입력 간소화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->