### PR TITLE
[REFACTOR] #483 캠페인별 크리에이터 성과 조회 메서드 보완

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
@@ -1,5 +1,17 @@
 package com.lokoko.domain.brand.application.usecase;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.lokoko.domain.brand.api.dto.request.BrandInfoUpdateRequest;
 import com.lokoko.domain.brand.api.dto.request.BrandMyPageUpdateRequest;
 import com.lokoko.domain.brand.api.dto.request.BrandProfileImageRequest;
@@ -18,13 +30,12 @@ import com.lokoko.domain.campaign.exception.NotCampaignOwnershipException;
 import com.lokoko.domain.campaignReview.api.dto.response.CampaignReviewDetailListResponse;
 import com.lokoko.domain.campaignReview.application.mapper.CampaignReviewMapper;
 import com.lokoko.domain.campaignReview.application.service.CampaignReviewGetService;
-import com.lokoko.domain.campaignReview.application.service.CampaignReviewStatusManager;
 import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
 import com.lokoko.domain.campaignReview.domain.entity.enums.ContentStatus;
 import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
 import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewStatus;
-import com.lokoko.domain.creator.domain.entity.Creator;
 import com.lokoko.domain.creator.api.dto.response.CreatorInfo;
+import com.lokoko.domain.creator.domain.entity.Creator;
 import com.lokoko.domain.creatorCampaign.application.service.CreatorCampaignGetService;
 import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
 import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
@@ -33,359 +44,385 @@ import com.lokoko.domain.media.socialclip.domain.SocialClip;
 import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
 import com.lokoko.global.common.response.PageableResponse;
 import com.lokoko.global.config.BetaFeatureConfig;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
