### PR TITLE
[REFACTOR] #489 BrandUsecase의 크리에이터 성과 조회 책임 분리

### DIFF
--- a/src/main/java/com/lokoko/domain/brand/application/service/BrandCreatorPerformanceQueryService.java
+++ b/src/main/java/com/lokoko/domain/brand/application/service/BrandCreatorPerformanceQueryService.java
@@ -1,0 +1,253 @@
+package com.lokoko.domain.brand.application.service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lokoko.domain.brand.api.dto.response.CreatorPerformanceResponse;
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaignReview.application.service.CampaignReviewGetService;
+import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ContentStatus;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewStatus;
+import com.lokoko.domain.creator.api.dto.response.CreatorInfo;
+import com.lokoko.domain.creator.domain.entity.Creator;
+import com.lokoko.domain.creatorCampaign.application.service.CreatorCampaignGetService;
+import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
+import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
+import com.lokoko.domain.media.socialclip.application.service.SocialClipGetService;
+import com.lokoko.domain.media.socialclip.domain.SocialClip;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import com.lokoko.global.common.response.PageableResponse;
+import com.lokoko.global.config.BetaFeatureConfig;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BrandCreatorPerformanceQueryService {
+
+    private final CreatorCampaignGetService creatorCampaignGetService;
+    private final CampaignReviewGetService campaignReviewGetService;
+    private final SocialClipGetService socialClipGetService;
+    private final BetaFeatureConfig betaFeatureConfig;
+
+    public CreatorPerformanceResponse getCreatorPerformances(Campaign campaign, int page, int size) {
+        List<CreatorCampaign> approvedCreatorCampaigns = creatorCampaignGetService.findAllByCampaign(campaign).stream()
+                .filter(creatorCampaign -> creatorCampaign.getStatus() != ParticipationStatus.REJECTED)
+                .sorted(Comparator.comparing(CreatorCampaign::getAppliedAt))
+                .toList();
+
+        List<CreatorPerformanceResponse.CreatorReviewPerformance> allCreatorPerformances =
+                approvedCreatorCampaigns.stream()
+                        .collect(Collectors.groupingBy(
+                                CreatorCampaign::getCreator,
+                                LinkedHashMap::new,
+                                Collectors.toList()
+                        ))
+                        .entrySet().stream()
+                        .map(creatorCampaignEntry -> {
+                            Creator creator = creatorCampaignEntry.getKey();
+                            List<CreatorCampaign> creatorCampaignList = creatorCampaignEntry.getValue();
+
+                            List<CreatorPerformanceResponse.ReviewPerformance> reviewPerformances =
+                                    buildReviewPerformances(campaign, creatorCampaignList);
+
+                            return CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+                                    .creator(CreatorInfo.builder()
+                                            .creatorId(creator.getId())
+                                            .creatorFullName(creator.getUser().getName())
+                                            .creatorNickname(creator.getCreatorName())
+                                            .profileImageUrl(creator.getUser().getProfileImageUrl())
+                                            .build())
+                                    .reviews(reviewPerformances)
+                                    .build();
+                        })
+                        .toList();
+
+        return buildPagedCreatorPerformanceResponse(campaign, allCreatorPerformances, page, size);
+    }
+
+    private CreatorPerformanceResponse buildPagedCreatorPerformanceResponse(
+            Campaign campaign,
+            List<CreatorPerformanceResponse.CreatorReviewPerformance> allCreatorPerformances,
+            int page,
+            int size
+    ) {
+        long totalElements = allCreatorPerformances.size();
+        long startIndex = (long) page * size;
+
+        if (startIndex >= totalElements) {
+            PageableResponse pageableResponse = PageableResponse.of(
+                    page,
+                    size,
+                    0,
+                    true,
+                    totalElements
+            );
+
+            return buildCreatorPerformanceResponse(campaign, List.of(), pageableResponse);
+        }
+
+        int safeStartIndex = (int) startIndex;
+        int endIndex = (int) Math.min(startIndex + size, totalElements);
+
+        List<CreatorPerformanceResponse.CreatorReviewPerformance> pagedCreatorPerformances =
+                allCreatorPerformances.subList(safeStartIndex, endIndex);
+
+        PageableResponse pageableResponse = PageableResponse.of(
+                page,
+                size,
+                pagedCreatorPerformances.size(),
+                endIndex >= totalElements,
+                totalElements
+        );
+
+        return buildCreatorPerformanceResponse(campaign, pagedCreatorPerformances, pageableResponse);
+    }
+
+    private CreatorPerformanceResponse buildCreatorPerformanceResponse(
+            Campaign campaign,
+            List<CreatorPerformanceResponse.CreatorReviewPerformance> creatorPerformances,
+            PageableResponse pageableResponse
+    ) {
+        return CreatorPerformanceResponse.builder()
+                .campaignId(campaign.getId())
+                .campaignTitle(campaign.getTitle())
+                .firstContentPlatform(campaign.getFirstContentPlatform())
+                .secondContentPlatform(campaign.getSecondContentPlatform())
+                .creators(creatorPerformances)
+                .pageableResponse(pageableResponse)
+                .build();
+    }
+
+    private List<CreatorPerformanceResponse.ReviewPerformance> buildReviewPerformances(
+            Campaign campaign,
+            List<CreatorCampaign> creatorCampaigns
+    ) {
+        List<ContentType> contentTypes = new ArrayList<>();
+        contentTypes.add(campaign.getFirstContentPlatform());
+        if (campaign.getSecondContentPlatform() != null) {
+            contentTypes.add(campaign.getSecondContentPlatform());
+        }
+
+        List<CreatorPerformanceResponse.ReviewPerformance> performances = new ArrayList<>();
+
+        for (CreatorCampaign creatorCampaign : creatorCampaigns) {
+            List<CampaignReview> reviews = campaignReviewGetService.findAllByCreatorCampaignId(creatorCampaign.getId());
+
+            Map<ContentType, CampaignReview> firstReviews = reviews.stream()
+                    .filter(review -> review.getReviewRound() == ReviewRound.FIRST)
+                    .collect(Collectors.toMap(CampaignReview::getContentType, review -> review, (a, b) -> a));
+
+            Map<ContentType, CampaignReview> secondReviews = reviews.stream()
+                    .filter(review -> review.getReviewRound() == ReviewRound.SECOND)
+                    .collect(Collectors.toMap(CampaignReview::getContentType, review -> review, (a, b) -> a));
+
+            for (ContentType contentType : contentTypes) {
+                CampaignReview secondReview = secondReviews.get(contentType);
+                CampaignReview firstReview = firstReviews.get(contentType);
+
+                if (secondReview != null) {
+                    performances.add(buildReviewPerformance(secondReview));
+                    continue;
+                }
+                if (firstReview != null) {
+                    performances.add(buildReviewPerformance(firstReview));
+                    continue;
+                }
+
+                ContentStatus contentStatus = Boolean.TRUE.equals(creatorCampaign.getAddressConfirmed())
+                        ? ContentStatus.IN_PROGRESS
+                        : ContentStatus.NOT_SUBMITTED;
+
+                performances.add(CreatorPerformanceResponse.ReviewPerformance.builder()
+                        .reviewRound(ReviewRound.FIRST)
+                        .reviewStatus(contentStatus)
+                        .contents(CreatorPerformanceResponse.ContentMetrics.builder()
+                                .contentType(contentType)
+                                .build())
+                        .build());
+            }
+        }
+
+        return performances;
+    }
+
+    private CreatorPerformanceResponse.ReviewPerformance buildReviewPerformance(CampaignReview review) {
+        ContentStatus contentStatus = getReviewContentStatus(review);
+        String postUrl = null;
+        Long viewCount = null;
+        Long likeCount = null;
+        Long commentCount = null;
+        Long shareCount = null;
+        Instant uploadedAt = null;
+
+        if (review.getReviewRound() == ReviewRound.SECOND && review.getStatus() == ReviewStatus.RESUBMITTED) {
+            postUrl = review.getPostUrl();
+
+            Optional<SocialClip> socialClip = socialClipGetService.findByCampaignReview(review);
+            if (socialClip.isPresent()) {
+                SocialClip clip = socialClip.get();
+                viewCount = clip.getPlays();
+                likeCount = clip.getLikes();
+                commentCount = clip.getComments();
+                shareCount = clip.getShares();
+                uploadedAt = clip.getUploadedAt();
+            }
+        } else if (betaFeatureConfig.isFirstReviewUrlEnabled()
+                && review.getReviewRound() == ReviewRound.FIRST
+                && review.getPostUrl() != null) {
+            postUrl = review.getPostUrl();
+            uploadedAt = review.getCreatedAt().toInstant(java.time.ZoneOffset.ofHours(9));
+        }
+
+        CreatorPerformanceResponse.ContentMetrics contents = null;
+        if (review.getContentType() != null) {
+            contents = CreatorPerformanceResponse.ContentMetrics.builder()
+                    .contentType(review.getContentType())
+                    .viewCount(viewCount)
+                    .likeCount(likeCount)
+                    .commentCount(commentCount)
+                    .shareCount(shareCount)
+                    .build();
+        }
+
+        return CreatorPerformanceResponse.ReviewPerformance.builder()
+                .campaignReviewId(review.getId())
+                .reviewRound(review.getReviewRound())
+                .reviewStatus(contentStatus)
+                .postUrl(postUrl)
+                .contents(contents)
+                .uploadedAt(uploadedAt)
+                .build();
+    }
+
+    private ContentStatus getReviewContentStatus(CampaignReview review) {
+        ReviewStatus status = review.getStatus();
+
+        if (betaFeatureConfig.isSimplifiedReviewFlow()
+                && review.getReviewRound() == ReviewRound.FIRST
+                && status == ReviewStatus.SUBMITTED) {
+            return ContentStatus.FINAL_UPLOADED;
+        }
+
+        return switch (status) {
+            case SUBMITTED -> ContentStatus.PENDING_REVISION;
+            case REVISION_REQUESTED -> review.isNoteViewed()
+                    ? ContentStatus.REVISING
+                    : ContentStatus.PENDING_REVISION;
+            case RESUBMITTED -> ContentStatus.FINAL_UPLOADED;
+        };
+    }
+}

