### PR TITLE
[TEST] #487 캠페인, 크리에이터 도메인 관련 테스트 코드 작성

### DIFF
--- a/src/test/java/com/lokoko/domain/campaign/domain/entity/CampaignTest.java
+++ b/src/test/java/com/lokoko/domain/campaign/domain/entity/CampaignTest.java
@@ -23,11 +23,11 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Campaign domain validation")
+@DisplayName("캠페인 도메인 검증")
 class CampaignTest {
 
     @Test
-    @DisplayName("isDraft() ignores missing brand relation when required publish fields are present")
+    @DisplayName("isDraft() : 발행 필수값이 모두 있으면 brand 연관관계가 없어도 draft가 아니다")
     void isDraft_ignoresMissingBrandRelation() {
         Campaign campaign = completeCampaignBuilder()
                 .brand(null)
@@ -38,7 +38,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validatePublishable() throws when a required brand-campaign field is missing")
+    @DisplayName("validatePublishable() : 필수 필드가 비어 있으면 예외를 던진다")
     void validatePublishable_throwsWhenRequiredFieldMissing() {
         Campaign campaign = completeCampaignBuilder()
                 .firstContentPlatform(null)
@@ -49,7 +49,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validatePublishableForAdmin() allows admin campaign without brand relation when brandName exists")
+    @DisplayName("validatePublishableForAdmin() : brandName 이 있으면 brand 연관관계 없이도 통과한다")
     void validatePublishableForAdmin_allowsBrandNameWithoutBrandRelation() {
         Campaign campaign = completeCampaignBuilder()
                 .brand(null)
@@ -61,7 +61,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validatePublishableForAdmin() requires brandName for admin-created campaigns")
+    @DisplayName("validatePublishableForAdmin() : 어드민 캠페인은 brandName 이 필수다")
     void validatePublishableForAdmin_requiresBrandName() {
         Campaign campaign = completeCampaignBuilder()
                 .brand(null)
@@ -73,7 +73,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("publish() marks the campaign as published and waiting approval")
+    @DisplayName("publish() : 캠페인을 발행 상태와 승인 대기 상태로 변경한다")
     void publish_marksCampaignAsWaitingApproval() {
         Campaign campaign = completeCampaignBuilder()
                 .campaignStatus(CampaignStatus.DRAFT)
@@ -87,7 +87,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validateParticipatableAt() rejects campaigns before the application window opens")
+    @DisplayName("validateParticipatableAt() : 신청 시작 전이면 예외를 던진다")
     void validateParticipatableAt_rejectsBeforeStart() {
         Instant now = Instant.parse("2026-03-11T00:00:00Z");
         Campaign campaign = completeCampaignBuilder()
@@ -100,7 +100,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validateParticipatableAt() rejects campaigns after the deadline")
+    @DisplayName("validateParticipatableAt() : 신청 마감 후면 예외를 던진다")
     void validateParticipatableAt_rejectsAfterDeadline() {
         Instant now = Instant.parse("2026-03-11T00:00:00Z");
         Campaign campaign = completeCampaignBuilder()
@@ -114,7 +114,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validateParticipatableAt() requires recruiting status")
+    @DisplayName("validateParticipatableAt() : 모집 중 상태가 아니면 예외를 던진다")
     void validateParticipatableAt_requiresRecruitingStatus() {
         Instant now = Instant.parse("2026-03-11T00:00:00Z");
         Campaign campaign = completeCampaignBuilder()
@@ -128,7 +128,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validateParticipatableAt() rejects full recruitment")
+    @DisplayName("validateParticipatableAt() : 모집 인원이 가득 찼으면 예외를 던진다")
     void validateParticipatableAt_rejectsFullRecruitment() {
         Instant now = Instant.parse("2026-03-11T00:00:00Z");
         Campaign campaign = completeCampaignBuilder()
@@ -144,7 +144,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("approveByAdmin() moves campaigns with a future start to OPEN_RESERVED")
+    @DisplayName("approveByAdmin() : 시작일이 미래면 OPEN_RESERVED 로 변경한다")
     void approveByAdmin_setsOpenReservedForFutureCampaign() {
         Instant now = Instant.parse("2026-03-11T00:00:00Z");
         Campaign campaign = completeCampaignBuilder()
@@ -158,7 +158,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("approveByAdmin() moves already-open campaigns to RECRUITING")
+    @DisplayName("approveByAdmin() : 이미 시작된 캠페인은 RECRUITING 으로 변경한다")
     void approveByAdmin_setsRecruitingForStartedCampaign() {
         Instant now = Instant.parse("2026-03-11T00:00:00Z");
         Campaign campaign = completeCampaignBuilder()
@@ -172,7 +172,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("approveByAdmin() rejects campaigns outside WAITING_APPROVAL")
+    @DisplayName("approveByAdmin() : WAITING_APPROVAL 이 아니면 예외를 던진다")
     void approveByAdmin_rejectsUnexpectedStatus() {
         Campaign campaign = completeCampaignBuilder()
                 .campaignStatus(CampaignStatus.RECRUITING)
@@ -183,7 +183,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validateAdminModifiable() only allows WAITING_APPROVAL campaigns")
+    @DisplayName("validateAdminModifiable() : WAITING_APPROVAL 상태에서만 수정 가능하다")
     void validateAdminModifiable_onlyAllowsWaitingApproval() {
         Campaign campaign = completeCampaignBuilder()
                 .campaignStatus(CampaignStatus.RECRUITING)
@@ -194,7 +194,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validateEditable() rejects already published campaigns")
+    @DisplayName("validateEditable() : 이미 발행된 캠페인이면 예외를 던진다")
     void validateEditable_rejectsPublishedCampaign() {
         Campaign campaign = completeCampaignBuilder()
                 .isPublished(true)
@@ -205,7 +205,7 @@ class CampaignTest {
     }
 
     @Test
-    @DisplayName("validateCapacityForApproval() rejects approvals exceeding recruitment number")
+    @DisplayName("validateCapacityForApproval() : 승인 요청 수가 모집 인원을 넘으면 예외를 던진다")
     void validateCapacityForApproval_rejectsExceedingRecruitmentNumber() {
         Campaign campaign = completeCampaignBuilder()
                 .approvedNumber(4)

--- a/src/test/java/com/lokoko/domain/campaign/domain/entity/CampaignTest.java
+++ b/src/test/java/com/lokoko/domain/campaign/domain/entity/CampaignTest.java
@@ -1,0 +1,239 @@
+package com.lokoko.domain.campaign.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignLanguage;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignProductType;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignType;
+import com.lokoko.domain.campaign.exception.AdminCampaignNotModifiableException;
+import com.lokoko.domain.campaign.exception.CampaignCapacityExceedException;
+import com.lokoko.domain.campaign.exception.CampaignExpiredException;
+import com.lokoko.domain.campaign.exception.DraftNotFilledException;
+import com.lokoko.domain.campaign.exception.CampaignNotEditableException;
+import com.lokoko.domain.creatorCampaign.exception.CampaignNotRecruitingException;
+import com.lokoko.domain.creatorCampaign.exception.CampaignNotStartedException;
+import com.lokoko.domain.creatorCampaign.exception.CampaignRecruitmentFullException;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import com.lokoko.domain.user.exception.CampaignApprovalNotAllowedException;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Campaign domain validation")
+class CampaignTest {
+
+    @Test
+    @DisplayName("isDraft() ignores missing brand relation when required publish fields are present")
+    void isDraft_ignoresMissingBrandRelation() {
+        Campaign campaign = completeCampaignBuilder()
+                .brand(null)
+                .brandName(null)
+                .build();
+
+        assertThat(campaign.isDraft()).isFalse();
+    }
+
+    @Test
+    @DisplayName("validatePublishable() throws when a required brand-campaign field is missing")
+    void validatePublishable_throwsWhenRequiredFieldMissing() {
+        Campaign campaign = completeCampaignBuilder()
+                .firstContentPlatform(null)
+                .build();
+
+        assertThatThrownBy(campaign::validatePublishable)
+                .isInstanceOf(DraftNotFilledException.class);
+    }
+
+    @Test
+    @DisplayName("validatePublishableForAdmin() allows admin campaign without brand relation when brandName exists")
+    void validatePublishableForAdmin_allowsBrandNameWithoutBrandRelation() {
+        Campaign campaign = completeCampaignBuilder()
+                .brand(null)
+                .brandName("Lokoko")
+                .build();
+
+        assertThatCode(campaign::validatePublishableForAdmin)
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("validatePublishableForAdmin() requires brandName for admin-created campaigns")
+    void validatePublishableForAdmin_requiresBrandName() {
+        Campaign campaign = completeCampaignBuilder()
+                .brand(null)
+                .brandName(" ")
+                .build();
+
+        assertThatThrownBy(campaign::validatePublishableForAdmin)
+                .isInstanceOf(DraftNotFilledException.class);
+    }
+
+    @Test
+    @DisplayName("publish() marks the campaign as published and waiting approval")
+    void publish_marksCampaignAsWaitingApproval() {
+        Campaign campaign = completeCampaignBuilder()
+                .campaignStatus(CampaignStatus.DRAFT)
+                .build();
+
+        campaign.publish();
+
+        assertThat(campaign.isPublished()).isTrue();
+        assertThat(campaign.getCampaignStatus()).isEqualTo(CampaignStatus.WAITING_APPROVAL);
+        assertThat(campaign.getPublishedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("validateParticipatableAt() rejects campaigns before the application window opens")
+    void validateParticipatableAt_rejectsBeforeStart() {
+        Instant now = Instant.parse("2026-03-11T00:00:00Z");
+        Campaign campaign = completeCampaignBuilder()
+                .campaignStatus(CampaignStatus.RECRUITING)
+                .applyStartDate(now.plusSeconds(60))
+                .build();
+
+        assertThatThrownBy(() -> campaign.validateParticipatableAt(now))
+                .isInstanceOf(CampaignNotStartedException.class);
+    }
+
+    @Test
+    @DisplayName("validateParticipatableAt() rejects campaigns after the deadline")
+    void validateParticipatableAt_rejectsAfterDeadline() {
+        Instant now = Instant.parse("2026-03-11T00:00:00Z");
+        Campaign campaign = completeCampaignBuilder()
+                .campaignStatus(CampaignStatus.RECRUITING)
+                .applyStartDate(now.minusSeconds(60))
+                .applyDeadline(now.minusSeconds(1))
+                .build();
+
+        assertThatThrownBy(() -> campaign.validateParticipatableAt(now))
+                .isInstanceOf(CampaignExpiredException.class);
+    }
+
+    @Test
+    @DisplayName("validateParticipatableAt() requires recruiting status")
+    void validateParticipatableAt_requiresRecruitingStatus() {
+        Instant now = Instant.parse("2026-03-11T00:00:00Z");
+        Campaign campaign = completeCampaignBuilder()
+                .applyStartDate(now.minusSeconds(60))
+                .applyDeadline(now.plusSeconds(3600))
+                .campaignStatus(CampaignStatus.OPEN_RESERVED)
+                .build();
+
+        assertThatThrownBy(() -> campaign.validateParticipatableAt(now))
+                .isInstanceOf(CampaignNotRecruitingException.class);
+    }
+
+    @Test
+    @DisplayName("validateParticipatableAt() rejects full recruitment")
+    void validateParticipatableAt_rejectsFullRecruitment() {
+        Instant now = Instant.parse("2026-03-11T00:00:00Z");
+        Campaign campaign = completeCampaignBuilder()
+                .applyStartDate(now.minusSeconds(60))
+                .applyDeadline(now.plusSeconds(3600))
+                .campaignStatus(CampaignStatus.RECRUITING)
+                .approvedNumber(5)
+                .recruitmentNumber(5)
+                .build();
+
+        assertThatThrownBy(() -> campaign.validateParticipatableAt(now))
+                .isInstanceOf(CampaignRecruitmentFullException.class);
+    }
+
+    @Test
+    @DisplayName("approveByAdmin() moves campaigns with a future start to OPEN_RESERVED")
+    void approveByAdmin_setsOpenReservedForFutureCampaign() {
+        Instant now = Instant.parse("2026-03-11T00:00:00Z");
+        Campaign campaign = completeCampaignBuilder()
+                .campaignStatus(CampaignStatus.WAITING_APPROVAL)
+                .applyStartDate(now.plusSeconds(60))
+                .build();
+
+        campaign.approveByAdmin(now);
+
+        assertThat(campaign.getCampaignStatus()).isEqualTo(CampaignStatus.OPEN_RESERVED);
+    }
+
+    @Test
+    @DisplayName("approveByAdmin() moves already-open campaigns to RECRUITING")
+    void approveByAdmin_setsRecruitingForStartedCampaign() {
+        Instant now = Instant.parse("2026-03-11T00:00:00Z");
+        Campaign campaign = completeCampaignBuilder()
+                .campaignStatus(CampaignStatus.WAITING_APPROVAL)
+                .applyStartDate(now.minusSeconds(60))
+                .build();
+
+        campaign.approveByAdmin(now);
+
+        assertThat(campaign.getCampaignStatus()).isEqualTo(CampaignStatus.RECRUITING);
+    }
+
+    @Test
+    @DisplayName("approveByAdmin() rejects campaigns outside WAITING_APPROVAL")
+    void approveByAdmin_rejectsUnexpectedStatus() {
+        Campaign campaign = completeCampaignBuilder()
+                .campaignStatus(CampaignStatus.RECRUITING)
+                .build();
+
+        assertThatThrownBy(() -> campaign.approveByAdmin(Instant.parse("2026-03-11T00:00:00Z")))
+                .isInstanceOf(CampaignApprovalNotAllowedException.class);
+    }
+
+    @Test
+    @DisplayName("validateAdminModifiable() only allows WAITING_APPROVAL campaigns")
+    void validateAdminModifiable_onlyAllowsWaitingApproval() {
+        Campaign campaign = completeCampaignBuilder()
+                .campaignStatus(CampaignStatus.RECRUITING)
+                .build();
+
+        assertThatThrownBy(campaign::validateAdminModifiable)
+                .isInstanceOf(AdminCampaignNotModifiableException.class);
+    }
+
+    @Test
+    @DisplayName("validateEditable() rejects already published campaigns")
+    void validateEditable_rejectsPublishedCampaign() {
+        Campaign campaign = completeCampaignBuilder()
+                .isPublished(true)
+                .build();
+
+        assertThatThrownBy(campaign::validateEditable)
+                .isInstanceOf(CampaignNotEditableException.class);
+    }
+
+    @Test
+    @DisplayName("validateCapacityForApproval() rejects approvals exceeding recruitment number")
+    void validateCapacityForApproval_rejectsExceedingRecruitmentNumber() {
+        Campaign campaign = completeCampaignBuilder()
+                .approvedNumber(4)
+                .recruitmentNumber(5)
+                .build();
+
+        assertThatThrownBy(() -> campaign.validateCapacityForApproval(2))
+                .isInstanceOf(CampaignCapacityExceedException.class);
+    }
+
+    private Campaign.CampaignBuilder<?, ?> completeCampaignBuilder() {
+        Instant now = Instant.parse("2026-03-11T00:00:00Z");
+
+        return Campaign.builder()
+                .brandName("Lokoko")
+                .title("Spring Campaign")
+                .language(CampaignLanguage.EN)
+                .campaignType(CampaignType.CONTENTS)
+                .campaignStatus(CampaignStatus.DRAFT)
+                .campaignProductType(CampaignProductType.SKINCARE)
+                .applyStartDate(now.plusSeconds(60))
+                .applyDeadline(now.plusSeconds(3600))
+                .creatorAnnouncementDate(now.plusSeconds(7200))
+                .reviewSubmissionDeadline(now.plusSeconds(10800))
+                .recruitmentNumber(5)
+                .participationRewards(List.of("Reward"))
+                .deliverableRequirements(List.of("Deliverable"))
+                .eligibilityRequirements(List.of("Eligibility"))
+                .firstContentPlatform(ContentType.INSTA_REELS);
+    }
+}

--- a/src/test/java/com/lokoko/domain/campaignReview/application/service/CampaignReviewUpdateServiceTest.java
+++ b/src/test/java/com/lokoko/domain/campaignReview/application/service/CampaignReviewUpdateServiceTest.java
@@ -1,0 +1,105 @@
+package com.lokoko.domain.campaignReview.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.lokoko.domain.brand.api.dto.request.BrandNoteRevisionRequest;
+import com.lokoko.domain.brand.domain.entity.Brand;
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaign.domain.entity.enums.CampaignStatus;
+import com.lokoko.domain.campaign.exception.NotCampaignOwnershipException;
+import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
+import com.lokoko.domain.campaignReview.domain.entity.enums.BrandNoteStatus;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewStatus;
+import com.lokoko.domain.campaignReview.domain.entity.enums.RevisionAction;
+import com.lokoko.domain.campaignReview.exception.RevisionRequestNotAllowedException;
+import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
+import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
+import com.lokoko.domain.media.application.service.S3Service;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("캠페인 리뷰 수정 요청 검증")
+class CampaignReviewUpdateServiceTest {
+
+	@Mock
+	private S3Service s3Service;
+
+	@Mock
+	private CampaignReviewGetService campaignReviewGetService;
+
+	@InjectMocks
+	private CampaignReviewUpdateService campaignReviewUpdateService;
+
+	@Test
+	@DisplayName("requestReviewRevision() : 소유한 브랜드의 제출된 리뷰에 대해서만 수정 요청을 반영한다")
+	void requestReviewRevision_submitsForSubmittedReviewOwnedByBrand() {
+		CampaignReview review = submittedReview(7L);
+		BrandNoteRevisionRequest request = new BrandNoteRevisionRequest("Please tighten the caption.");
+
+		given(campaignReviewGetService.findById(11L)).willReturn(review);
+
+		var response = campaignReviewUpdateService.requestReviewRevision(
+			RevisionAction.SUBMIT, 7L, 11L, request);
+
+		assertThat(response.brandNote()).isEqualTo("Please tighten the caption.");
+		assertThat(response.status()).isEqualTo(BrandNoteStatus.PUBLISHED);
+		assertThat(response.revisionRequestedAt()).isNotNull();
+		assertThat(review.getStatus()).isEqualTo(ReviewStatus.REVISION_REQUESTED);
+		assertThat(review.getCreatorCampaign().getStatus()).isEqualTo(ParticipationStatus.ACTIVE);
+	}
+
+	@Test
+	@DisplayName("requestReviewRevision() : SUBMITTED 상태가 아니면 수정 요청을 거부한다")
+	void requestReviewRevision_rejectsNonSubmittedReviews() {
+		CampaignReview review = submittedReview(7L);
+		review.requestSecondReview("updated caption", "https://example.com/post");
+
+		given(campaignReviewGetService.findById(11L)).willReturn(review);
+
+		assertThatThrownBy(() -> campaignReviewUpdateService.requestReviewRevision(
+			RevisionAction.SUBMIT, 7L, 11L, new BrandNoteRevisionRequest("Please revise")))
+			.isInstanceOf(RevisionRequestNotAllowedException.class);
+	}
+
+	@Test
+	@DisplayName("requestReviewRevision() : 소유하지 않은 브랜드면 예외를 던진다")
+	void requestReviewRevision_rejectsOtherBrands() {
+		CampaignReview review = submittedReview(7L);
+
+		given(campaignReviewGetService.findById(11L)).willReturn(review);
+
+		assertThatThrownBy(() -> campaignReviewUpdateService.requestReviewRevision(
+			RevisionAction.SUBMIT, 99L, 11L, new BrandNoteRevisionRequest("Please revise")))
+			.isInstanceOf(NotCampaignOwnershipException.class);
+	}
+
+	private CampaignReview submittedReview(Long brandId) {
+		Brand brand = Brand.builder()
+			.id(brandId)
+			.brandName("Lokoko")
+			.build();
+
+		Campaign campaign = Campaign.builder()
+			.brand(brand)
+			.brandName(brand.getBrandName())
+			.campaignStatus(CampaignStatus.IN_REVIEW)
+			.build();
+
+		CreatorCampaign creatorCampaign = CreatorCampaign.builder()
+			.campaign(campaign)
+			.status(ParticipationStatus.COMPLETED)
+			.build();
+
+		CampaignReview review = new CampaignReview();
+		review.bindToCreatorCampaign(creatorCampaign);
+		review.requestFirstReview("initial caption");
+		return review;
+	}
+}

--- a/src/test/java/com/lokoko/domain/campaignReview/application/service/CampaignReviewValidationServiceTest.java
+++ b/src/test/java/com/lokoko/domain/campaignReview/application/service/CampaignReviewValidationServiceTest.java
@@ -1,0 +1,75 @@
+package com.lokoko.domain.campaignReview.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.lokoko.domain.campaignReview.exception.ErrorMessage;
+import com.lokoko.domain.campaignReview.exception.InvalidReviewPayloadException;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import com.lokoko.domain.productReview.exception.InvalidMediaTypeException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("캠페인 리뷰 업로드 검증")
+class CampaignReviewValidationServiceTest {
+
+    private final CampaignReviewValidationService campaignReviewValidationService =
+            new CampaignReviewValidationService();
+
+    @Test
+    @DisplayName("validateTwoSetCombination() : 첫 번째 플랫폼이 없으면 예외를 던진다")
+    void validateTwoSetCombination_requiresFirstPlatform() {
+        assertThatThrownBy(() -> campaignReviewValidationService.validateTwoSetCombination(
+                null, ContentType.TIKTOK_VIDEO))
+                .isInstanceOf(InvalidReviewPayloadException.class)
+                .hasMessage(ErrorMessage.MISSING_PLATFORM.getMessage());
+    }
+
+    @Test
+    @DisplayName("requireFirstSetPresent() : 1차 리뷰 입력이 불완전하면 예외를 던진다")
+    void requireFirstSetPresent_rejectsIncompleteContent() {
+        assertThatThrownBy(() -> campaignReviewValidationService.requireFirstSetPresent(List.of("media"), " "))
+                .isInstanceOf(InvalidReviewPayloadException.class)
+                .hasMessage(ErrorMessage.FIRST_SET_REQUIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("ensureSecondSetAbsentForSecondRound() : 허용되지 않은 두 번째 세트가 있으면 예외를 던진다")
+    void ensureSecondSetAbsentForSecondRound_rejectsUnexpectedSecondSet() {
+        assertThatThrownBy(() -> campaignReviewValidationService.ensureSecondSetAbsentForSecondRound(
+                List.of("media"), null, null))
+                .isInstanceOf(InvalidReviewPayloadException.class)
+                .hasMessage(ErrorMessage.SECOND_SET_NOT_ALLOWED.getMessage());
+    }
+
+    @Test
+    @DisplayName("requireSecondSetPresent() : media 와 caption 이 있으면 postUrl 도 필수다")
+    void requireSecondSetPresent_requiresPostUrl() {
+        assertThatThrownBy(() -> campaignReviewValidationService.requireSecondSetPresent(
+                List.of("media"), "caption", " "))
+                .isInstanceOf(InvalidReviewPayloadException.class)
+                .hasMessage(ErrorMessage.SECOND_POST_URL_REQUIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("validateCombinedMediaLimit() : 두 세트 합산 media 가 15개를 넘으면 예외를 던진다")
+    void validateCombinedMediaLimit_rejectsMoreThanFifteenUrls() {
+        List<String> first = List.of(
+                "1", "2", "3", "4", "5", "6", "7", "8"
+        );
+        List<String> second = List.of(
+                "9", "10", "11", "12", "13", "14", "15", "16"
+        );
+
+        assertThatThrownBy(() -> campaignReviewValidationService.validateCombinedMediaLimit(first, second))
+                .isInstanceOf(InvalidMediaTypeException.class);
+    }
+
+    @Test
+    @DisplayName("단일 플랫폼 1차 업로드에서는 두 번째 세트가 없어도 통과한다")
+    void ensureSecondSetAbsentForFirstRound_allowsMissingSecondSet() {
+        assertThatCode(() -> campaignReviewValidationService.ensureSecondSetAbsentForFirstRound(null, null))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/lokoko/domain/campaignReview/application/service/CreatorCampaignStatusResolverTest.java
+++ b/src/test/java/com/lokoko/domain/campaignReview/application/service/CreatorCampaignStatusResolverTest.java
@@ -1,0 +1,42 @@
+package com.lokoko.domain.campaignReview.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
+import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+
+@DisplayName("CreatorCampaign 상태 계산")
+class CreatorCampaignStatusResolverTest {
+
+    private final CreatorCampaignStatusResolver resolver = new CreatorCampaignStatusResolver();
+
+    @Test
+    @DisplayName("determineNextStatus() : 2차 리뷰만 있어도 1차 리뷰가 없으면 완료 처리하지 않는다")
+    void determineNextStatus_doesNotCompleteWithoutFirstReview() {
+        CreatorCampaign creatorCampaign = CreatorCampaign.builder()
+                .addressConfirmed(true)
+                .status(ParticipationStatus.ACTIVE)
+                .build();
+        Campaign campaign = Campaign.builder()
+                .firstContentPlatform(ContentType.INSTA_REELS)
+                .build();
+
+        ParticipationStatus result = resolver.determineNextStatus(
+                creatorCampaign,
+                campaign,
+                false,
+                false,
+                true,
+                List.of()
+        );
+
+        assertThat(result).isEqualTo(ParticipationStatus.ACTIVE);
+    }
+}

--- a/src/test/java/com/lokoko/domain/campaignReview/application/service/CreatorCampaignUpdateServiceTest.java
+++ b/src/test/java/com/lokoko/domain/campaignReview/application/service/CreatorCampaignUpdateServiceTest.java
@@ -1,0 +1,138 @@
+package com.lokoko.domain.campaignReview.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
+import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
+import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
+import com.lokoko.domain.creatorCampaign.domain.repository.CreatorCampaignRepository;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import com.lokoko.global.config.BetaFeatureConfig;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreatorCampaign 상태 갱신")
+class CreatorCampaignUpdateServiceTest {
+
+    @Mock
+    private CreatorCampaignRepository creatorCampaignRepository;
+
+    @Mock
+    private CampaignReviewGetService campaignReviewGetService;
+
+    @Mock
+    private BetaFeatureConfig betaFeatureConfig;
+
+    @Mock
+    private CreatorCampaignStatusResolver creatorCampaignStatusResolver;
+
+    @InjectMocks
+    private CreatorCampaignUpdateService creatorCampaignUpdateService;
+
+    @Test
+    @DisplayName("refreshParticipationStatus() : 배송지 확인 전까지는 APPROVED 로 유지한다")
+    void refreshParticipationStatus_requiresConfirmedAddressFirst() {
+        CreatorCampaign creatorCampaign = creatorCampaign(false, ParticipationStatus.ACTIVE, singlePlatformCampaign());
+
+        given(creatorCampaignRepository.getByIdForUpdate(1L)).willReturn(creatorCampaign);
+        given(campaignReviewGetService.existsFirst(1L)).willReturn(true);
+        given(campaignReviewGetService.existsSecond(1L)).willReturn(true);
+        given(campaignReviewGetService.findContentTypesByRound(eq(1L), any(ReviewRound.class)))
+                .willReturn(List.of(ContentType.INSTA_REELS));
+        given(creatorCampaignStatusResolver.determineNextStatus(
+                eq(creatorCampaign),
+                eq(creatorCampaign.getCampaign()),
+                eq(false),
+                eq(true),
+                eq(true),
+                any(List.class)
+        )).willReturn(ParticipationStatus.APPROVED);
+
+        creatorCampaignUpdateService.refreshParticipationStatus(1L);
+
+        assertThat(creatorCampaign.getStatus()).isEqualTo(ParticipationStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("refreshParticipationStatus() : 베타 플로우에서는 필요한 1차 리뷰가 모두 있어야 완료 처리한다")
+    void refreshParticipationStatus_completesBetaFlowWhenAllFirstReviewsExist() {
+        CreatorCampaign creatorCampaign = creatorCampaign(true, ParticipationStatus.ACTIVE, dualPlatformCampaign());
+
+        given(creatorCampaignRepository.getByIdForUpdate(1L)).willReturn(creatorCampaign);
+        given(campaignReviewGetService.existsFirst(1L)).willReturn(true);
+        given(campaignReviewGetService.existsSecond(1L)).willReturn(false);
+        given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(true);
+        given(campaignReviewGetService.findContentTypesByRound(eq(1L), any(ReviewRound.class)))
+                .willReturn(List.of(ContentType.INSTA_REELS, ContentType.TIKTOK_VIDEO));
+        given(creatorCampaignStatusResolver.determineNextStatus(
+                eq(creatorCampaign),
+                eq(creatorCampaign.getCampaign()),
+                eq(true),
+                eq(true),
+                eq(false),
+                any(List.class)
+        )).willReturn(ParticipationStatus.COMPLETED);
+
+        creatorCampaignUpdateService.refreshParticipationStatus(1L);
+
+        assertThat(creatorCampaign.getStatus()).isEqualTo(ParticipationStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("refreshParticipationStatus() : 일반 플로우에서는 2차 리뷰가 있으면 완료 처리한다")
+    void refreshParticipationStatus_marksCompletedWhenSecondReviewExists() {
+        CreatorCampaign creatorCampaign = creatorCampaign(true, ParticipationStatus.ACTIVE, singlePlatformCampaign());
+
+        given(creatorCampaignRepository.getByIdForUpdate(1L)).willReturn(creatorCampaign);
+        given(campaignReviewGetService.existsFirst(1L)).willReturn(true);
+        given(campaignReviewGetService.existsSecond(1L)).willReturn(true);
+        given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(false);
+        given(campaignReviewGetService.findContentTypesByRound(eq(1L), any(ReviewRound.class)))
+                .willReturn(List.of(ContentType.INSTA_REELS));
+        given(creatorCampaignStatusResolver.determineNextStatus(
+                eq(creatorCampaign),
+                eq(creatorCampaign.getCampaign()),
+                eq(false),
+                eq(true),
+                eq(true),
+                any(List.class)
+        )).willReturn(ParticipationStatus.COMPLETED);
+
+        creatorCampaignUpdateService.refreshParticipationStatus(1L);
+
+        assertThat(creatorCampaign.getStatus()).isEqualTo(ParticipationStatus.COMPLETED);
+    }
+
+    private CreatorCampaign creatorCampaign(boolean addressConfirmed,
+                                            ParticipationStatus status,
+                                            Campaign campaign) {
+        return CreatorCampaign.builder()
+                .campaign(campaign)
+                .status(status)
+                .addressConfirmed(addressConfirmed)
+                .build();
+    }
+
+    private Campaign singlePlatformCampaign() {
+        return Campaign.builder()
+                .firstContentPlatform(ContentType.INSTA_REELS)
+                .build();
+    }
+
+    private Campaign dualPlatformCampaign() {
+        return Campaign.builder()
+                .firstContentPlatform(ContentType.INSTA_REELS)
+                .secondContentPlatform(ContentType.TIKTOK_VIDEO)
+                .build();
+    }
+}

--- a/src/test/java/com/lokoko/domain/creator/domain/entity/CreatorTest.java
+++ b/src/test/java/com/lokoko/domain/creator/domain/entity/CreatorTest.java
@@ -1,0 +1,48 @@
+package com.lokoko.domain.creator.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("크리에이터 동작")
+class CreatorTest {
+
+    @Test
+    @DisplayName("SNS 연결 정보는 저장되고 signupCompletedAt 은 최초 한 번만 설정된다")
+    void snsLinksAreStoredAndSignupCompletedAtIsStable() {
+        Creator creator = Creator.builder().build();
+
+        creator.connectInsta("https://www.instagram.com/lokoko");
+        creator.connectTikTok("https://www.tiktok.com/@lokoko");
+        creator.updateSignupCompleted();
+        var firstCompletedAt = creator.getSignupCompletedAt();
+        creator.updateSignupCompleted();
+
+        assertThat(creator.getInstagramUserId()).isEqualTo("https://www.instagram.com/lokoko");
+        assertThat(creator.getTikTokUserId()).isEqualTo("https://www.tiktok.com/@lokoko");
+        assertThat(firstCompletedAt).isNotNull();
+        assertThat(creator.getSignupCompletedAt()).isEqualTo(firstCompletedAt);
+    }
+
+    @Test
+    @DisplayName("assertHasConnectedSns() : 연결된 SNS 가 없으면 예외를 던진다")
+    void assertHasConnectedSns_throwsWhenNoSnsIsConnected() {
+        Creator creator = Creator.builder().build();
+
+        assertThatThrownBy(() -> creator.assertHasConnectedSns(IllegalStateException::new))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("assertHasConnectedSns() : 하나 이상 연결되어 있으면 통과한다")
+    void assertHasConnectedSns_allowsConnectedCreator() {
+        Creator creator = Creator.builder().build();
+        creator.connectInsta("lokoko_insta");
+
+        creator.assertHasConnectedSns(IllegalStateException::new);
+
+        assertThat(creator.hasConnectedSns()).isTrue();
+    }
+}

--- a/src/test/java/com/lokoko/domain/user/domain/entity/UserTest.java
+++ b/src/test/java/com/lokoko/domain/user/domain/entity/UserTest.java
@@ -1,0 +1,58 @@
+package com.lokoko.domain.user.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.lokoko.domain.user.domain.entity.enums.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("유저 동작")
+class UserTest {
+
+    @Test
+    @DisplayName("createGoogleUser() : 프로필 값과 함께 PENDING 유저를 생성한다")
+    void createGoogleUser_initializesPendingProfile() {
+        User user = User.createGoogleUser(
+                "google-1",
+                "user@example.com",
+                "Lokoko User",
+                "Lokoko",
+                "User",
+                "https://example.com/profile.png");
+
+        assertThat(user.getGoogleId()).isEqualTo("google-1");
+        assertThat(user.getEmail()).isEqualTo("user@example.com");
+        assertThat(user.getName()).isEqualTo("Lokoko User");
+        assertThat(user.getRole()).isEqualTo(Role.PENDING);
+        assertThat(user.getLastLoginAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("updateRole() : 유저 역할을 변경한다")
+    void updateRole_updatesUserRole() {
+        User user = User.createLineUser("line-1", "user@example.com", "Lokoko User");
+
+        user.updateRole(Role.CREATOR);
+
+        assertThat(user.getRole()).isEqualTo(Role.CREATOR);
+    }
+
+    @Test
+    @DisplayName("assertRole() : 역할이 일치하면 통과한다")
+    void assertRole_allowsMatchingRole() {
+        User user = User.createLineUser("line-1", "user@example.com", "Lokoko User");
+        user.updateRole(Role.CREATOR);
+
+        user.assertRole(Role.CREATOR, IllegalStateException::new);
+    }
+
+    @Test
+    @DisplayName("assertRole() : 역할이 다르면 전달한 예외를 던진다")
+    void assertRole_throwsSupplierExceptionWhenRoleDiffers() {
+        User user = User.createLineUser("line-1", "user@example.com", "Lokoko User");
+
+        assertThatThrownBy(() -> user.assertRole(Role.CREATOR, IllegalStateException::new))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #486 

## 작업 내용 💻

- [x] `CampaignReviewUpdateServiceTest` 추가
  - 리뷰 수정 요청 시 소유 브랜드 여부, `SUBMITTED` 상태 여부를 검증하는 테스트 작성
- [x] `CampaignReviewValidationServiceTest` 추가
  - 리뷰 업로드 요청의 media / caption / postUrl 조합 검증 시나리오 테스트 작성
- [x] `CreatorCampaignStatusResolverTest` 추가
  - 참여 상태 계산 중 비정상 조합(예: 2차 리뷰만 존재하는 경우)에서 완료 처리되지 않도록 검증하는 테스트 작성
- [x] `CreatorCampaignUpdateServiceTest` 추가
  - 배송지 확인 여부, 베타 플로우, 2차 리뷰 존재 여부에 따른 참여 상태 갱신 테스트 작성
- [x] `CreatorTest` 추가
  - SNS 연결 여부 판단과 `signupCompletedAt` 갱신 동작 테스트 작성

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- `CreatorCampaignStatusResolverTest`와 `CreatorCampaignUpdateServiceTest`는 참여 상태 계산 책임이 분리된 이후에도 비정상 조합이나 플로우별 상태 전이가 깨지지 않도록 테스트를 하였습니다.
- `CreatorTest`는 단순하긴한데, 엔티티로 옮긴 역할 + SNS 관련 판단 책임을 이후에도 쉽게 확인할 수 있도록 최소 단위 테스트를 추가했다고 이해해주시면 될거같아요
- 추가로 이번에 작성한 테스트들 기준으로, 이후에도 검증 책임을 옮길 때 “엔티티 불변식 테스트”와 “application/service 입력 검증 테스트”를 나눠서 가져가는 방식이 일관성 있을지 얘기해보면 좋을거같아요 (만약 아니라면 통일해서 작성할지)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 캠페인, 캠페인 리뷰, 크리에이터 및 사용자 도메인에 대한 새로운 단위 테스트 추가
  * 상태 전환, 유효성 검사 및 비즈니스 로직 검증을 위한 테스트 커버리지 강화

*참고: 이번 업데이트는 주로 내부 테스트 개선사항으로 구성되어 있으며, 최종 사용자에게 직접적인 기능 변화는 없습니다.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->