-import java.util.*;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class BrandUsecase {
 
-    private final BrandGetService brandGetService;
-    private final CampaignGetService campaignGetService;
-    private final CreatorCampaignGetService creatorCampaignGetService;
-    private final CampaignReviewGetService campaignReviewGetService;
-    private final SocialClipGetService socialClipGetService;
+	private final BrandGetService brandGetService;
+	private final CampaignGetService campaignGetService;
+	private final CreatorCampaignGetService creatorCampaignGetService;
+	private final CampaignReviewGetService campaignReviewGetService;
+	private final SocialClipGetService socialClipGetService;
 
-    private final BrandUpdateService brandUpdateService;
+	private final BrandUpdateService brandUpdateService;
 
-    private final CampaignReviewStatusManager campaignReviewStatusManager;
-    private final BetaFeatureConfig betaFeatureConfig;
+	private final BetaFeatureConfig betaFeatureConfig;
 
-    private final CampaignMapper campaignMapper;
-    private final CampaignReviewMapper campaignReviewMapper;
+	private final CampaignMapper campaignMapper;
+	private final CampaignReviewMapper campaignReviewMapper;
 
-    @Transactional
-    public BrandProfileImageResponse createBrandProfilePresignedUrl(Long brandId, BrandProfileImageRequest request) {
-        Brand brand = brandGetService.getBrandById(brandId);
+	@Transactional
+	public BrandProfileImageResponse createBrandProfilePresignedUrl(Long brandId, BrandProfileImageRequest request) {
+		Brand brand = brandGetService.getBrandById(brandId);
 
-        return brandUpdateService.createBrandProfilePresignedUrl(brand, request);
-    }
+		return brandUpdateService.createBrandProfilePresignedUrl(brand, request);
+	}
 
-    @Transactional(readOnly = true)
-    public BrandMyPageResponse getBrandMyPage(Long brandId) {
-        Brand brand = brandGetService.getBrandWithUserById(brandId);
+	@Transactional(readOnly = true)
+	public BrandMyPageResponse getBrandMyPage(Long brandId) {
+		Brand brand = brandGetService.getBrandWithUserById(brandId);
 
-        return BrandMyPageResponse.from(brand, brand.getUser());
-    }
+		return BrandMyPageResponse.from(brand, brand.getUser());
+	}
 
-    @Transactional(readOnly = true)
-    public BrandProfileAndStatisticsResponse getBrandProfileAndStatistics(Long brandId) {
-        Brand brand = brandGetService.getBrandById(brandId);
+	@Transactional(readOnly = true)
+	public BrandProfileAndStatisticsResponse getBrandProfileAndStatistics(Long brandId) {
+		Brand brand = brandGetService.getBrandById(brandId);
 
-        Instant now = Instant.now();
-        int ongoingCampaigns = campaignGetService.countOngoingCampaigns(brandId, now);
-        int completedCampaigns = campaignGetService.countCompletedCampaigns(brandId, now);
+		Instant now = Instant.now();
+		int ongoingCampaigns = campaignGetService.countOngoingCampaigns(brandId, now);
+		int completedCampaigns = campaignGetService.countCompletedCampaigns(brandId, now);
 
-        return BrandProfileAndStatisticsResponse.of(brand, ongoingCampaigns, completedCampaigns);
-    }
+		return BrandProfileAndStatisticsResponse.of(brand, ongoingCampaigns, completedCampaigns);
+	}
 
-    @Transactional(readOnly = true)
-    public List<BrandIssuedCampaignResponse> getMyIssuedCampaignsInReview(Long brandId) {
-        Brand brand = brandGetService.getBrandById(brandId);
-        List<Campaign> campaigns = campaignGetService.getBrandIssuedCampaignsInReview(brand);
+	@Transactional(readOnly = true)
+	public List<BrandIssuedCampaignResponse> getMyIssuedCampaignsInReview(Long brandId) {
+		Brand brand = brandGetService.getBrandById(brandId);
+		List<Campaign> campaigns = campaignGetService.getBrandIssuedCampaignsInReview(brand);
 
-        return campaigns.stream()
-                .map(campaignMapper::toBrandIssuedCampaignResponse)
-                .toList();
-    }
+		return campaigns.stream()
+			.map(campaignMapper::toBrandIssuedCampaignResponse)
+			.toList();
+	}
 
-    @Transactional(readOnly = true)
-    public CampaignReviewDetailListResponse getCreatorCampaignReview(Long brandId, Long campaignReviewId) {
+	@Transactional(readOnly = true)
+	public CampaignReviewDetailListResponse getCreatorCampaignReview(Long brandId, Long campaignReviewId) {
 
-        // 캠페인 리뷰 ID로 캠페인 리뷰 조회
-        CampaignReview review = campaignReviewGetService.findById(campaignReviewId);
+		// 캠페인 리뷰 ID로 캠페인 리뷰 조회
+		CampaignReview review = campaignReviewGetService.findById(campaignReviewId);
 
-        // 연관 엔티티들
-        CreatorCampaign creatorCampaign = review.getCreatorCampaign();
-        Campaign campaign = creatorCampaign.getCampaign();
-        Creator creator = creatorCampaign.getCreator();
+		// 연관 엔티티들
+		CreatorCampaign creatorCampaign = review.getCreatorCampaign();
+		Campaign campaign = creatorCampaign.getCampaign();
+		Creator creator = creatorCampaign.getCreator();
 
-        // 브랜드 권한 검증 (해당 브랜드가 발행한 캠페인인지 아닌지)
-        if (!campaign.getBrand().getId().equals(brandId)) {
-            throw new NotCampaignOwnershipException();
-        }
+		// 브랜드 권한 검증 (해당 브랜드가 발행한 캠페인인지 아닌지)
+		if (!campaign.getBrand().getId().equals(brandId)) {
+			throw new NotCampaignOwnershipException();
+		}
 
-        // 현재 라운드 결정 (일단 미사용)
-        //ReviewRound round = campaignReviewStatusManager.determineReviewRound(
-        //        campaign.getCampaignStatus(),
-        //        creatorCampaign.getStatus()
-        //);
+		// 현재 라운드 결정 (일단 미사용)
+		//ReviewRound round = campaignReviewStatusManager.determineReviewRound(
+		//        campaign.getCampaignStatus(),
+		//        creatorCampaign.getStatus()
+		//);
 
-        // 현재 DB에 저장된 round를 가져와서 검증
-        ReviewRound round = review.getReviewRound();
+		// 현재 DB에 저장된 round를 가져와서 검증
+		ReviewRound round = review.getReviewRound();
 
-        // 업로드 된 미디어 URL 조회
-        List<String> mediaUrls = campaignReviewGetService.getOrderedMediaUrls(review);
+		// 업로드 된 미디어 URL 조회
+		List<String> mediaUrls = campaignReviewGetService.getOrderedMediaUrls(review);
 
-        // 만약 2차 리뷰이고, postUrl이 존재한다면 같이 내려주기
-        String postUrl = null;
-        if (round == ReviewRound.SECOND && review.getPostUrl() != null) {
-            postUrl = review.getPostUrl();
-        }
+		// 만약 2차 리뷰이고, postUrl이 존재한다면 같이 내려주기
+		String postUrl = null;
+		if (round == ReviewRound.SECOND && review.getPostUrl() != null) {
+			postUrl = review.getPostUrl();
+		}
 
-        // 크리에이터 정보
-        CreatorInfo creatorInfo = CreatorInfo.builder()
-                .creatorId(creator.getId())
-                .creatorFullName(creator.getUser().getName())
-                .creatorNickname(creator.getCreatorName())
-                .profileImageUrl(creator.getUser().getProfileImageUrl())
-                .build();
+		// 크리에이터 정보
+		CreatorInfo creatorInfo = CreatorInfo.builder()
+			.creatorId(creator.getId())
+			.creatorFullName(creator.getUser().getName())
+			.creatorNickname(creator.getCreatorName())
+			.profileImageUrl(creator.getUser().getProfileImageUrl())
+			.build();
 
-        // 검토 요청 시간 (브랜드가 수정 요청한 시간)
-        Instant reviewRequestedAt = review.getRevisionRequestedAt();
+		// 검토 요청 시간 (브랜드가 수정 요청한 시간)
+		Instant reviewRequestedAt = review.getRevisionRequestedAt();
 
-        return campaignReviewMapper.toDetailListResponse(
-                campaign,
-                review,
-                round,
-                mediaUrls,
-                postUrl,
-                creatorInfo,
-                reviewRequestedAt
-        );
-    }
+		return campaignReviewMapper.toDetailListResponse(
+			campaign,
+			review,
+			round,
+			mediaUrls,
+			postUrl,
+			creatorInfo,
+			reviewRequestedAt
+		);
+	}
 
-    @Transactional
-    public void updateBrandInfo(Long brandId, BrandInfoUpdateRequest request) {
-        Brand brand = brandGetService.getBrandById(brandId);
-        brandUpdateService.updateBrandInfo(brand, request);
-    }
+	@Transactional
+	public void updateBrandInfo(Long brandId, BrandInfoUpdateRequest request) {
+		Brand brand = brandGetService.getBrandById(brandId);
+		brandUpdateService.updateBrandInfo(brand, request);
+	}
 
-    @Transactional
-    public void updateBrandMyPage(Long brandId, BrandMyPageUpdateRequest request) {
-        Brand brand = brandGetService.getBrandById(brandId);
-        brandUpdateService.updateBrandMyPage(brand, request);
-    }
+	@Transactional
+	public void updateBrandMyPage(Long brandId, BrandMyPageUpdateRequest request) {
+		Brand brand = brandGetService.getBrandById(brandId);
+		brandUpdateService.updateBrandMyPage(brand, request);
+	}
 
-    /**
-     * 브랜드 컨텐츠 확인 API - 캠페인별 크리에이터 성과 조회
-     */
-    @Transactional(readOnly = true)
-    public CreatorPerformanceResponse getCreatorPerformances(Long brandId, Long campaignId, int page, int size) {
-        Brand brand = brandGetService.getBrandById(brandId);
-        Campaign campaign = campaignGetService.findByCampaignId(campaignId);
+	/**
+	 * 브랜드 컨텐츠 확인 API - 캠페인별 크리에이터 성과 조회
+	 */
+	@Transactional(readOnly = true)
+	public CreatorPerformanceResponse getCreatorPerformances(Long brandId, Long campaignId, int page, int size) {
+		Brand brand = brandGetService.getBrandById(brandId);
+		Campaign campaign = campaignGetService.findByCampaignId(campaignId);
 
-        // 브랜드 권한 검증
-        if (!campaign.getBrand().getId().equals(brandId)) {
-            throw new NotCampaignOwnershipException();
-        }
+		validateCampaignOwnership(brand, campaign);
 
-        // 해당 캠페인에 참여한 승인된 CreatorCampaign만 조회 (REJECTED 제외), 지원 순서대로 정렬
-        List<CreatorCampaign> creatorCampaigns = creatorCampaignGetService.findAllByCampaign(campaign).stream()
-                .filter(cc -> cc.getStatus() != ParticipationStatus.REJECTED)
-                .sorted(Comparator.comparing(CreatorCampaign::getAppliedAt))
-                .toList();
+		List<CreatorCampaign> approvedCreatorCampaigns = creatorCampaignGetService.findAllByCampaign(campaign).stream()
+			.filter(creatorCampaign -> creatorCampaign.getStatus() != ParticipationStatus.REJECTED)
+			.sorted(Comparator.comparing(CreatorCampaign::getAppliedAt))
+			.toList();
 
-        // 크리에이터별로 그룹화하여 리뷰 정보 구성 (지원 순서 유지)
-        List<CreatorPerformanceResponse.CreatorReviewPerformance> allCreatorPerformances = creatorCampaigns.stream()
-                .collect(Collectors.groupingBy(
-                        CreatorCampaign::getCreator,
-                        LinkedHashMap::new,
-                        Collectors.toList()
-                ))
-                .entrySet().stream()
-                .map(entry -> {
-                    Creator creator = entry.getKey();
-                    List<CreatorCampaign> ccList = entry.getValue();
+		List<CreatorPerformanceResponse.CreatorReviewPerformance> allCreatorPerformances =
+			approvedCreatorCampaigns.stream()
+				.collect(Collectors.groupingBy(
+					CreatorCampaign::getCreator,
+					LinkedHashMap::new,
+					Collectors.toList()
+				))
+				.entrySet().stream()
+				.map(creatorCampaignEntry -> {
+					Creator creator = creatorCampaignEntry.getKey();
+					List<CreatorCampaign> creatorCampaignList = creatorCampaignEntry.getValue();
 
-                    // 해당 크리에이터의 모든 리뷰 조회
-                    List<CreatorPerformanceResponse.ReviewPerformance> reviews = buildReviewPerformances(campaign, ccList);
+					List<CreatorPerformanceResponse.ReviewPerformance> reviewPerformances =
+						buildReviewPerformances(campaign, creatorCampaignList);
 
-                    return CreatorPerformanceResponse.CreatorReviewPerformance.builder()
-                            .creator(CreatorInfo.builder()
-                                    .creatorId(creator.getId())
-                                    .creatorFullName(creator.getUser().getName())
-                                    .creatorNickname(creator.getCreatorName())
-                                    .profileImageUrl(creator.getUser().getProfileImageUrl())
-                                    .build())
-                            .reviews(reviews)
-                            .build();
-                })
-                .collect(Collectors.toList());
+					return CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+						.creator(CreatorInfo.builder()
+							.creatorId(creator.getId())
+							.creatorFullName(creator.getUser().getName())
+							.creatorNickname(creator.getCreatorName())
+							.profileImageUrl(creator.getUser().getProfileImageUrl())
+							.build())
+						.reviews(reviewPerformances)
+						.build();
+				})
+				.toList();
 
-        // 페이징 처리
-        long totalElements = allCreatorPerformances.size();
-        int startIndex = page * size;
-        int endIndex = Math.min(startIndex + size, allCreatorPerformances.size());
+		return buildPagedCreatorPerformanceResponse(campaign, allCreatorPerformances, page, size);
+	}
 
-        List<CreatorPerformanceResponse.CreatorReviewPerformance> pagedCreatorPerformances =
-                allCreatorPerformances.subList(startIndex, endIndex);
+	private void validateCampaignOwnership(Brand brand, Campaign campaign) {
+		if (!campaign.getBrand().getId().equals(brand.getId())) {
+			throw new NotCampaignOwnershipException();
+		}
+	}
 
-        PageableResponse pageableResponse = PageableResponse.of(
-                page,
-                size,
-                pagedCreatorPerformances.size(),
-                endIndex >= allCreatorPerformances.size(),
-                totalElements
-        );
+	private CreatorPerformanceResponse buildPagedCreatorPerformanceResponse(
+		Campaign campaign,
+		List<CreatorPerformanceResponse.CreatorReviewPerformance> allCreatorPerformances,
+		int page,
+		int size
+	) {
+		long totalElements = allCreatorPerformances.size();
+		long startIndex = (long)page * size;
 
-        return CreatorPerformanceResponse.builder()
-                .campaignId(campaign.getId())
-                .campaignTitle(campaign.getTitle())
-                .firstContentPlatform(campaign.getFirstContentPlatform())
-                .secondContentPlatform(campaign.getSecondContentPlatform())
-                .creators(pagedCreatorPerformances)
-                .pageableResponse(pageableResponse)
-                .build();
-    }
+		if (startIndex >= totalElements) {
+			PageableResponse pageableResponse = PageableResponse.of(
+				page,
+				size,
+				0,
+				true,
+				totalElements
+			);
 
-    /**
-     * 크리에이터의 리뷰 성과 정보 구성
-     */
-    private List<CreatorPerformanceResponse.ReviewPerformance> buildReviewPerformances(
-            Campaign campaign, List<CreatorCampaign> creatorCampaigns) {
+			return buildCreatorPerformanceResponse(campaign, List.of(), pageableResponse);
+		}
 
-        // 캠페인의 콘텐츠 타입들
-        List<ContentType> contentTypes = new ArrayList<>();
-        contentTypes.add(campaign.getFirstContentPlatform());
-        if (campaign.getSecondContentPlatform() != null) {
-            contentTypes.add(campaign.getSecondContentPlatform());
-        }
+		int safeStartIndex = (int)startIndex;
+		int endIndex = (int)Math.min(startIndex + size, totalElements);
 
-        List<CreatorPerformanceResponse.ReviewPerformance> performances = new ArrayList<>();
+		List<CreatorPerformanceResponse.CreatorReviewPerformance> pagedCreatorPerformances =
+			allCreatorPerformances.subList(safeStartIndex, endIndex);
 
-        // 각 CreatorCampaign에 대해 처리
-        for (CreatorCampaign cc : creatorCampaigns) {
-            // 해당 CreatorCampaign의 모든 리뷰 조회
-            List<CampaignReview> reviews = campaignReviewGetService.findAllByCreatorCampaignId(cc.getId());
+		PageableResponse pageableResponse = PageableResponse.of(
+			page,
+			size,
+			pagedCreatorPerformances.size(),
+			endIndex >= totalElements,
+			totalElements
+		);
 
-            // contentType별로 리뷰를 맵으로 구성 (1차/2차 구분)
-            Map<ContentType, CampaignReview> firstReviews = reviews.stream()
-                    .filter(r -> r.getReviewRound() == ReviewRound.FIRST)
-                    .collect(Collectors.toMap(CampaignReview::getContentType, r -> r, (a, b) -> a));
+		return buildCreatorPerformanceResponse(campaign, pagedCreatorPerformances, pageableResponse);
+	}
 
-            Map<ContentType, CampaignReview> secondReviews = reviews.stream()
-                    .filter(r -> r.getReviewRound() == ReviewRound.SECOND)
-                    .collect(Collectors.toMap(CampaignReview::getContentType, r -> r, (a, b) -> a));
+	private CreatorPerformanceResponse buildCreatorPerformanceResponse(
+		Campaign campaign,
+		List<CreatorPerformanceResponse.CreatorReviewPerformance> creatorPerformances,
+		PageableResponse pageableResponse
+	) {
+		return CreatorPerformanceResponse.builder()
+			.campaignId(campaign.getId())
+			.campaignTitle(campaign.getTitle())
+			.firstContentPlatform(campaign.getFirstContentPlatform())
+			.secondContentPlatform(campaign.getSecondContentPlatform())
+			.creators(creatorPerformances)
+			.pageableResponse(pageableResponse)
+			.build();
+	}
 
-            // 각 contentType에 대해 리뷰 성과 정보 생성
-            for (ContentType contentType : contentTypes) {
-                CampaignReview secondReview = secondReviews.get(contentType);
-                CampaignReview firstReview = firstReviews.get(contentType);
+	/**
+	 * 크리에이터의 리뷰 성과 정보 구성
+	 */
+	private List<CreatorPerformanceResponse.ReviewPerformance> buildReviewPerformances(
+		Campaign campaign, List<CreatorCampaign> creatorCampaigns) {
 
-                if (secondReview != null) {
-                    // 2차 리뷰가 있는 경우
-                    performances.add(buildReviewPerformance(secondReview));
-                } else if (firstReview != null) {
-                    // 1차 리뷰만 있는 경우
-                    performances.add(buildReviewPerformance(firstReview));
-                } else {
-                    // 리뷰가 없는 경우
-                    ContentStatus contentStatus;
+		// 캠페인의 콘텐츠 타입들
+		List<ContentType> contentTypes = new ArrayList<>();
+		contentTypes.add(campaign.getFirstContentPlatform());
+		if (campaign.getSecondContentPlatform() != null) {
+			contentTypes.add(campaign.getSecondContentPlatform());
+		}
 
-                    // 배송지 입력 여부에 따라 상태 결정
-                    if (cc.getAddressConfirmed() != null && cc.getAddressConfirmed()) {
-                        // 배송지는 입력했지만 1차 리뷰 미업로드 = 진행중
-                        contentStatus = ContentStatus.IN_PROGRESS;
-                    } else {
-                        // 배송지 미입력 = 미제출
-                        contentStatus = ContentStatus.NOT_SUBMITTED;
-                    }
+		List<CreatorPerformanceResponse.ReviewPerformance> performances = new ArrayList<>();
 
-                    performances.add(CreatorPerformanceResponse.ReviewPerformance.builder()
-                            .reviewRound(ReviewRound.FIRST)
-                            .reviewStatus(contentStatus)
-                            .contents(CreatorPerformanceResponse.ContentMetrics.builder()
-                                    .contentType(contentType)
-                                    .build())
-                            .build());
-                }
-            }
-        }
+		// 각 CreatorCampaign에 대해 처리
+		for (CreatorCampaign cc : creatorCampaigns) {
+			// 해당 CreatorCampaign의 모든 리뷰 조회
+			List<CampaignReview> reviews = campaignReviewGetService.findAllByCreatorCampaignId(cc.getId());
 
-        return performances;
-    }
+			// contentType별로 리뷰를 맵으로 구성 (1차/2차 구분)
+			Map<ContentType, CampaignReview> firstReviews = reviews.stream()
+				.filter(r -> r.getReviewRound() == ReviewRound.FIRST)
+				.collect(Collectors.toMap(CampaignReview::getContentType, r -> r, (a, b) -> a));
 
-    /**
-     * 개별 리뷰의 성과 정보 생성
-     */
-    private CreatorPerformanceResponse.ReviewPerformance buildReviewPerformance(CampaignReview review) {
-        ContentStatus contentStatus = getReviewContentStatus(review);
-        String postUrl = null;
-        Long viewCount = null;
-        Long likeCount = null;
-        Long commentCount = null;
-        Long shareCount = null;
-        Instant uploadedAt = null;
+			Map<ContentType, CampaignReview> secondReviews = reviews.stream()
+				.filter(r -> r.getReviewRound() == ReviewRound.SECOND)
+				.collect(Collectors.toMap(CampaignReview::getContentType, r -> r, (a, b) -> a));
 
-        // postUrl 처리 (베타: 1차 리뷰도 포함, 정식: 2차 리뷰만)
-        if (review.getReviewRound() == ReviewRound.SECOND && review.getStatus() == ReviewStatus.RESUBMITTED) {
-            // 2차 리뷰의 경우 항상 postUrl 포함
-            postUrl = review.getPostUrl();
+			// 각 contentType에 대해 리뷰 성과 정보 생성
+			for (ContentType contentType : contentTypes) {
+				CampaignReview secondReview = secondReviews.get(contentType);
+				CampaignReview firstReview = firstReviews.get(contentType);
 
-            // SocialClip에서 성과 지표 조회
-            Optional<SocialClip> socialClip = socialClipGetService.findByCampaignReview(review);
-            if (socialClip.isPresent()) {
-                SocialClip clip = socialClip.get();
-                viewCount = clip.getPlays();
-                likeCount = clip.getLikes();
-                commentCount = clip.getComments();
-                shareCount = clip.getShares();
-                uploadedAt = clip.getUploadedAt();
-            }
-        // 정식 릴리즈 시 제거
-        } else if (betaFeatureConfig.isFirstReviewUrlEnabled() &&
-                   review.getReviewRound() == ReviewRound.FIRST &&
-                   review.getPostUrl() != null) {
-           // 1차 리뷰에도 postUrl이 있으면 포함
-            postUrl = review.getPostUrl();
-            // LocalDateTime은 한국 시간(UTC+9)이므로 9시간을 빼서 UTC로 변환
-            uploadedAt = review.getCreatedAt().toInstant(java.time.ZoneOffset.ofHours(9));
-        }
+				if (secondReview != null) {
+					// 2차 리뷰가 있는 경우
+					performances.add(buildReviewPerformance(secondReview));
+				} else if (firstReview != null) {
+					// 1차 리뷰만 있는 경우
+					performances.add(buildReviewPerformance(firstReview));
+				} else {
+					// 리뷰가 없는 경우
+					ContentStatus contentStatus;
 
-        CreatorPerformanceResponse.ContentMetrics contents = null;
-        if (review.getContentType() != null) {
-            contents = CreatorPerformanceResponse.ContentMetrics.builder()
-                    .contentType(review.getContentType())
-                    .viewCount(viewCount)
-                    .likeCount(likeCount)
-                    .commentCount(commentCount)
-                    .shareCount(shareCount)
-                    .build();
-        }
+					// 배송지 입력 여부에 따라 상태 결정
+					if (cc.getAddressConfirmed() != null && cc.getAddressConfirmed()) {
+						// 배송지는 입력했지만 1차 리뷰 미업로드 = 진행중
+						contentStatus = ContentStatus.IN_PROGRESS;
+					} else {
+						// 배송지 미입력 = 미제출
+						contentStatus = ContentStatus.NOT_SUBMITTED;
+					}
 
-        return CreatorPerformanceResponse.ReviewPerformance.builder()
-                .campaignReviewId(review.getId())
-                .reviewRound(review.getReviewRound())
-                .reviewStatus(contentStatus)
-                .postUrl(postUrl)
-                .contents(contents)
-                .uploadedAt(uploadedAt)
-                .build();
-    }
+					performances.add(CreatorPerformanceResponse.ReviewPerformance.builder()
+						.reviewRound(ReviewRound.FIRST)
+						.reviewStatus(contentStatus)
+						.contents(CreatorPerformanceResponse.ContentMetrics.builder()
+							.contentType(contentType)
+							.build())
+						.build());
+				}
+			}
+		}
 
-    /**
-     * 리뷰 상태를 ContentStatus enum으로 변환
-     * PENDING_REVISION: 브랜드 리뷰 대기중 또는 수정 요청 후 크리에이터 노트 미확인
-     * REVISING: 브랜드가 수정 요청 + 크리에이터가 노트 확인
-     * FINAL_UPLOADED: 최종 업로드 완료 (베타: 1차 리뷰 완료, 정식: 2차 리뷰 완료)
-     */
-    private ContentStatus getReviewContentStatus(CampaignReview review) {
-        ReviewStatus status = review.getStatus();
+		return performances;
+	}
 
-        // 베타 모드에서 1차 리뷰 SUBMITTED 상태는 최종 완료로 처리 , 정식 릴리즈시 제거
-        if (betaFeatureConfig.isSimplifiedReviewFlow() &&
-            review.getReviewRound() == ReviewRound.FIRST &&
-            status == ReviewStatus.SUBMITTED) {
-            return ContentStatus.FINAL_UPLOADED;
-        }
+	/**
+	 * 개별 리뷰의 성과 정보 생성
+	 */
+	private CreatorPerformanceResponse.ReviewPerformance buildReviewPerformance(CampaignReview review) {
+		ContentStatus contentStatus = getReviewContentStatus(review);
+		String postUrl = null;
+		Long viewCount = null;
+		Long likeCount = null;
+		Long commentCount = null;
+		Long shareCount = null;
+		Instant uploadedAt = null;
 
-        // 정식 모드 또는 2차 리뷰 처리
-        return switch (status) {
-            case SUBMITTED -> ContentStatus.PENDING_REVISION;
-            case REVISION_REQUESTED -> {
-                if (review.isNoteViewed()) {
-                    yield ContentStatus.REVISING;
-                } else {
-                    yield ContentStatus.PENDING_REVISION;
-                }
-            }
-            case RESUBMITTED -> ContentStatus.FINAL_UPLOADED;
-        };
-    }
+		// postUrl 처리 (베타: 1차 리뷰도 포함, 정식: 2차 리뷰만)
+		if (review.getReviewRound() == ReviewRound.SECOND && review.getStatus() == ReviewStatus.RESUBMITTED) {
+			// 2차 리뷰의 경우 항상 postUrl 포함
+			postUrl = review.getPostUrl();
+
+			// SocialClip에서 성과 지표 조회
+			Optional<SocialClip> socialClip = socialClipGetService.findByCampaignReview(review);
+			if (socialClip.isPresent()) {
+				SocialClip clip = socialClip.get();
+				viewCount = clip.getPlays();
+				likeCount = clip.getLikes();
+				commentCount = clip.getComments();
+				shareCount = clip.getShares();
+				uploadedAt = clip.getUploadedAt();
+			}
+			// 정식 릴리즈 시 제거
+		} else if (betaFeatureConfig.isFirstReviewUrlEnabled() &&
+			review.getReviewRound() == ReviewRound.FIRST &&
+			review.getPostUrl() != null) {
+			// 1차 리뷰에도 postUrl이 있으면 포함
+			postUrl = review.getPostUrl();
+			// LocalDateTime은 한국 시간(UTC+9)이므로 9시간을 빼서 UTC로 변환
+			uploadedAt = review.getCreatedAt().toInstant(java.time.ZoneOffset.ofHours(9));
+		}
+
+		CreatorPerformanceResponse.ContentMetrics contents = null;
+		if (review.getContentType() != null) {
+			contents = CreatorPerformanceResponse.ContentMetrics.builder()
+				.contentType(review.getContentType())
+				.viewCount(viewCount)
+				.likeCount(likeCount)
+				.commentCount(commentCount)
+				.shareCount(shareCount)
+				.build();
+		}
+
+		return CreatorPerformanceResponse.ReviewPerformance.builder()
+			.campaignReviewId(review.getId())
+			.reviewRound(review.getReviewRound())
+			.reviewStatus(contentStatus)
+			.postUrl(postUrl)
+			.contents(contents)
+			.uploadedAt(uploadedAt)
+			.build();
+	}
+
+	/**
+	 * 리뷰 상태를 ContentStatus enum으로 변환
+	 * PENDING_REVISION: 브랜드 리뷰 대기중 또는 수정 요청 후 크리에이터 노트 미확인
+	 * REVISING: 브랜드가 수정 요청 + 크리에이터가 노트 확인
+	 * FINAL_UPLOADED: 최종 업로드 완료 (베타: 1차 리뷰 완료, 정식: 2차 리뷰 완료)
+	 */
+	private ContentStatus getReviewContentStatus(CampaignReview review) {
+		ReviewStatus status = review.getStatus();
+
+		// 베타 모드에서 1차 리뷰 SUBMITTED 상태는 최종 완료로 처리 , 정식 릴리즈시 제거
+		if (betaFeatureConfig.isSimplifiedReviewFlow() &&
+			review.getReviewRound() == ReviewRound.FIRST &&
+			status == ReviewStatus.SUBMITTED) {
+			return ContentStatus.FINAL_UPLOADED;
+		}
+
+		// 정식 모드 또는 2차 리뷰 처리
+		return switch (status) {
+			case SUBMITTED -> ContentStatus.PENDING_REVISION;
+			case REVISION_REQUESTED -> {
+				if (review.isNoteViewed()) {
+					yield ContentStatus.REVISING;
+				} else {
+					yield ContentStatus.PENDING_REVISION;
+				}
+			}
+			case RESUBMITTED -> ContentStatus.FINAL_UPLOADED;
+		};
+	}
 }