--- a/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
+++ b/src/main/java/com/lokoko/domain/brand/application/usecase/BrandUsecase.java
@@ -1,13 +1,7 @@
 package com.lokoko.domain.brand.application.usecase;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import java.time.Instant;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +14,7 @@ import com.lokoko.domain.brand.api.dto.response.BrandMyPageResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandProfileAndStatisticsResponse;
 import com.lokoko.domain.brand.api.dto.response.BrandProfileImageResponse;
 import com.lokoko.domain.brand.api.dto.response.CreatorPerformanceResponse;
+import com.lokoko.domain.brand.application.service.BrandCreatorPerformanceQueryService;
 import com.lokoko.domain.brand.application.service.BrandGetService;
 import com.lokoko.domain.brand.application.service.BrandUpdateService;
 import com.lokoko.domain.brand.domain.entity.Brand;
@@ -31,19 +26,11 @@ import com.lokoko.domain.campaignReview.api.dto.response.CampaignReviewDetailLis
 import com.lokoko.domain.campaignReview.application.mapper.CampaignReviewMapper;
 import com.lokoko.domain.campaignReview.application.service.CampaignReviewGetService;
 import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
-import com.lokoko.domain.campaignReview.domain.entity.enums.ContentStatus;
 import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
-import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewStatus;
 import com.lokoko.domain.creator.api.dto.response.CreatorInfo;
 import com.lokoko.domain.creator.domain.entity.Creator;
 import com.lokoko.domain.creatorCampaign.application.service.CreatorCampaignGetService;
 import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
-import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
-import com.lokoko.domain.media.socialclip.application.service.SocialClipGetService;
-import com.lokoko.domain.media.socialclip.domain.SocialClip;
-import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
-import com.lokoko.global.common.response.PageableResponse;
-import com.lokoko.global.config.BetaFeatureConfig;
 
 import lombok.RequiredArgsConstructor;
 
