### PR TITLE
[TEST] #481 브랜드 도메인 테스트 코드 작성

### DIFF
--- a/src/test/java/com/lokoko/domain/brand/BrandApplicantManagementTest.java
+++ b/src/test/java/com/lokoko/domain/brand/BrandApplicantManagementTest.java
@@ -1,0 +1,400 @@
+package com.lokoko.domain.brand;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Answers.*;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.lokoko.domain.brand.api.dto.response.CreatorPerformanceResponse;
+import com.lokoko.domain.brand.domain.entity.Brand;
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaign.exception.NotCampaignOwnershipException;
+import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ContentStatus;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewStatus;
+import com.lokoko.domain.creator.api.dto.response.CreatorInfo;
+import com.lokoko.domain.creator.domain.entity.Creator;
+import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
+import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
+import com.lokoko.domain.media.socialclip.domain.SocialClip;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import com.lokoko.global.common.response.PageableResponse;
+
+@DisplayName("Brand 지원자/성과 관리 Usecase 테스트")
+class BrandApplicantManagementTest extends BrandUsecaseTestSupport {
+
+	private Long brandId;
+	private Long campaignId;
+	private Brand brand;
+	private Campaign campaign;
+	private ContentType firstContentType;
+	private ParticipationStatus approvedParticipationStatus;
+
+	@BeforeEach
+	void setUp() {
+		brandId = 1L;
+		campaignId = 10L;
+		brand = mock(Brand.class, RETURNS_DEEP_STUBS);
+		campaign = mock(Campaign.class, RETURNS_DEEP_STUBS);
+		firstContentType = ContentType.values()[0];
+		approvedParticipationStatus = Arrays.stream(ParticipationStatus.values())
+			.filter(participationStatus -> participationStatus != ParticipationStatus.REJECTED)
+			.findFirst()
+			.orElseThrow();
+
+		given(brandGetService.getBrandById(brandId)).willReturn(brand);
+		given(campaignGetService.findByCampaignId(campaignId)).willReturn(campaign);
+		given(campaign.getId()).willReturn(campaignId);
+		given(campaign.getBrand().getId()).willReturn(brandId);
+		given(campaign.getTitle()).willReturn("브랜드 릴스 캠페인");
+		given(campaign.getFirstContentPlatform()).willReturn(firstContentType);
+		given(campaign.getSecondContentPlatform()).willReturn(null);
+
+		given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(false);
+		given(betaFeatureConfig.isFirstReviewUrlEnabled()).willReturn(false);
+	}
+
+	@Nested
+	@DisplayName("브랜드 권한 검증")
+	class OwnershipValidation {
+
+		@Test
+		@DisplayName("getCreatorPerformances() : 다른 브랜드의 캠페인이면 예외를 던진다")
+		void getCreatorPerformances_notOwner_throwsException() {
+			// given
+			given(campaign.getBrand().getId()).willReturn(999L);
+
+			// when & then
+			assertThatThrownBy(() -> brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10))
+				.isInstanceOf(NotCampaignOwnershipException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("브랜드 성과 조회")
+	class GetCreatorPerformances {
+
+		@Test
+		@DisplayName("getCreatorPerformances() : 1차/2차 리뷰가 함께 있으면 2차 리뷰를 우선 반영한다")
+		void getCreatorPerformances_prioritizesSecondReview() {
+			// given
+			Creator creator = createCreator(11L, "홍길동", "creator-one", "https://cdn.test/creator-one.jpg");
+			CreatorCampaign creatorCampaign =
+				createCreatorCampaign(101L, creator, approvedParticipationStatus, true);
+
+			CampaignReview firstReview =
+				createCampaignReview(1001L, ReviewRound.FIRST, ReviewStatus.SUBMITTED, firstContentType);
+			CampaignReview secondReview =
+				createCampaignReview(1002L, ReviewRound.SECOND, ReviewStatus.RESUBMITTED, firstContentType);
+
+			SocialClip socialClip = mock(SocialClip.class);
+			Instant uploadedAt = Instant.parse("2026-03-01T12:00:00Z");
+
+			given(secondReview.getPostUrl()).willReturn("https://instagram.com/p/final");
+			given(firstReview.getPostUrl()).willReturn("https://instagram.com/p/draft");
+			given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
+			given(campaignReviewGetService.findAllByCreatorCampaignId(101L))
+				.willReturn(List.of(firstReview, secondReview));
+
+			given(socialClipGetService.findByCampaignReview(secondReview)).willReturn(Optional.of(socialClip));
+			given(socialClip.getPlays()).willReturn(1200L);
+			given(socialClip.getLikes()).willReturn(300L);
+			given(socialClip.getComments()).willReturn(45L);
+			given(socialClip.getShares()).willReturn(12L);
+			given(socialClip.getUploadedAt()).willReturn(uploadedAt);
+
+			// when
+			CreatorPerformanceResponse result =
+				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
+
+			// then
+			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+				.campaignId(campaignId)
+				.campaignTitle("브랜드 릴스 캠페인")
+				.firstContentPlatform(firstContentType)
+				.secondContentPlatform(null)
+				.creators(List.of(
+					CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+						.creator(createCreatorInfo(11L, "홍길동", "creator-one",
+							"https://cdn.test/creator-one.jpg"))
+						.reviews(List.of(
+							CreatorPerformanceResponse.ReviewPerformance.builder()
+								.campaignReviewId(1002L)
+								.reviewRound(ReviewRound.SECOND)
+								.reviewStatus(ContentStatus.FINAL_UPLOADED)
+								.postUrl("https://instagram.com/p/final")
+								.contents(CreatorPerformanceResponse.ContentMetrics.builder()
+									.contentType(firstContentType)
+									.viewCount(1200L)
+									.likeCount(300L)
+									.commentCount(45L)
+									.shareCount(12L)
+									.build())
+								.uploadedAt(uploadedAt)
+								.build()
+						))
+						.build()
+				))
+				.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
+				.build();
+
+			assertThat(result)
+				.usingRecursiveComparison()
+				.isEqualTo(expected);
+		}
+
+		@Test
+		@DisplayName("getCreatorPerformances() : 리뷰가 없고 배송지 입력이 완료되었으면 진행중 상태를 반환한다")
+		void getCreatorPerformances_returnsInProgress_whenAddressConfirmedAndNoReview() {
+			// given
+			Creator creator = createCreator(21L, "김로코", "creator-two", "https://cdn.test/creator-two.jpg");
+			CreatorCampaign creatorCampaign =
+				createCreatorCampaign(201L, creator, approvedParticipationStatus, true);
+
+			given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
+			given(campaignReviewGetService.findAllByCreatorCampaignId(201L)).willReturn(List.of());
+
+			// when
+			CreatorPerformanceResponse result =
+				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
+
+			// then
+			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+				.campaignId(campaignId)
+				.campaignTitle("브랜드 릴스 캠페인")
+				.firstContentPlatform(firstContentType)
+				.secondContentPlatform(null)
+				.creators(List.of(
+					CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+						.creator(createCreatorInfo(21L, "김로코", "creator-two",
+							"https://cdn.test/creator-two.jpg"))
+						.reviews(List.of(
+							CreatorPerformanceResponse.ReviewPerformance.builder()
+								.reviewRound(ReviewRound.FIRST)
+								.reviewStatus(ContentStatus.IN_PROGRESS)
+								.contents(CreatorPerformanceResponse.ContentMetrics.builder()
+									.contentType(firstContentType)
+									.build())
+								.build()
+						))
+						.build()
+				))
+				.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
+				.build();
+
+			assertThat(result)
+				.usingRecursiveComparison()
+				.isEqualTo(expected);
+		}
+
+		@Test
+		@DisplayName("getCreatorPerformances() : 리뷰가 없고 배송지 입력이 없으면 미제출 상태를 반환한다")
+		void getCreatorPerformances_returnsNotSubmitted_whenAddressNotConfirmedAndNoReview() {
+			// given
+			Creator creator = createCreator(31L, "박지원", "creator-three", "https://cdn.test/creator-three.jpg");
+			CreatorCampaign creatorCampaign =
+				createCreatorCampaign(301L, creator, approvedParticipationStatus, false);
+
+			given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
+			given(campaignReviewGetService.findAllByCreatorCampaignId(301L)).willReturn(List.of());
+
+			// when
+			CreatorPerformanceResponse result =
+				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
+
+			// then
+			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+				.campaignId(campaignId)
+				.campaignTitle("브랜드 릴스 캠페인")
+				.firstContentPlatform(firstContentType)
+				.secondContentPlatform(null)
+				.creators(List.of(
+					CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+						.creator(createCreatorInfo(31L, "박지원", "creator-three",
+							"https://cdn.test/creator-three.jpg"))
+						.reviews(List.of(
+							CreatorPerformanceResponse.ReviewPerformance.builder()
+								.reviewRound(ReviewRound.FIRST)
+								.reviewStatus(ContentStatus.NOT_SUBMITTED)
+								.contents(CreatorPerformanceResponse.ContentMetrics.builder()
+									.contentType(firstContentType)
+									.build())
+								.build()
+						))
+						.build()
+				))
+				.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
+				.build();
+
+			assertThat(result)
+				.usingRecursiveComparison()
+				.isEqualTo(expected);
+		}
+
+		@Test
+		@DisplayName("getCreatorPerformances() : 베타 모드에서는 1차 SUBMITTED 리뷰를 최종 업로드로 처리하고 postUrl을 포함한다")
+		void getCreatorPerformances_betaMode_returnsFinalUploadedForFirstReview() {
+			// given
+			Creator creator = createCreator(41L, "최지훈", "creator-four", "https://cdn.test/creator-four.jpg");
+			CreatorCampaign creatorCampaign =
+				createCreatorCampaign(401L, creator, approvedParticipationStatus, true);
+
+			CampaignReview firstReview =
+				createCampaignReview(4001L, ReviewRound.FIRST, ReviewStatus.SUBMITTED, firstContentType);
+
+			LocalDateTime createdAt = LocalDateTime.of(2026, 3, 1, 12, 0);
+			Instant expectedUploadedAt = createdAt.toInstant(ZoneOffset.ofHours(9));
+
+			given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(true);
+			given(betaFeatureConfig.isFirstReviewUrlEnabled()).willReturn(true);
+
+			given(firstReview.getPostUrl()).willReturn("https://instagram.com/p/beta-first");
+			given(firstReview.getCreatedAt()).willReturn(createdAt);
+
+			given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
+			given(campaignReviewGetService.findAllByCreatorCampaignId(401L))
+				.willReturn(List.of(firstReview));
+
+			// when
+			CreatorPerformanceResponse result =
+				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
+
+			// then
+			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+				.campaignId(campaignId)
+				.campaignTitle("브랜드 릴스 캠페인")
+				.firstContentPlatform(firstContentType)
+				.secondContentPlatform(null)
+				.creators(List.of(
+					CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+						.creator(createCreatorInfo(41L, "최지훈", "creator-four",
+							"https://cdn.test/creator-four.jpg"))
+						.reviews(List.of(
+							CreatorPerformanceResponse.ReviewPerformance.builder()
+								.campaignReviewId(4001L)
+								.reviewRound(ReviewRound.FIRST)
+								.reviewStatus(ContentStatus.FINAL_UPLOADED)
+								.postUrl("https://instagram.com/p/beta-first")
+								.contents(CreatorPerformanceResponse.ContentMetrics.builder()
+									.contentType(firstContentType)
+									.build())
+								.uploadedAt(expectedUploadedAt)
+								.build()
+						))
+						.build()
+				))
+				.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
+				.build();
+
+			assertThat(result)
+				.usingRecursiveComparison()
+				.isEqualTo(expected);
+		}
+
+		@Test
+		@DisplayName("getCreatorPerformances() : REJECTED 지원자는 결과에서 제외한다")
+		void getCreatorPerformances_excludesRejectedCreatorCampaign() {
+			// given
+			Creator creator = createCreator(51L, "서로코", "creator-five", "https://cdn.test/creator-five.jpg");
+			CreatorCampaign rejectedCreatorCampaign =
+				createCreatorCampaign(501L, creator, ParticipationStatus.REJECTED, false);
+
+			given(creatorCampaignGetService.findAllByCampaign(campaign))
+				.willReturn(List.of(rejectedCreatorCampaign));
+
+			// when
+			CreatorPerformanceResponse result =
+				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
+
+			// then
+			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+				.campaignId(campaignId)
+				.campaignTitle("브랜드 릴스 캠페인")
+				.firstContentPlatform(firstContentType)
+				.secondContentPlatform(null)
+				.creators(List.of())
+				.pageableResponse(PageableResponse.of(0, 10, 0, true, 0L))
+				.build();
+
+			assertThat(result)
+				.usingRecursiveComparison()
+				.isEqualTo(expected);
+		}
+	}
+
+	private Creator createCreator(
+		Long creatorId,
+		String creatorFullName,
+		String creatorNickname,
+		String profileImageUrl
+	) {
+		Creator creator = mock(Creator.class, RETURNS_DEEP_STUBS);
+
+		given(creator.getId()).willReturn(creatorId);
+		given(creator.getCreatorName()).willReturn(creatorNickname);
+		given(creator.getUser().getName()).willReturn(creatorFullName);
+		given(creator.getUser().getProfileImageUrl()).willReturn(profileImageUrl);
+
+		return creator;
+	}
+
+	private CreatorCampaign createCreatorCampaign(
+		Long creatorCampaignId,
+		Creator creator,
+		ParticipationStatus participationStatus,
+		Boolean addressConfirmed
+	) {
+		CreatorCampaign creatorCampaign = mock(CreatorCampaign.class);
+
+		given(creatorCampaign.getId()).willReturn(creatorCampaignId);
+		given(creatorCampaign.getCreator()).willReturn(creator);
+		given(creatorCampaign.getStatus()).willReturn(participationStatus);
+		given(creatorCampaign.getAddressConfirmed()).willReturn(addressConfirmed);
+
+		return creatorCampaign;
+	}
+
+	private CampaignReview createCampaignReview(
+		Long campaignReviewId,
+		ReviewRound reviewRound,
+		ReviewStatus reviewStatus,
+		ContentType contentType
+	) {
+		CampaignReview campaignReview = mock(CampaignReview.class);
+
+		given(campaignReview.getId()).willReturn(campaignReviewId);
+		given(campaignReview.getReviewRound()).willReturn(reviewRound);
+		given(campaignReview.getStatus()).willReturn(reviewStatus);
+		given(campaignReview.getContentType()).willReturn(contentType);
+
+		return campaignReview;
+	}
+
+	private CreatorInfo createCreatorInfo(
+		Long creatorId,
+		String creatorFullName,
+		String creatorNickname,
+		String profileImageUrl
+	) {
+		return CreatorInfo.builder()
+			.creatorId(creatorId)
+			.creatorFullName(creatorFullName)
+			.creatorNickname(creatorNickname)
+			.profileImageUrl(profileImageUrl)
+			.build();
+	}
+}

--- a/src/test/java/com/lokoko/domain/brand/BrandMyPageTest.java
+++ b/src/test/java/com/lokoko/domain/brand/BrandMyPageTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Answers.*;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
 
 import java.time.Instant;
 import java.util.List;

--- a/src/test/java/com/lokoko/domain/brand/BrandMyPageTest.java
+++ b/src/test/java/com/lokoko/domain/brand/BrandMyPageTest.java
@@ -1,0 +1,230 @@
+package com.lokoko.domain.brand;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Answers.*;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.lokoko.domain.brand.api.dto.request.BrandMyPageUpdateRequest;
+import com.lokoko.domain.brand.api.dto.response.BrandIssuedCampaignResponse;
+import com.lokoko.domain.brand.api.dto.response.BrandMyPageResponse;
+import com.lokoko.domain.brand.api.dto.response.BrandProfileAndStatisticsResponse;
+import com.lokoko.domain.brand.domain.entity.Brand;
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaign.exception.NotCampaignOwnershipException;
+import com.lokoko.domain.campaignReview.api.dto.response.CampaignReviewDetailListResponse;
+import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
+import com.lokoko.domain.creator.api.dto.response.CreatorInfo;
+import com.lokoko.domain.creator.domain.entity.Creator;
+import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
+
+@DisplayName("Brand 마이페이지 Usecase 테스트")
+class BrandMyPageTest extends BrandUsecaseTestSupport {
+
+	private Long brandId;
+	private Brand brand;
+
+	@BeforeEach
+	void setUp() {
+		brandId = 1L;
+		brand = mock(Brand.class, RETURNS_DEEP_STUBS);
+	}
+
+	@Nested
+	@DisplayName("브랜드 마이페이지 조회")
+	class GetBrandMyPage {
+
+		@Test
+		@DisplayName("getBrandMyPage() : 브랜드와 유저 정보를 조회해 마이페이지 응답을 반환한다")
+		void getBrandMyPage_success() {
+			// given
+			given(brandGetService.getBrandWithUserById(brandId)).willReturn(brand);
+
+			// when
+			BrandMyPageResponse result = brandUsecase.getBrandMyPage(brandId);
+
+			// then
+			BrandMyPageResponse expected = BrandMyPageResponse.from(brand, brand.getUser());
+
+			assertThat(result)
+				.usingRecursiveComparison()
+				.isEqualTo(expected);
+		}
+
+		@Test
+		@DisplayName("getBrandProfileAndStatistics() : 진행 중/종료 캠페인 수를 포함한 프로필 통계를 반환한다")
+		void getBrandProfileAndStatistics_success() {
+			// given
+			given(brandGetService.getBrandById(brandId)).willReturn(brand);
+			given(campaignGetService.countOngoingCampaigns(eq(brandId), any(Instant.class))).willReturn(3);
+			given(campaignGetService.countCompletedCampaigns(eq(brandId), any(Instant.class))).willReturn(7);
+
+			// when
+			BrandProfileAndStatisticsResponse result = brandUsecase.getBrandProfileAndStatistics(brandId);
+
+			// then
+			BrandProfileAndStatisticsResponse expected =
+				BrandProfileAndStatisticsResponse.of(brand, 3, 7);
+
+			assertThat(result)
+				.usingRecursiveComparison()
+				.isEqualTo(expected);
+		}
+	}
+
+	@Nested
+	@DisplayName("브랜드 발행 캠페인 및 리뷰 조회")
+	class ReviewAndCampaignQuery {
+
+		@Test
+		@DisplayName("getMyIssuedCampaignsInReview() : 검토 중인 캠페인 목록을 응답 DTO 리스트로 반환한다")
+		void getMyIssuedCampaignsInReview_success() {
+			// given
+			Campaign firstCampaign = mock(Campaign.class);
+			Campaign secondCampaign = mock(Campaign.class);
+			BrandIssuedCampaignResponse firstResponse = mock(BrandIssuedCampaignResponse.class);
+			BrandIssuedCampaignResponse secondResponse = mock(BrandIssuedCampaignResponse.class);
+
+			given(brandGetService.getBrandById(brandId)).willReturn(brand);
+			given(campaignGetService.getBrandIssuedCampaignsInReview(brand))
+				.willReturn(List.of(firstCampaign, secondCampaign));
+			given(campaignMapper.toBrandIssuedCampaignResponse(firstCampaign)).willReturn(firstResponse);
+			given(campaignMapper.toBrandIssuedCampaignResponse(secondCampaign)).willReturn(secondResponse);
+
+			// when
+			List<BrandIssuedCampaignResponse> result = brandUsecase.getMyIssuedCampaignsInReview(brandId);
+
+			// then
+			assertThat(result).containsExactly(firstResponse, secondResponse);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		@DisplayName("getCreatorCampaignReview() : 브랜드 소유 캠페인의 리뷰 상세를 조립해 mapper에 전달한다")
+		void getCreatorCampaignReview_success() {
+			// given
+			Long campaignReviewId = 100L;
+			CampaignReview campaignReview = mock(CampaignReview.class);
+			CreatorCampaign creatorCampaign = mock(CreatorCampaign.class);
+			Campaign campaign = mock(Campaign.class, RETURNS_DEEP_STUBS);
+			Creator creator = mock(Creator.class, RETURNS_DEEP_STUBS);
+			CampaignReviewDetailListResponse expectedResponse = mock(CampaignReviewDetailListResponse.class);
+
+			Instant reviewRequestedAt = Instant.parse("2026-03-07T00:00:00Z");
+			List<String> mediaUrls = List.of("https://cdn.test/1.jpg", "https://cdn.test/2.jpg");
+
+			given(campaignReviewGetService.findById(campaignReviewId)).willReturn(campaignReview);
+			given(campaignReview.getCreatorCampaign()).willReturn(creatorCampaign);
+			given(creatorCampaign.getCampaign()).willReturn(campaign);
+			given(creatorCampaign.getCreator()).willReturn(creator);
+			given(campaign.getBrand().getId()).willReturn(brandId);
+
+			given(campaignReview.getReviewRound()).willReturn(ReviewRound.SECOND);
+			given(campaignReview.getPostUrl()).willReturn("https://instagram.com/p/test");
+			given(campaignReview.getRevisionRequestedAt()).willReturn(reviewRequestedAt);
+			given(campaignReviewGetService.getOrderedMediaUrls(campaignReview)).willReturn(mediaUrls);
+
+			given(creator.getId()).willReturn(55L);
+			given(creator.getCreatorName()).willReturn("creator-nickname");
+			given(creator.getUser().getName()).willReturn("홍길동");
+			given(creator.getUser().getProfileImageUrl()).willReturn("https://cdn.test/profile.jpg");
+
+			given(campaignReviewMapper.toDetailListResponse(
+				eq(campaign),
+				eq(campaignReview),
+				any(ReviewRound.class),
+				anyList(),
+				any(),
+				any(CreatorInfo.class),
+				any(Instant.class)
+			)).willReturn(expectedResponse);
+
+			// when
+			CampaignReviewDetailListResponse result =
+				brandUsecase.getCreatorCampaignReview(brandId, campaignReviewId);
+
+			// then
+			ArgumentCaptor<ReviewRound> reviewRoundCaptor = ArgumentCaptor.forClass(ReviewRound.class);
+			ArgumentCaptor<List<String>> mediaUrlsCaptor = ArgumentCaptor.forClass(List.class);
+			ArgumentCaptor<String> postUrlCaptor = ArgumentCaptor.forClass(String.class);
+			ArgumentCaptor<CreatorInfo> creatorInfoCaptor = ArgumentCaptor.forClass(CreatorInfo.class);
+			ArgumentCaptor<Instant> reviewRequestedAtCaptor = ArgumentCaptor.forClass(Instant.class);
+
+			then(campaignReviewMapper).should().toDetailListResponse(
+				eq(campaign),
+				eq(campaignReview),
+				reviewRoundCaptor.capture(),
+				mediaUrlsCaptor.capture(),
+				postUrlCaptor.capture(),
+				creatorInfoCaptor.capture(),
+				reviewRequestedAtCaptor.capture()
+			);
+
+			CreatorInfo expectedCreatorInfo = CreatorInfo.builder()
+				.creatorId(55L)
+				.creatorFullName("홍길동")
+				.creatorNickname("creator-nickname")
+				.profileImageUrl("https://cdn.test/profile.jpg")
+				.build();
+
+			assertThat(result).isSameAs(expectedResponse);
+			assertThat(reviewRoundCaptor.getValue()).isEqualTo(ReviewRound.SECOND);
+			assertThat(mediaUrlsCaptor.getValue()).containsExactlyElementsOf(mediaUrls);
+			assertThat(postUrlCaptor.getValue()).isEqualTo("https://instagram.com/p/test");
+			assertThat(creatorInfoCaptor.getValue())
+				.usingRecursiveComparison()
+				.isEqualTo(expectedCreatorInfo);
+			assertThat(reviewRequestedAtCaptor.getValue()).isEqualTo(reviewRequestedAt);
+		}
+
+		@Test
+		@DisplayName("getCreatorCampaignReview() : 다른 브랜드의 캠페인 리뷰면 예외를 던진다")
+		void getCreatorCampaignReview_notOwner_throwsException() {
+			// given
+			Long campaignReviewId = 100L;
+			CampaignReview campaignReview = mock(CampaignReview.class);
+			CreatorCampaign creatorCampaign = mock(CreatorCampaign.class);
+			Campaign campaign = mock(Campaign.class, RETURNS_DEEP_STUBS);
+
+			given(campaignReviewGetService.findById(campaignReviewId)).willReturn(campaignReview);
+			given(campaignReview.getCreatorCampaign()).willReturn(creatorCampaign);
+			given(creatorCampaign.getCampaign()).willReturn(campaign);
+			given(campaign.getBrand().getId()).willReturn(999L);
+
+			// when & then
+			assertThatThrownBy(() -> brandUsecase.getCreatorCampaignReview(brandId, campaignReviewId))
+				.isInstanceOf(NotCampaignOwnershipException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("브랜드 마이페이지 수정")
+	class UpdateBrandMyPage {
+
+		@Test
+		@DisplayName("updateBrandMyPage() : 브랜드를 조회한 뒤 마이페이지 정보를 수정한다")
+		void updateBrandMyPage_success() {
+			// given
+			BrandMyPageUpdateRequest request = mock(BrandMyPageUpdateRequest.class);
+			given(brandGetService.getBrandById(brandId)).willReturn(brand);
+
+			// when & then
+			assertThatCode(() -> brandUsecase.updateBrandMyPage(brandId, request))
+				.doesNotThrowAnyException();
+
+			then(brandUpdateService).should().updateBrandMyPage(brand, request);
+		}
+	}
+}

--- a/src/test/java/com/lokoko/domain/brand/BrandRegistrationTest.java
+++ b/src/test/java/com/lokoko/domain/brand/BrandRegistrationTest.java
@@ -1,0 +1,74 @@
+package com.lokoko.domain.brand;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Answers.*;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.lokoko.domain.brand.api.dto.request.BrandInfoUpdateRequest;
+import com.lokoko.domain.brand.api.dto.request.BrandProfileImageRequest;
+import com.lokoko.domain.brand.api.dto.response.BrandProfileImageResponse;
+import com.lokoko.domain.brand.domain.entity.Brand;
+
+@DisplayName("Brand 회원가입 Usecase 테스트")
+class BrandRegistrationTest extends BrandUsecaseTestSupport {
+
+	private Long brandId;
+	private Brand brand;
+	private BrandProfileImageRequest brandProfileImageRequest;
+	private BrandInfoUpdateRequest brandInfoUpdateRequest;
+	private BrandProfileImageResponse brandProfileImageResponse;
+
+	@BeforeEach
+	void setUp() {
+		brandId = 1L;
+		brand = mock(Brand.class, RETURNS_DEEP_STUBS);
+		brandProfileImageRequest = mock(BrandProfileImageRequest.class);
+		brandInfoUpdateRequest = mock(BrandInfoUpdateRequest.class);
+		brandProfileImageResponse = mock(BrandProfileImageResponse.class);
+	}
+
+	@Nested
+	@DisplayName("브랜드 프로필 이미지 presigned url 발급")
+	class CreateBrandProfilePresignedUrl {
+
+		@Test
+		@DisplayName("createBrandProfilePresignedUrl() : 브랜드를 조회한 뒤 presigned url 응답을 반환한다")
+		void createBrandProfilePresignedUrl_success() {
+			// given
+			given(brandGetService.getBrandById(brandId)).willReturn(brand);
+			given(brandUpdateService.createBrandProfilePresignedUrl(brand, brandProfileImageRequest))
+				.willReturn(brandProfileImageResponse);
+
+			// when
+			BrandProfileImageResponse result =
+				brandUsecase.createBrandProfilePresignedUrl(brandId, brandProfileImageRequest);
+
+			// then
+			assertThat(result).isSameAs(brandProfileImageResponse);
+		}
+	}
+
+	@Nested
+	@DisplayName("브랜드 회원가입 추가 정보 입력")
+	class UpdateBrandInfo {
+
+		@Test
+		@DisplayName("updateBrandInfo() : 브랜드를 조회한 뒤 추가 정보를 수정한다")
+		void updateBrandInfo_success() {
+			// given
+			given(brandGetService.getBrandById(brandId)).willReturn(brand);
+
+			// when & then
+			assertThatCode(() -> brandUsecase.updateBrandInfo(brandId, brandInfoUpdateRequest))
+				.doesNotThrowAnyException();
+
+			then(brandUpdateService).should().updateBrandInfo(brand, brandInfoUpdateRequest);
+		}
+	}
+}

--- a/src/test/java/com/lokoko/domain/brand/BrandUsecaseTestSupport.java
+++ b/src/test/java/com/lokoko/domain/brand/BrandUsecaseTestSupport.java
@@ -1,0 +1,55 @@
+package com.lokoko.domain.brand;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lokoko.domain.brand.application.service.BrandGetService;
+import com.lokoko.domain.brand.application.service.BrandUpdateService;
+import com.lokoko.domain.brand.application.usecase.BrandUsecase;
+import com.lokoko.domain.campaign.application.mapper.CampaignMapper;
+import com.lokoko.domain.campaign.application.service.CampaignGetService;
+import com.lokoko.domain.campaignReview.application.mapper.CampaignReviewMapper;
+import com.lokoko.domain.campaignReview.application.service.CampaignReviewGetService;
+import com.lokoko.domain.campaignReview.application.service.CampaignReviewStatusManager;
+import com.lokoko.domain.creatorCampaign.application.service.CreatorCampaignGetService;
+import com.lokoko.domain.media.socialclip.application.service.SocialClipGetService;
+import com.lokoko.global.config.BetaFeatureConfig;
+
+@ExtendWith(MockitoExtension.class)
+abstract class BrandUsecaseTestSupport {
+
+	@Mock
+	protected BrandGetService brandGetService;
+
+	@Mock
+	protected CampaignGetService campaignGetService;
+
+	@Mock
+	protected CreatorCampaignGetService creatorCampaignGetService;
+
+	@Mock
+	protected CampaignReviewGetService campaignReviewGetService;
+
+	@Mock
+	protected SocialClipGetService socialClipGetService;
+
+	@Mock
+	protected BrandUpdateService brandUpdateService;
+
+	@Mock
+	protected CampaignReviewStatusManager campaignReviewStatusManager;
+
+	@Mock
+	protected BetaFeatureConfig betaFeatureConfig;
+
+	@Mock
+	protected CampaignMapper campaignMapper;
+
+	@Mock
+	protected CampaignReviewMapper campaignReviewMapper;
+
+	@InjectMocks
+	protected BrandUsecase brandUsecase;
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #480 

## 작업 내용 💻
브랜드 도메인의 주요 비즈니스 로직에 대해 Mockito 기반 단위 테스트를 작성했습니다.  
공통적으로 반복되는 `given` 객체 설정은 `setUp()`으로 분리했고, 결과 검증은 `assertThat()` 중심으로 구성했습니다.  
단순 호출 여부를 전부 검증하기보다는, 실제 비즈니스 로직이 기대한 흐름대로 동작하는지와 권한/예외 케이스가 올바르게 처리되는지를 우선 확인하는 방향으로 테스트를 작성했습니다.

- [x] 	브랜드 회원가입 관련 테스트 코드 작성: `BrandRegistrationTest`
브랜드 조회 이후 update service로 정상 위임되는지, 응답 객체가 기대한 값으로 반환되는지 검증했습니다.  
회원가입 직후 브랜드가 입력하는 추가 정보와 프로필 이미지 업로드 진입점이 안전하게 동작하는지 확인하는 목적의 테스트입니다.

- [x] 	브랜드 마이페이지 테스트 코드 작성: `BrandMyPageTest`
프로필 조회, 통계 조회, 발행 캠페인 조회, 리뷰 상세 조회, 마이페이지 수정 흐름이 각각 올바르게 동작하는지 검증했습니다.
특히 크리에이터의 캠페인 조회에는 다른 브랜드가 발행한 캠페인 리뷰에 접근하는 경우, 발생하는 권한 검증도 함께 테스트했습니다.

- [x] 	브랜드 지원자/성과 테스트 코드 작성: `BrandApplicantManagementTest`
1차/2차 리뷰가 함께 존재할 때 어떤 리뷰를 우선 반영하는지, 리뷰 미제출/진행중/최종 업로드 상태가 비즈니스 규칙에 맞게 계산되는지 검증했습니다.  또한 베타 기능 플래그에 따라 1차 리뷰의 `postUrl`, 업로드 시간 처리 방식이 달라지는 부분도 함께 확인했습니다.

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 테스트 코드를 작성하다가 알게된 내용이지만, 캠페인별 크리에이터 성과 조회 메서드에 보완이 필요할거같습니다.
현재는 정상적으로 동작하고 있는 상황인데 page * size가 전체 크기를 넘으면 500 에러가 발생할 수도 있을거같아요
해당 작업은 따로 이슈 파서 작업하도록 할게요



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 브랜드 관련 기능에 대한 포괄적인 테스트 스위트 추가
  * 소유권 검증, 기본 기능, 프로필 관리 등 다양한 시나리오를 다루는 테스트 커버리지 확대
  * 테스트 인프라 개선으로 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->