### PR DESCRIPTION
## Related issue 🛠

- closed #482 

## 작업 내용 💻
브랜드 지원자/성과 조회 로직 중 페이징 경계값 처리 보완 작업을 진행했습니다.  
공통적으로 범위를 벗어난 페이지 요청이 들어오더라도 500 에러로 이어지지 않도록 방어 로직을 추가했고, 해당 흐름을 검증하는 테스트 코드도 함께 작성했습니다.
- [x] 캠페인별 크리에이터 성과 조회 getCreatorPerformances 메서드 보완

- `getCreatorPerformances()`에서 `page * size`가 전체 크기를 초과하는 경우 `subList()`를 바로 호출하지 않도록 보완했어요.  
-  기존에는 범위를 벗어난 페이지 요청 시 `IndexOutOfBoundsException` 가능성이 있었는데, 이번 수정으로 빈 `creators` 리스트와 정상적인 `PageableResponse`를 반환하도록 변경했습니다.  
- 응답 생성 로직도 별도 메서드로 분리해서 중복을 줄이고 가독성을 높였지만, 컨트롤러와 서비스단의 강결합을 줄여주기위해 만들었던 유스케이스단에 너무 과도한 책임이 있는건 아닌지 걱정이 되기도 합니다.

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 이번 작업은 우선 `page * size` 초과 케이스를 보완하는 범위로 진행하긴 했습니다.
- 현재 모든 컨트롤러에서는 `page`, `size`에 대한 음수와 0에 대한 `validation`이 별도로 없어서, 이후 `@Min(0)`, `@Positive` 등을 활용한 요청 파라미터 검증을 추가하면 더 안전할 것 같다는 생각이 들었어요
- 변경된 흐름에 맞춰서 테스트 코드도 재작성 예정입니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 브랜드 기능의 내부 코드 구조를 개선하여 유지보수성을 향상시켰습니다.
  * 캠페인 소유권 확인 로직을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->