@@ -55,11 +42,9 @@ public class BrandUsecase {
 	private final CampaignGetService campaignGetService;
 	private final CreatorCampaignGetService creatorCampaignGetService;
 	private final CampaignReviewGetService campaignReviewGetService;
-	private final SocialClipGetService socialClipGetService;
 
 	private final BrandUpdateService brandUpdateService;
-
-	private final BetaFeatureConfig betaFeatureConfig;
+	private final BrandCreatorPerformanceQueryService brandCreatorPerformanceQueryService;
 
 	private final CampaignMapper campaignMapper;
 	private final CampaignReviewMapper campaignReviewMapper;
@@ -177,252 +162,12 @@ public class BrandUsecase {
 
 		validateCampaignOwnership(brand, campaign);
 
-		List<CreatorCampaign> approvedCreatorCampaigns = creatorCampaignGetService.findAllByCampaign(campaign).stream()
-			.filter(creatorCampaign -> creatorCampaign.getStatus() != ParticipationStatus.REJECTED)
-			.sorted(Comparator.comparing(CreatorCampaign::getAppliedAt))
-			.toList();
-
-		List<CreatorPerformanceResponse.CreatorReviewPerformance> allCreatorPerformances =
-			approvedCreatorCampaigns.stream()
-				.collect(Collectors.groupingBy(
-					CreatorCampaign::getCreator,
-					LinkedHashMap::new,
-					Collectors.toList()
-				))
-				.entrySet().stream()
-				.map(creatorCampaignEntry -> {
-					Creator creator = creatorCampaignEntry.getKey();
-					List<CreatorCampaign> creatorCampaignList = creatorCampaignEntry.getValue();
-
-					List<CreatorPerformanceResponse.ReviewPerformance> reviewPerformances =
-						buildReviewPerformances(campaign, creatorCampaignList);
-
-					return CreatorPerformanceResponse.CreatorReviewPerformance.builder()
-						.creator(CreatorInfo.builder()
-							.creatorId(creator.getId())
-							.creatorFullName(creator.getUser().getName())
-							.creatorNickname(creator.getCreatorName())
-							.profileImageUrl(creator.getUser().getProfileImageUrl())
-							.build())
-						.reviews(reviewPerformances)
-						.build();
-				})
-				.toList();
-
-		return buildPagedCreatorPerformanceResponse(campaign, allCreatorPerformances, page, size);
+		return brandCreatorPerformanceQueryService.getCreatorPerformances(campaign, page, size);
 	}
 
 	private void validateCampaignOwnership(Brand brand, Campaign campaign) {
 		if (!campaign.getBrand().getId().equals(brand.getId())) {
 			throw new NotCampaignOwnershipException();
 		}
-	}
-
-	private CreatorPerformanceResponse buildPagedCreatorPerformanceResponse(
-		Campaign campaign,
-		List<CreatorPerformanceResponse.CreatorReviewPerformance> allCreatorPerformances,
-		int page,
-		int size
-	) {
-		long totalElements = allCreatorPerformances.size();
-		long startIndex = (long)page * size;
-
-		if (startIndex >= totalElements) {
-			PageableResponse pageableResponse = PageableResponse.of(
-				page,
-				size,
-				0,
-				true,
-				totalElements
-			);
-
-			return buildCreatorPerformanceResponse(campaign, List.of(), pageableResponse);
-		}
-
-		int safeStartIndex = (int)startIndex;
-		int endIndex = (int)Math.min(startIndex + size, totalElements);
-
-		List<CreatorPerformanceResponse.CreatorReviewPerformance> pagedCreatorPerformances =
-			allCreatorPerformances.subList(safeStartIndex, endIndex);
-
-		PageableResponse pageableResponse = PageableResponse.of(
-			page,
-			size,
-			pagedCreatorPerformances.size(),
-			endIndex >= totalElements,
-			totalElements
-		);
-
-		return buildCreatorPerformanceResponse(campaign, pagedCreatorPerformances, pageableResponse);
-	}
-
-	private CreatorPerformanceResponse buildCreatorPerformanceResponse(
-		Campaign campaign,
-		List<CreatorPerformanceResponse.CreatorReviewPerformance> creatorPerformances,
-		PageableResponse pageableResponse
-	) {
-		return CreatorPerformanceResponse.builder()
-			.campaignId(campaign.getId())
-			.campaignTitle(campaign.getTitle())
-			.firstContentPlatform(campaign.getFirstContentPlatform())
-			.secondContentPlatform(campaign.getSecondContentPlatform())
-			.creators(creatorPerformances)
-			.pageableResponse(pageableResponse)
-			.build();
-	}
-
-	/**
-	 * 크리에이터의 리뷰 성과 정보 구성
-	 */
-	private List<CreatorPerformanceResponse.ReviewPerformance> buildReviewPerformances(
-		Campaign campaign, List<CreatorCampaign> creatorCampaigns) {
-
-		// 캠페인의 콘텐츠 타입들
-		List<ContentType> contentTypes = new ArrayList<>();
-		contentTypes.add(campaign.getFirstContentPlatform());
-		if (campaign.getSecondContentPlatform() != null) {
-			contentTypes.add(campaign.getSecondContentPlatform());
-		}
-
-		List<CreatorPerformanceResponse.ReviewPerformance> performances = new ArrayList<>();
-
-		// 각 CreatorCampaign에 대해 처리
-		for (CreatorCampaign cc : creatorCampaigns) {
-			// 해당 CreatorCampaign의 모든 리뷰 조회
-			List<CampaignReview> reviews = campaignReviewGetService.findAllByCreatorCampaignId(cc.getId());
-
-			// contentType별로 리뷰를 맵으로 구성 (1차/2차 구분)
-			Map<ContentType, CampaignReview> firstReviews = reviews.stream()
-				.filter(r -> r.getReviewRound() == ReviewRound.FIRST)
-				.collect(Collectors.toMap(CampaignReview::getContentType, r -> r, (a, b) -> a));
-
-			Map<ContentType, CampaignReview> secondReviews = reviews.stream()
-				.filter(r -> r.getReviewRound() == ReviewRound.SECOND)
-				.collect(Collectors.toMap(CampaignReview::getContentType, r -> r, (a, b) -> a));
-
-			// 각 contentType에 대해 리뷰 성과 정보 생성
-			for (ContentType contentType : contentTypes) {
-				CampaignReview secondReview = secondReviews.get(contentType);
-				CampaignReview firstReview = firstReviews.get(contentType);
-
-				if (secondReview != null) {
-					// 2차 리뷰가 있는 경우
-					performances.add(buildReviewPerformance(secondReview));
-				} else if (firstReview != null) {
-					// 1차 리뷰만 있는 경우
-					performances.add(buildReviewPerformance(firstReview));
-				} else {
-					// 리뷰가 없는 경우
-					ContentStatus contentStatus;
-
-					// 배송지 입력 여부에 따라 상태 결정
-					if (cc.getAddressConfirmed() != null && cc.getAddressConfirmed()) {
-						// 배송지는 입력했지만 1차 리뷰 미업로드 = 진행중
-						contentStatus = ContentStatus.IN_PROGRESS;
-					} else {
-						// 배송지 미입력 = 미제출
-						contentStatus = ContentStatus.NOT_SUBMITTED;
-					}
-
-					performances.add(CreatorPerformanceResponse.ReviewPerformance.builder()
-						.reviewRound(ReviewRound.FIRST)
-						.reviewStatus(contentStatus)
-						.contents(CreatorPerformanceResponse.ContentMetrics.builder()
-							.contentType(contentType)
-							.build())
-						.build());
-				}
-			}
-		}
-
-		return performances;
-	}
-
-	/**
-	 * 개별 리뷰의 성과 정보 생성
-	 */
-	private CreatorPerformanceResponse.ReviewPerformance buildReviewPerformance(CampaignReview review) {
-		ContentStatus contentStatus = getReviewContentStatus(review);
-		String postUrl = null;
-		Long viewCount = null;
-		Long likeCount = null;
-		Long commentCount = null;
-		Long shareCount = null;
-		Instant uploadedAt = null;
-
-		// postUrl 처리 (베타: 1차 리뷰도 포함, 정식: 2차 리뷰만)
-		if (review.getReviewRound() == ReviewRound.SECOND && review.getStatus() == ReviewStatus.RESUBMITTED) {
-			// 2차 리뷰의 경우 항상 postUrl 포함
-			postUrl = review.getPostUrl();
-
-			// SocialClip에서 성과 지표 조회
-			Optional<SocialClip> socialClip = socialClipGetService.findByCampaignReview(review);
-			if (socialClip.isPresent()) {
-				SocialClip clip = socialClip.get();
-				viewCount = clip.getPlays();
-				likeCount = clip.getLikes();
-				commentCount = clip.getComments();
-				shareCount = clip.getShares();
-				uploadedAt = clip.getUploadedAt();
-			}
-			// 정식 릴리즈 시 제거
-		} else if (betaFeatureConfig.isFirstReviewUrlEnabled() &&
-			review.getReviewRound() == ReviewRound.FIRST &&
-			review.getPostUrl() != null) {
-			// 1차 리뷰에도 postUrl이 있으면 포함
-			postUrl = review.getPostUrl();
-			// LocalDateTime은 한국 시간(UTC+9)이므로 9시간을 빼서 UTC로 변환
-			uploadedAt = review.getCreatedAt().toInstant(java.time.ZoneOffset.ofHours(9));
-		}
-
-		CreatorPerformanceResponse.ContentMetrics contents = null;
-		if (review.getContentType() != null) {
-			contents = CreatorPerformanceResponse.ContentMetrics.builder()
-				.contentType(review.getContentType())
-				.viewCount(viewCount)
-				.likeCount(likeCount)
-				.commentCount(commentCount)
-				.shareCount(shareCount)
-				.build();
-		}
-
-		return CreatorPerformanceResponse.ReviewPerformance.builder()
-			.campaignReviewId(review.getId())
-			.reviewRound(review.getReviewRound())
-			.reviewStatus(contentStatus)
-			.postUrl(postUrl)
-			.contents(contents)
-			.uploadedAt(uploadedAt)
-			.build();
-	}
-
-	/**
-	 * 리뷰 상태를 ContentStatus enum으로 변환
-	 * PENDING_REVISION: 브랜드 리뷰 대기중 또는 수정 요청 후 크리에이터 노트 미확인
-	 * REVISING: 브랜드가 수정 요청 + 크리에이터가 노트 확인
-	 * FINAL_UPLOADED: 최종 업로드 완료 (베타: 1차 리뷰 완료, 정식: 2차 리뷰 완료)
-	 */
-	private ContentStatus getReviewContentStatus(CampaignReview review) {
-		ReviewStatus status = review.getStatus();
-
-		// 베타 모드에서 1차 리뷰 SUBMITTED 상태는 최종 완료로 처리 , 정식 릴리즈시 제거
-		if (betaFeatureConfig.isSimplifiedReviewFlow() &&
-			review.getReviewRound() == ReviewRound.FIRST &&
-			status == ReviewStatus.SUBMITTED) {
-			return ContentStatus.FINAL_UPLOADED;
-		}
-
-		// 정식 모드 또는 2차 리뷰 처리
-		return switch (status) {
-			case SUBMITTED -> ContentStatus.PENDING_REVISION;
-			case REVISION_REQUESTED -> {
-				if (review.isNoteViewed()) {
-					yield ContentStatus.REVISING;
-				} else {
-					yield ContentStatus.PENDING_REVISION;
-				}
-			}
-			case RESUBMITTED -> ContentStatus.FINAL_UPLOADED;
-		};
 	}
 }

--- a/src/test/java/com/lokoko/domain/brand/BrandApplicantManagementTest.java
+++ b/src/test/java/com/lokoko/domain/brand/BrandApplicantManagementTest.java
@@ -1,18 +1,10 @@
 package com.lokoko.domain.brand;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Answers.*;
-import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.*;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,28 +16,20 @@ import com.lokoko.domain.brand.api.dto.response.CreatorPerformanceResponse;
 import com.lokoko.domain.brand.domain.entity.Brand;
 import com.lokoko.domain.campaign.domain.entity.Campaign;
 import com.lokoko.domain.campaign.exception.NotCampaignOwnershipException;
-import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
-import com.lokoko.domain.campaignReview.domain.entity.enums.ContentStatus;
-import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
-import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewStatus;
-import com.lokoko.domain.creator.api.dto.response.CreatorInfo;
-import com.lokoko.domain.creator.domain.entity.Creator;
-import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
-import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
-import com.lokoko.domain.media.socialclip.domain.SocialClip;
 import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
-import com.lokoko.global.common.response.PageableResponse;
 
 @DisplayName("Brand 지원자/성과 관리 Usecase 테스트")
 @MockitoSettings(strictness = Strictness.LENIENT)
 class BrandApplicantManagementTest extends BrandUsecaseTestSupport {
+
+	private static final String BRAND_CREATOR_PERFORMANCE_QUERY_SERVICE =
+		"com.lokoko.domain.brand.application.service.BrandCreatorPerformanceQueryService";
 
 	private Long brandId;
 	private Long campaignId;
 	private Brand brand;
 	private Campaign campaign;
 	private ContentType firstContentType;
-	private ParticipationStatus approvedParticipationStatus;
 
 	@BeforeEach
 	void setUp() {
@@ -54,10 +38,6 @@ class BrandApplicantManagementTest extends BrandUsecaseTestSupport {
 		brand = mock(Brand.class, RETURNS_DEEP_STUBS);
 		campaign = mock(Campaign.class, RETURNS_DEEP_STUBS);
 		firstContentType = ContentType.values()[0];
-		approvedParticipationStatus = Arrays.stream(ParticipationStatus.values())
-			.filter(participationStatus -> participationStatus != ParticipationStatus.REJECTED)
-			.findFirst()
-			.orElseThrow();
 
 		given(brandGetService.getBrandById(brandId)).willReturn(brand);
 		given(brand.getId()).willReturn(brandId);
@@ -89,316 +69,25 @@ class BrandApplicantManagementTest extends BrandUsecaseTestSupport {
 	}
 
 	@Nested
-	@DisplayName("브랜드 성과 조회")
-	class GetCreatorPerformances {
+	@DisplayName("브랜드 성과 조회 위임")
+	class CreatorPerformanceDelegation {
 
 		@Test
-		@DisplayName("getCreatorPerformances() : 1차/2차 리뷰가 함께 있으면 2차 리뷰를 우선 반영한다")
-		void getCreatorPerformances_prioritizesSecondReview() {
-			// given
-			Creator creator = createCreator(11L, "홍길동", "creator-one", "https://cdn.test/creator-one.jpg");
-			CreatorCampaign creatorCampaign =
-				createCreatorCampaign(101L, creator, approvedParticipationStatus, true);
+		@DisplayName("getCreatorPerformances() : 리팩터링 후에는 권한 검증 뒤 QueryService 응답을 그대로 반환한다")
+		void getCreatorPerformances_returnsQueryServiceResponse_whenQueryServiceExists() {
+			Assumptions.assumeTrue(hasDynamicMock(BRAND_CREATOR_PERFORMANCE_QUERY_SERVICE));
 
-			CampaignReview firstReview =
-				createCampaignReview(1001L, ReviewRound.FIRST, ReviewStatus.SUBMITTED, firstContentType);
-			CampaignReview secondReview =
-				createCampaignReview(1002L, ReviewRound.SECOND, ReviewStatus.RESUBMITTED, firstContentType);
+			CreatorPerformanceResponse expected = mock(CreatorPerformanceResponse.class);
+			stubDynamicMethodReturn(
+				BRAND_CREATOR_PERFORMANCE_QUERY_SERVICE,
+				"getCreatorPerformances",
+				expected
+			);
 
-			SocialClip socialClip = mock(SocialClip.class);
-			Instant uploadedAt = Instant.parse("2026-03-01T12:00:00Z");
-
-			given(secondReview.getPostUrl()).willReturn("https://instagram.com/p/final");
-			given(firstReview.getPostUrl()).willReturn("https://instagram.com/p/draft");
-			given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
-			given(campaignReviewGetService.findAllByCreatorCampaignId(101L))
-				.willReturn(List.of(firstReview, secondReview));
-
-			given(socialClipGetService.findByCampaignReview(secondReview)).willReturn(Optional.of(socialClip));
-			given(socialClip.getPlays()).willReturn(1200L);
-			given(socialClip.getLikes()).willReturn(300L);
-			given(socialClip.getComments()).willReturn(45L);
-			given(socialClip.getShares()).willReturn(12L);
-			given(socialClip.getUploadedAt()).willReturn(uploadedAt);
-
-			// when
 			CreatorPerformanceResponse result =
 				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
 
-			// then
-			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
-				.campaignId(campaignId)
-				.campaignTitle("브랜드 릴스 캠페인")
-				.firstContentPlatform(firstContentType)
-				.secondContentPlatform(null)
-				.creators(List.of(
-					CreatorPerformanceResponse.CreatorReviewPerformance.builder()
-						.creator(createCreatorInfo(11L, "홍길동", "creator-one",
-							"https://cdn.test/creator-one.jpg"))
-						.reviews(List.of(
-							CreatorPerformanceResponse.ReviewPerformance.builder()
-								.campaignReviewId(1002L)
-								.reviewRound(ReviewRound.SECOND)
-								.reviewStatus(ContentStatus.FINAL_UPLOADED)
-								.postUrl("https://instagram.com/p/final")
-								.contents(CreatorPerformanceResponse.ContentMetrics.builder()
-									.contentType(firstContentType)
-									.viewCount(1200L)
-									.likeCount(300L)
-									.commentCount(45L)
-									.shareCount(12L)
-									.build())
-								.uploadedAt(uploadedAt)
-								.build()
-						))
-						.build()
-				))
-				.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
-				.build();
-
-			assertThat(result)
-				.usingRecursiveComparison()
-				.isEqualTo(expected);
+			assertThat(result).isSameAs(expected);
 		}
-
-		@Test
-		@DisplayName("getCreatorPerformances() : 리뷰가 없고 배송지 입력이 완료되었으면 진행중 상태를 반환한다")
-		void getCreatorPerformances_returnsInProgress_whenAddressConfirmedAndNoReview() {
-			// given
-			Creator creator = createCreator(21L, "김로코", "creator-two", "https://cdn.test/creator-two.jpg");
-			CreatorCampaign creatorCampaign =
-				createCreatorCampaign(201L, creator, approvedParticipationStatus, true);
-
-			given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
-			given(campaignReviewGetService.findAllByCreatorCampaignId(201L)).willReturn(List.of());
-
-			// when
-			CreatorPerformanceResponse result =
-				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
-
-			// then
-			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
-				.campaignId(campaignId)
-				.campaignTitle("브랜드 릴스 캠페인")
-				.firstContentPlatform(firstContentType)
-				.secondContentPlatform(null)
-				.creators(List.of(
-					CreatorPerformanceResponse.CreatorReviewPerformance.builder()
-						.creator(createCreatorInfo(21L, "김로코", "creator-two",
-							"https://cdn.test/creator-two.jpg"))
-						.reviews(List.of(
-							CreatorPerformanceResponse.ReviewPerformance.builder()
-								.reviewRound(ReviewRound.FIRST)
-								.reviewStatus(ContentStatus.IN_PROGRESS)
-								.contents(CreatorPerformanceResponse.ContentMetrics.builder()
-									.contentType(firstContentType)
-									.build())
-								.build()
-						))
-						.build()
-				))
-				.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
-				.build();
-
-			assertThat(result)
-				.usingRecursiveComparison()
-				.isEqualTo(expected);
-		}
-
-		@Test
-		@DisplayName("getCreatorPerformances() : 리뷰가 없고 배송지 입력이 없으면 미제출 상태를 반환한다")
-		void getCreatorPerformances_returnsNotSubmitted_whenAddressNotConfirmedAndNoReview() {
-			// given
-			Creator creator = createCreator(31L, "박지원", "creator-three", "https://cdn.test/creator-three.jpg");
-			CreatorCampaign creatorCampaign =
-				createCreatorCampaign(301L, creator, approvedParticipationStatus, false);
-
-			given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
-			given(campaignReviewGetService.findAllByCreatorCampaignId(301L)).willReturn(List.of());
-
-			// when
-			CreatorPerformanceResponse result =
-				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
-
-			// then
-			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
-				.campaignId(campaignId)
-				.campaignTitle("브랜드 릴스 캠페인")
-				.firstContentPlatform(firstContentType)
-				.secondContentPlatform(null)
-				.creators(List.of(
-					CreatorPerformanceResponse.CreatorReviewPerformance.builder()
-						.creator(createCreatorInfo(31L, "박지원", "creator-three",
-							"https://cdn.test/creator-three.jpg"))
-						.reviews(List.of(
-							CreatorPerformanceResponse.ReviewPerformance.builder()
-								.reviewRound(ReviewRound.FIRST)
-								.reviewStatus(ContentStatus.NOT_SUBMITTED)
-								.contents(CreatorPerformanceResponse.ContentMetrics.builder()
-									.contentType(firstContentType)
-									.build())
-								.build()
-						))
-						.build()
-				))
-				.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
-				.build();
-
-			assertThat(result)
-				.usingRecursiveComparison()
-				.isEqualTo(expected);
-		}
-
-		@Test
-		@DisplayName("getCreatorPerformances() : 베타 모드에서는 1차 SUBMITTED 리뷰를 최종 업로드로 처리하고 postUrl을 포함한다")
-		void getCreatorPerformances_betaMode_returnsFinalUploadedForFirstReview() {
-			// given
-			Creator creator = createCreator(41L, "최지훈", "creator-four", "https://cdn.test/creator-four.jpg");
-			CreatorCampaign creatorCampaign =
-				createCreatorCampaign(401L, creator, approvedParticipationStatus, true);
-
-			CampaignReview firstReview =
-				createCampaignReview(4001L, ReviewRound.FIRST, ReviewStatus.SUBMITTED, firstContentType);
-
-			LocalDateTime createdAt = LocalDateTime.of(2026, 3, 1, 12, 0);
-			Instant expectedUploadedAt = createdAt.toInstant(ZoneOffset.ofHours(9));
-
-			given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(true);
-			given(betaFeatureConfig.isFirstReviewUrlEnabled()).willReturn(true);
-
-			given(firstReview.getPostUrl()).willReturn("https://instagram.com/p/beta-first");
-			given(firstReview.getCreatedAt()).willReturn(createdAt);
-
-			given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
-			given(campaignReviewGetService.findAllByCreatorCampaignId(401L))
-				.willReturn(List.of(firstReview));
-
-			// when
-			CreatorPerformanceResponse result =
-				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
-
-			// then
-			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
-				.campaignId(campaignId)
-				.campaignTitle("브랜드 릴스 캠페인")
-				.firstContentPlatform(firstContentType)
-				.secondContentPlatform(null)
-				.creators(List.of(
-					CreatorPerformanceResponse.CreatorReviewPerformance.builder()
-						.creator(createCreatorInfo(41L, "최지훈", "creator-four",
-							"https://cdn.test/creator-four.jpg"))
-						.reviews(List.of(
-							CreatorPerformanceResponse.ReviewPerformance.builder()
-								.campaignReviewId(4001L)
-								.reviewRound(ReviewRound.FIRST)
-								.reviewStatus(ContentStatus.FINAL_UPLOADED)
-								.postUrl("https://instagram.com/p/beta-first")
-								.contents(CreatorPerformanceResponse.ContentMetrics.builder()
-									.contentType(firstContentType)
-									.build())
-								.uploadedAt(expectedUploadedAt)
-								.build()
-						))
-						.build()
-				))
-				.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
-				.build();
-
-			assertThat(result)
-				.usingRecursiveComparison()
-				.isEqualTo(expected);
-		}
-
-		@Test
-		@DisplayName("getCreatorPerformances() : REJECTED 지원자는 결과에서 제외한다")
-		void getCreatorPerformances_excludesRejectedCreatorCampaign() {
-			// given
-			Creator creator = createCreator(51L, "서로코", "creator-five", "https://cdn.test/creator-five.jpg");
-			CreatorCampaign rejectedCreatorCampaign =
-				createCreatorCampaign(501L, creator, ParticipationStatus.REJECTED, false);
-
-			given(creatorCampaignGetService.findAllByCampaign(campaign))
-				.willReturn(List.of(rejectedCreatorCampaign));
-
-			// when
-			CreatorPerformanceResponse result =
-				brandUsecase.getCreatorPerformances(brandId, campaignId, 0, 10);
-
-			// then
-			CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
-				.campaignId(campaignId)
-				.campaignTitle("브랜드 릴스 캠페인")
-				.firstContentPlatform(firstContentType)
-				.secondContentPlatform(null)
-				.creators(List.of())
-				.pageableResponse(PageableResponse.of(0, 10, 0, true, 0L))
-				.build();
-
-			assertThat(result)
-				.usingRecursiveComparison()
-				.isEqualTo(expected);
-		}
-	}
-
-	private Creator createCreator(
-		Long creatorId,
-		String creatorFullName,
-		String creatorNickname,
-		String profileImageUrl
-	) {
-		Creator creator = mock(Creator.class, RETURNS_DEEP_STUBS);
-
-		given(creator.getId()).willReturn(creatorId);
-		given(creator.getCreatorName()).willReturn(creatorNickname);
-		given(creator.getUser().getName()).willReturn(creatorFullName);
-		given(creator.getUser().getProfileImageUrl()).willReturn(profileImageUrl);
-
-		return creator;
-	}
-
-	private CreatorCampaign createCreatorCampaign(
-		Long creatorCampaignId,
-		Creator creator,
-		ParticipationStatus participationStatus,
-		Boolean addressConfirmed
-	) {
-		CreatorCampaign creatorCampaign = mock(CreatorCampaign.class);
-
-		given(creatorCampaign.getId()).willReturn(creatorCampaignId);
-		given(creatorCampaign.getCreator()).willReturn(creator);
-		given(creatorCampaign.getStatus()).willReturn(participationStatus);
-		given(creatorCampaign.getAddressConfirmed()).willReturn(addressConfirmed);
-
-		return creatorCampaign;
-	}
-
-	private CampaignReview createCampaignReview(
-		Long campaignReviewId,
-		ReviewRound reviewRound,
-		ReviewStatus reviewStatus,
-		ContentType contentType
-	) {
-		CampaignReview campaignReview = mock(CampaignReview.class);
-
-		given(campaignReview.getId()).willReturn(campaignReviewId);
-		given(campaignReview.getReviewRound()).willReturn(reviewRound);
-		given(campaignReview.getStatus()).willReturn(reviewStatus);
-		given(campaignReview.getContentType()).willReturn(contentType);
-
-		return campaignReview;
-	}
-
-	private CreatorInfo createCreatorInfo(
-		Long creatorId,
-		String creatorFullName,
-		String creatorNickname,
-		String profileImageUrl
-	) {
-		return CreatorInfo.builder()
-			.creatorId(creatorId)
-			.creatorFullName(creatorFullName)
-			.creatorNickname(creatorNickname)
-			.profileImageUrl(profileImageUrl)
-			.build();
 	}
 }

--- a/src/test/java/com/lokoko/domain/brand/BrandUsecaseTestSupport.java
+++ b/src/test/java/com/lokoko/domain/brand/BrandUsecaseTestSupport.java
@@ -1,7 +1,15 @@
 package com.lokoko.domain.brand;
 
+import static org.mockito.Answers.RETURNS_DEFAULTS;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -19,6 +27,9 @@ import com.lokoko.global.config.BetaFeatureConfig;
 
 @ExtendWith(MockitoExtension.class)
 abstract class BrandUsecaseTestSupport {
+
+	private static final String BRAND_CREATOR_PERFORMANCE_QUERY_SERVICE =
+		"com.lokoko.domain.brand.application.service.BrandCreatorPerformanceQueryService";
 
 	@Mock
 	protected BrandGetService brandGetService;
@@ -50,6 +61,87 @@ abstract class BrandUsecaseTestSupport {
 	@Mock
 	protected CampaignReviewMapper campaignReviewMapper;
 
-	@InjectMocks
 	protected BrandUsecase brandUsecase;
+
+	private final Map<String, Object> dynamicMocks = new HashMap<>();
+	private final Map<String, Object> dynamicMethodReturns = new HashMap<>();
+
+	@BeforeEach
+	void initializeBrandUsecase() {
+		brandUsecase = instantiateBrandUsecase();
+	}
+
+	protected boolean hasDynamicMock(String className) {
+		return dynamicMocks.containsKey(className);
+	}
+
+	protected void stubDynamicMethodReturn(String className, String methodName, Object returnValue) {
+		dynamicMethodReturns.put(dynamicMethodKey(className, methodName), returnValue);
+	}
+
+	private BrandUsecase instantiateBrandUsecase() {
+		try {
+			Constructor<?> constructor = Arrays.stream(BrandUsecase.class.getDeclaredConstructors())
+				.max((left, right) -> Integer.compare(left.getParameterCount(), right.getParameterCount()))
+				.orElseThrow();
+
+			constructor.setAccessible(true);
+
+			Object[] arguments = Arrays.stream(constructor.getParameterTypes())
+				.map(this::resolveConstructorArgument)
+				.toArray();
+
+			return (BrandUsecase)constructor.newInstance(arguments);
+		} catch (ReflectiveOperationException exception) {
+			throw new IllegalStateException("Failed to instantiate BrandUsecase for tests", exception);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Object resolveConstructorArgument(Class<?> parameterType) {
+		if (parameterType == BrandGetService.class) {
+			return brandGetService;
+		}
+		if (parameterType == CampaignGetService.class) {
+			return campaignGetService;
+		}
+		if (parameterType == CreatorCampaignGetService.class) {
+			return creatorCampaignGetService;
+		}
+		if (parameterType == CampaignReviewGetService.class) {
+			return campaignReviewGetService;
+		}
+		if (parameterType == SocialClipGetService.class) {
+			return socialClipGetService;
+		}
+		if (parameterType == BrandUpdateService.class) {
+			return brandUpdateService;
+		}
+		if (parameterType == BetaFeatureConfig.class) {
+			return betaFeatureConfig;
+		}
+		if (parameterType == CampaignMapper.class) {
+			return campaignMapper;
+		}
+		if (parameterType == CampaignReviewMapper.class) {
+			return campaignReviewMapper;
+		}
+		if (parameterType.getName().equals(BRAND_CREATOR_PERFORMANCE_QUERY_SERVICE)) {
+			return dynamicMocks.computeIfAbsent(
+				parameterType.getName(),
+				key -> mock((Class<Object>)parameterType, invocation -> {
+					String methodKey = dynamicMethodKey(parameterType.getName(), invocation.getMethod().getName());
+					if (dynamicMethodReturns.containsKey(methodKey)) {
+						return dynamicMethodReturns.get(methodKey);
+					}
+					return RETURNS_DEFAULTS.answer(invocation);
+				})
+			);
+		}
+		return mock((Class<Object>)parameterType, RETURNS_DEFAULTS);
+	}
+
+	private String dynamicMethodKey(String className, String methodName) {
+		return className + "#" + methodName;
+	}
 }

--- a/src/test/java/com/lokoko/domain/brand/application/service/BrandCreatorPerformanceQueryServiceTest.java
+++ b/src/test/java/com/lokoko/domain/brand/application/service/BrandCreatorPerformanceQueryServiceTest.java
@@ -1,0 +1,474 @@
+package com.lokoko.domain.brand.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_DEFAULTS;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.lokoko.domain.brand.api.dto.response.CreatorPerformanceResponse;
+import com.lokoko.domain.campaign.domain.entity.Campaign;
+import com.lokoko.domain.campaignReview.application.service.CampaignReviewGetService;
+import com.lokoko.domain.campaignReview.domain.entity.CampaignReview;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ContentStatus;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewRound;
+import com.lokoko.domain.campaignReview.domain.entity.enums.ReviewStatus;
+import com.lokoko.domain.creator.api.dto.response.CreatorInfo;
+import com.lokoko.domain.creator.domain.entity.Creator;
+import com.lokoko.domain.creatorCampaign.application.service.CreatorCampaignGetService;
+import com.lokoko.domain.creatorCampaign.domain.entity.CreatorCampaign;
+import com.lokoko.domain.creatorCampaign.domain.enums.ParticipationStatus;
+import com.lokoko.domain.media.socialclip.application.service.SocialClipGetService;
+import com.lokoko.domain.media.socialclip.domain.SocialClip;
+import com.lokoko.domain.media.socialclip.domain.entity.enums.ContentType;
+import com.lokoko.global.common.response.PageableResponse;
+import com.lokoko.global.config.BetaFeatureConfig;
+
+@DisplayName("Brand creator performance QueryService 테스트")
+class BrandCreatorPerformanceQueryServiceTest {
+
+	private static final String QUERY_SERVICE_CLASS_NAME =
+		"com.lokoko.domain.brand.application.service.BrandCreatorPerformanceQueryService";
+
+	private CreatorCampaignGetService creatorCampaignGetService;
+
+	private CampaignReviewGetService campaignReviewGetService;
+
+	private SocialClipGetService socialClipGetService;
+
+	private BetaFeatureConfig betaFeatureConfig;
+
+	private Object queryService;
+	private Long campaignId;
+	private Campaign campaign;
+	private ContentType firstContentType;
+	private ParticipationStatus approvedParticipationStatus;
+
+	@BeforeEach
+	void setUp() {
+		creatorCampaignGetService = mock(CreatorCampaignGetService.class);
+		campaignReviewGetService = mock(CampaignReviewGetService.class);
+		socialClipGetService = mock(SocialClipGetService.class);
+		betaFeatureConfig = mock(BetaFeatureConfig.class);
+
+		Class<?> queryServiceClass = loadQueryServiceClass();
+		Assumptions.assumeTrue(queryServiceClass != null, QUERY_SERVICE_CLASS_NAME + " is not present yet");
+
+		queryService = instantiateQueryService(queryServiceClass);
+		campaignId = 10L;
+		campaign = mock(Campaign.class, RETURNS_DEEP_STUBS);
+		firstContentType = ContentType.values()[0];
+		approvedParticipationStatus = Arrays.stream(ParticipationStatus.values())
+			.filter(participationStatus -> participationStatus != ParticipationStatus.REJECTED)
+			.findFirst()
+			.orElseThrow();
+
+		given(campaign.getId()).willReturn(campaignId);
+		given(campaign.getTitle()).willReturn("브랜드 릴스 캠페인");
+		given(campaign.getFirstContentPlatform()).willReturn(firstContentType);
+		given(campaign.getSecondContentPlatform()).willReturn(null);
+	}
+
+	@Test
+	@DisplayName("getCreatorPerformances() : 1차/2차 리뷰가 함께 있으면 2차 리뷰를 우선 반영한다")
+	void getCreatorPerformances_prioritizesSecondReview() {
+		Creator creator = createCreator(11L, "홍길동", "creator-one", "https://cdn.test/creator-one.jpg");
+		CreatorCampaign creatorCampaign =
+			createCreatorCampaign(101L, creator, approvedParticipationStatus, true);
+
+		CampaignReview firstReview =
+			createCampaignReview(1001L, ReviewRound.FIRST, ReviewStatus.SUBMITTED, firstContentType);
+		CampaignReview secondReview =
+			createCampaignReview(1002L, ReviewRound.SECOND, ReviewStatus.RESUBMITTED, firstContentType);
+
+		SocialClip socialClip = mock(SocialClip.class);
+		Instant uploadedAt = Instant.parse("2026-03-01T12:00:00Z");
+
+		given(secondReview.getPostUrl()).willReturn("https://instagram.com/p/final");
+		given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
+		given(campaignReviewGetService.findAllByCreatorCampaignId(101L))
+			.willReturn(List.of(firstReview, secondReview));
+		given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(false);
+
+		given(socialClipGetService.findByCampaignReview(secondReview)).willReturn(Optional.of(socialClip));
+		given(socialClip.getPlays()).willReturn(1200L);
+		given(socialClip.getLikes()).willReturn(300L);
+		given(socialClip.getComments()).willReturn(45L);
+		given(socialClip.getShares()).willReturn(12L);
+		given(socialClip.getUploadedAt()).willReturn(uploadedAt);
+
+		CreatorPerformanceResponse result = invokeGetCreatorPerformances(0, 10);
+
+		CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+			.campaignId(campaignId)
+			.campaignTitle("브랜드 릴스 캠페인")
+			.firstContentPlatform(firstContentType)
+			.secondContentPlatform(null)
+			.creators(List.of(
+				CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+					.creator(createCreatorInfo(11L, "홍길동", "creator-one", "https://cdn.test/creator-one.jpg"))
+					.reviews(List.of(
+						CreatorPerformanceResponse.ReviewPerformance.builder()
+							.campaignReviewId(1002L)
+							.reviewRound(ReviewRound.SECOND)
+							.reviewStatus(ContentStatus.FINAL_UPLOADED)
+							.postUrl("https://instagram.com/p/final")
+							.contents(CreatorPerformanceResponse.ContentMetrics.builder()
+								.contentType(firstContentType)
+								.viewCount(1200L)
+								.likeCount(300L)
+								.commentCount(45L)
+								.shareCount(12L)
+								.build())
+							.uploadedAt(uploadedAt)
+							.build()
+					))
+					.build()
+			))
+			.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
+			.build();
+
+		assertThat(result)
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	@Test
+	@DisplayName("getCreatorPerformances() : 리뷰가 없고 배송지 입력이 완료되었으면 진행중 상태를 반환한다")
+	void getCreatorPerformances_returnsInProgress_whenAddressConfirmedAndNoReview() {
+		Creator creator = createCreator(21L, "김로코", "creator-two", "https://cdn.test/creator-two.jpg");
+		CreatorCampaign creatorCampaign =
+			createCreatorCampaign(201L, creator, approvedParticipationStatus, true);
+
+		given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
+		given(campaignReviewGetService.findAllByCreatorCampaignId(201L)).willReturn(List.of());
+		given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(false);
+
+		CreatorPerformanceResponse result = invokeGetCreatorPerformances(0, 10);
+
+		CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+			.campaignId(campaignId)
+			.campaignTitle("브랜드 릴스 캠페인")
+			.firstContentPlatform(firstContentType)
+			.secondContentPlatform(null)
+			.creators(List.of(
+				CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+					.creator(createCreatorInfo(21L, "김로코", "creator-two", "https://cdn.test/creator-two.jpg"))
+					.reviews(List.of(
+						CreatorPerformanceResponse.ReviewPerformance.builder()
+							.reviewRound(ReviewRound.FIRST)
+							.reviewStatus(ContentStatus.IN_PROGRESS)
+							.contents(CreatorPerformanceResponse.ContentMetrics.builder()
+								.contentType(firstContentType)
+								.build())
+							.build()
+					))
+					.build()
+			))
+			.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
+			.build();
+
+		assertThat(result)
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	@Test
+	@DisplayName("getCreatorPerformances() : 리뷰가 없고 배송지 입력이 없으면 미제출 상태를 반환한다")
+	void getCreatorPerformances_returnsNotSubmitted_whenAddressNotConfirmedAndNoReview() {
+		Creator creator = createCreator(31L, "박지원", "creator-three", "https://cdn.test/creator-three.jpg");
+		CreatorCampaign creatorCampaign =
+			createCreatorCampaign(301L, creator, approvedParticipationStatus, false);
+
+		given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
+		given(campaignReviewGetService.findAllByCreatorCampaignId(301L)).willReturn(List.of());
+		given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(false);
+
+		CreatorPerformanceResponse result = invokeGetCreatorPerformances(0, 10);
+
+		CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+			.campaignId(campaignId)
+			.campaignTitle("브랜드 릴스 캠페인")
+			.firstContentPlatform(firstContentType)
+			.secondContentPlatform(null)
+			.creators(List.of(
+				CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+					.creator(createCreatorInfo(31L, "박지원", "creator-three", "https://cdn.test/creator-three.jpg"))
+					.reviews(List.of(
+						CreatorPerformanceResponse.ReviewPerformance.builder()
+							.reviewRound(ReviewRound.FIRST)
+							.reviewStatus(ContentStatus.NOT_SUBMITTED)
+							.contents(CreatorPerformanceResponse.ContentMetrics.builder()
+								.contentType(firstContentType)
+								.build())
+							.build()
+					))
+					.build()
+			))
+			.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
+			.build();
+
+		assertThat(result)
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	@Test
+	@DisplayName("getCreatorPerformances() : 베타 모드에서는 1차 SUBMITTED 리뷰를 최종 업로드로 처리하고 postUrl을 포함한다")
+	void getCreatorPerformances_betaMode_returnsFinalUploadedForFirstReview() {
+		Creator creator = createCreator(41L, "최지훈", "creator-four", "https://cdn.test/creator-four.jpg");
+		CreatorCampaign creatorCampaign =
+			createCreatorCampaign(401L, creator, approvedParticipationStatus, true);
+
+		CampaignReview firstReview =
+			createCampaignReview(4001L, ReviewRound.FIRST, ReviewStatus.SUBMITTED, firstContentType);
+
+		LocalDateTime createdAt = LocalDateTime.of(2026, 3, 1, 12, 0);
+		Instant expectedUploadedAt = createdAt.toInstant(ZoneOffset.ofHours(9));
+
+		given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(true);
+		given(betaFeatureConfig.isFirstReviewUrlEnabled()).willReturn(true);
+
+		given(firstReview.getPostUrl()).willReturn("https://instagram.com/p/beta-first");
+		given(firstReview.getCreatedAt()).willReturn(createdAt);
+
+		given(creatorCampaignGetService.findAllByCampaign(campaign)).willReturn(List.of(creatorCampaign));
+		given(campaignReviewGetService.findAllByCreatorCampaignId(401L))
+			.willReturn(List.of(firstReview));
+
+		CreatorPerformanceResponse result = invokeGetCreatorPerformances(0, 10);
+
+		CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+			.campaignId(campaignId)
+			.campaignTitle("브랜드 릴스 캠페인")
+			.firstContentPlatform(firstContentType)
+			.secondContentPlatform(null)
+			.creators(List.of(
+				CreatorPerformanceResponse.CreatorReviewPerformance.builder()
+					.creator(createCreatorInfo(41L, "최지훈", "creator-four", "https://cdn.test/creator-four.jpg"))
+					.reviews(List.of(
+						CreatorPerformanceResponse.ReviewPerformance.builder()
+							.campaignReviewId(4001L)
+							.reviewRound(ReviewRound.FIRST)
+							.reviewStatus(ContentStatus.FINAL_UPLOADED)
+							.postUrl("https://instagram.com/p/beta-first")
+							.contents(CreatorPerformanceResponse.ContentMetrics.builder()
+								.contentType(firstContentType)
+								.build())
+							.uploadedAt(expectedUploadedAt)
+							.build()
+					))
+					.build()
+			))
+			.pageableResponse(PageableResponse.of(0, 10, 1, true, 1L))
+			.build();
+
+		assertThat(result)
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	@Test
+	@DisplayName("getCreatorPerformances() : REJECTED 지원자는 결과에서 제외한다")
+	void getCreatorPerformances_excludesRejectedCreatorCampaign() {
+		Creator creator = createCreator(51L, "서로코", "creator-five", "https://cdn.test/creator-five.jpg");
+		CreatorCampaign rejectedCreatorCampaign =
+			createCreatorCampaign(501L, creator, ParticipationStatus.REJECTED, false);
+
+		given(creatorCampaignGetService.findAllByCampaign(campaign))
+			.willReturn(List.of(rejectedCreatorCampaign));
+		given(betaFeatureConfig.isSimplifiedReviewFlow()).willReturn(false);
+
+		CreatorPerformanceResponse result = invokeGetCreatorPerformances(0, 10);
+
+		CreatorPerformanceResponse expected = CreatorPerformanceResponse.builder()
+			.campaignId(campaignId)
+			.campaignTitle("브랜드 릴스 캠페인")
+			.firstContentPlatform(firstContentType)
+			.secondContentPlatform(null)
+			.creators(List.of())
+			.pageableResponse(PageableResponse.of(0, 10, 0, true, 0L))
+			.build();
+
+		assertThat(result)
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	private Class<?> loadQueryServiceClass() {
+		try {
+			return Class.forName(QUERY_SERVICE_CLASS_NAME);
+		} catch (ClassNotFoundException exception) {
+			return null;
+		}
+	}
+
+	private Object instantiateQueryService(Class<?> queryServiceClass) {
+		try {
+			Constructor<?> constructor = Arrays.stream(queryServiceClass.getDeclaredConstructors())
+				.max((left, right) -> Integer.compare(left.getParameterCount(), right.getParameterCount()))
+				.orElseThrow();
+
+			constructor.setAccessible(true);
+
+			Object[] arguments = Arrays.stream(constructor.getParameterTypes())
+				.map(this::resolveConstructorArgument)
+				.toArray();
+
+			return constructor.newInstance(arguments);
+		} catch (ReflectiveOperationException exception) {
+			throw new IllegalStateException("Failed to instantiate " + QUERY_SERVICE_CLASS_NAME, exception);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Object resolveConstructorArgument(Class<?> parameterType) {
+		if (parameterType == CreatorCampaignGetService.class) {
+			return creatorCampaignGetService;
+		}
+		if (parameterType == CampaignReviewGetService.class) {
+			return campaignReviewGetService;
+		}
+		if (parameterType == SocialClipGetService.class) {
+			return socialClipGetService;
+		}
+		if (parameterType == BetaFeatureConfig.class) {
+			return betaFeatureConfig;
+		}
+		return mock((Class<Object>)parameterType, RETURNS_DEFAULTS);
+	}
+
+	private CreatorPerformanceResponse invokeGetCreatorPerformances(int page, int size) {
+		try {
+			Method method = Arrays.stream(queryService.getClass().getMethods())
+				.filter(candidate -> candidate.getName().equals("getCreatorPerformances"))
+				.findFirst()
+				.orElseThrow(() -> new NoSuchMethodException("getCreatorPerformances"));
+
+			method.setAccessible(true);
+
+			return (CreatorPerformanceResponse)method.invoke(
+				queryService,
+				resolveMethodArguments(method, page, size)
+			);
+		} catch (ReflectiveOperationException exception) {
+			throw new IllegalStateException("Failed to invoke getCreatorPerformances on query service", exception);
+		}
+	}
+
+	private Object[] resolveMethodArguments(Method method, int page, int size) {
+		Class<?>[] parameterTypes = method.getParameterTypes();
+		int totalIntParameters = countParameters(parameterTypes, Integer.class, int.class);
+		int intIndex = 0;
+		List<Object> arguments = new ArrayList<>(parameterTypes.length);
+
+		for (Class<?> parameterType : parameterTypes) {
+			if (parameterType == Campaign.class) {
+				arguments.add(campaign);
+				continue;
+			}
+			if (parameterType == Long.class || parameterType == long.class) {
+				arguments.add(campaignId);
+				continue;
+			}
+			if (parameterType == Integer.class || parameterType == int.class) {
+				if (totalIntParameters == 1) {
+					arguments.add(page);
+				} else {
+					arguments.add(intIndex++ == 0 ? page : size);
+				}
+				continue;
+			}
+			throw new IllegalStateException("Unsupported getCreatorPerformances parameter: " + parameterType.getName());
+		}
+
+		return arguments.toArray();
+	}
+
+	private int countParameters(Class<?>[] parameterTypes, Class<?> wrapperType, Class<?> primitiveType) {
+		int count = 0;
+		for (Class<?> parameterType : parameterTypes) {
+			if (parameterType == wrapperType || parameterType == primitiveType) {
+				count++;
+			}
+		}
+		return count;
+	}
+
+	private Creator createCreator(
+		Long creatorId,
+		String creatorFullName,
+		String creatorNickname,
+		String profileImageUrl
+	) {
+		Creator creator = mock(Creator.class, RETURNS_DEEP_STUBS);
+
+		given(creator.getId()).willReturn(creatorId);
+		given(creator.getCreatorName()).willReturn(creatorNickname);
+		given(creator.getUser().getName()).willReturn(creatorFullName);
+		given(creator.getUser().getProfileImageUrl()).willReturn(profileImageUrl);
+
+		return creator;
+	}
+
+	private CreatorCampaign createCreatorCampaign(
+		Long creatorCampaignId,
+		Creator creator,
+		ParticipationStatus participationStatus,
+		Boolean addressConfirmed
+	) {
+		CreatorCampaign creatorCampaign = mock(CreatorCampaign.class);
+
+		given(creatorCampaign.getId()).willReturn(creatorCampaignId);
+		given(creatorCampaign.getCreator()).willReturn(creator);
+		given(creatorCampaign.getStatus()).willReturn(participationStatus);
+		given(creatorCampaign.getAddressConfirmed()).willReturn(addressConfirmed);
+
+		return creatorCampaign;
+	}
+
+	private CampaignReview createCampaignReview(
+		Long campaignReviewId,
+		ReviewRound reviewRound,
+		ReviewStatus reviewStatus,
+		ContentType contentType
+	) {
+		CampaignReview campaignReview = mock(CampaignReview.class);
+
+		given(campaignReview.getId()).willReturn(campaignReviewId);
+		given(campaignReview.getReviewRound()).willReturn(reviewRound);
+		given(campaignReview.getStatus()).willReturn(reviewStatus);
+		given(campaignReview.getContentType()).willReturn(contentType);
+
+		return campaignReview;
+	}
+
+	private CreatorInfo createCreatorInfo(
+		Long creatorId,
+		String creatorFullName,
+		String creatorNickname,
+		String profileImageUrl
+	) {
+		return CreatorInfo.builder()
+			.creatorId(creatorId)
+			.creatorFullName(creatorFullName)
+			.creatorNickname(creatorNickname)
+			.profileImageUrl(profileImageUrl)
+			.build();
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #488 

## 작업 내용 💻

- [x] `BrandUsecase.getCreatorPerformances()`에서 크리에이터 성과 조회 조립 책임을 분리하고 `BrandCreatorPerformanceQueryService`로 위임
- [x] 리뷰/소셜 지표/상태 조립 및 수동 페이징 로직을 `BrandCreatorPerformanceQueryService`로 이동
- [x] `BrandUsecase`는 브랜드 권한 검증과 조회 흐름 진입점 역할만 담당하도록 정리

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 이번 작업은 조회 책임 분리의 첫 단계라서, 기존 `usecase`를 없애기보다 `BrandUsecase`를 얇게 만들고 read assembly를 `QueryService`로 옮기는 방향으로 가져갔습니다.
- 지금 기준으로는 `BrandCreatorPerformanceQueryService` 안에 여전히 수동 페이징과 응답 조립이 함께 있는데, 다음 단계에서는 이 책임을 `Assembler`까지 더 분리할지, 아니면 조회 전용 서비스 안에 유지할지 팀 컨벤션을 한 번 맞춰보면 좋을 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 크리에이터 성과 지표 계산 로직을 별도 서비스로 분리하여 코드 구조 개선

* **Tests**
  * 테스트 코드 업데이트 및 확대를 통한 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->